### PR TITLE
Fix the initializing of stack in Numbas.Error

### DIFF
--- a/runtime/scripts/numbas.js
+++ b/runtime/scripts/numbas.js
@@ -56,16 +56,17 @@ Numbas.showError = function(e)
  */
 Numbas.Error = function(message)
 {
-    Error.call(this);
-    if(Error.captureStackTrace) {
-        Error.captureStackTrace(this, this.constructor);
-    }
-    this.name="Numbas Error";
-    this.originalMessage = message;
-    this.message = R.apply(this,arguments);
+    var e = new Error();
+    e.name = "Numbas Error";
+    e.originalMessage = message;
+    e.message = R.apply(this,arguments);
+    e.stack = e.stack || "No stack trace available";
+
+    // This also overrides the return value of
+    //     new Numbas.Error()
+    return e;
 }
-Numbas.Error.prototype = Error.prototype;
-Numbas.Error.prototype.constructor = Numbas.Error;
+
 var scriptreqs = {};
 /** Keep track of loading status of a script and its dependencies
  * @param {String} file - name of script


### PR DESCRIPTION
**Bug summary**: on some browsers, an exception was being thrown when trying
to access the `stack` property on instances of `Numbas.Error`.

-----------------------------

The statement

    Error.call(this);

is effectively a no-op, since:

> when `Error` is called as a function rather than as a constructor, it
> creates and initializes a new Error object.

Source: http://es5.github.io/#x15.11.1

Thus properties of `Numbas.Error` instances had to be set manually. In
particular, the `stack` (non-standard) property was being initialized
with `Error.captureStackTrace` (non-standard) which isn't available in
all browser (eg, Safari/ Firefox?).

However, all major browsers provide a `Error.stack` property on `Error`
instances (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack).

This commit provides a fix by having `Numbas.Error` return a new
instance of `Error` that is monkey-patched in order to have the
localized message. The fix has the following caveat:

    (new Numbas.Error() instanceof Numbas.Error) === false

-----------------------------

**NOTE**: If it is prefered, I can provide a patch that cirvumvents this issue.
