### PR TITLE
Show a warning when no LMS is connected

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -28,6 +28,7 @@
     "exam.failed": "Failed",
     "exam.review header": "Review: ",
     "frontpage.start": "Start",
+    "frontpage.scorm.lms not connected": "This exam is running in standalone mode. Your answers and marks will not be saved!",
     "suspend.paused header": "Paused",
     "suspend.exam suspended": "The Exam has been suspended. Press <em>Resume</em> to continue.",
     "suspend.you can resume": "You will be able to resume this session the next time you start this activity.",

--- a/runtime/scripts/scorm-storage.js
+++ b/runtime/scripts/scorm-storage.js
@@ -20,12 +20,14 @@ var scorm = Numbas.storage.scorm = {};
  */
 var SCORMStorage = scorm.SCORMStorage = function()
 {
+    Numbas.storage.lmsConnected = true;
     if(!pipwerks.SCORM.init())
     {
         var errorCode = pipwerks.SCORM.debug.getCode();
         if(errorCode) {
             throw(new Numbas.Error(R('scorm.error initialising',{message: pipwerks.SCORM.debug.getInfo(errorCode)})));
         }
+        Numbas.storage.lmsConnected = false;
         //if the pretend LMS extension is loaded, we can start that up
         if(Numbas.storage.PretendLMS)
         {

--- a/themes/default/templates/frontpage.html
+++ b/themes/default/templates/frontpage.html
@@ -18,6 +18,7 @@
     </tr>
 </table>
 <div id="intro" class="alert col-sm-6 col-sm-offset-3" data-bind="visible: exam.hasIntro, latex: exam.introMessage" localise-data-jme-context-description="exam.introduction"></div>
+<div id="standalone-warning" class="alert alert-info col-sm-6 col-sm-offset-3" data-bind="visible: !Numbas.storage.lmsConnected" data-localise="frontpage.scorm.lms not connected"></div>
 <div class="info-buttons col-sm-6 col-sm-offset-3">
     <button class="btn btn-primary" id="startBtn" data-bind="click: Numbas.controls.beginExam" data-localise="frontpage.start"></button>
 </div>


### PR DESCRIPTION
Fixes #529. There is now a variable Numbas.storage.lmsConnected telling us
whether a true SCORM connection to an LMS exists.

The front page uses this variable to show a warning message explaining that
marks and answers are not saved when there is no SCORM connection.