### PR TITLE
add sort_by (closes #530)

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -86,6 +86,7 @@
     "jme.shunt.list mixed argument types": "Can't parse {{mode}}: mix of dictionary and list elements",
     "jme.typecheck.function maybe implicit multiplication": "Operation <code>{{name}}</code> is not defined. Did you mean <code>{{first}}*{{possibleOp}}(...)</code>?",
     "jme.typecheck.function not defined": "Operation <code>{{op}}</code> is not defined. Is <code>{{op}}</code> a variable, and did you mean <code>{{suggestion}}*(...)</code>?",
+    "jme.typecheck.invalid type": "Invalid argument received. Expected <code>{{expected}}</code>, but received <code>{{received}}</code>.",
     "jme.typecheck.op not defined": "Operation '{{op}}' is not defined.",
     "jme.typecheck.no right type definition": "No definition of '{{op}}' of correct type found.",
     "jme.typecheck.no right type unbound name": "Variable <code>{{name}}</code> is not defined.",

--- a/runtime/scripts/jme-builtins.js
+++ b/runtime/scripts/jme-builtins.js
@@ -941,22 +941,178 @@ jme.substituteTreeOps.let = function(tree,scope,allowUnbound) {
         tree.args[i] = jme.substituteTree(tree.args[i],scope,allowUnbound);
     }
 }
-newBuiltin('sort',[TList],TList, null, {
-    evaluate: function(args,scope)
+var sortCompare = function(a, b) {
+    // We can't compare complex numbers
+    if (a.complex || b.complex) {
+        throw new Numbas.Error('math.order complex numbers');
+    }
+    return (a.value - b.value);
+};
+newBuiltin('sort', [TList], TList, null, {
+    evaluate: function(args, scope)
     {
-        var list = args[0];
-        var newlist = new TList(list.vars);
-        newlist.value = list.value.slice().sort(function(a,b){
-            if(math.gt(a.value,b.value))
-                return 1;
-            else if(math.lt(a.value,b.value))
-                return -1;
-            else
-                return 0;
-        });
-        return newlist;
+        var listCopy = args[0].value.slice();
+        listCopy.sort(sortCompare); // In-place
+        return new TList(listCopy);
     }
 });
+var sortByHelper = function(list, accessor, extra) {
+    return new TList(
+        // Start from the value of the given list
+        list.value
+        // Make a copy because sorting is in-place
+        .slice()
+        // Map each element to a pair (key, val):
+        // - key: Key to compare on
+        // - val: Value in the list (the element)
+        .map(function(elem) {
+            return {
+                key: accessor(elem, extra),
+                val: elem
+            };
+        })
+        // Sort according to the key (IN-PLACE!)
+        .sort(function(pair0, pair1) {
+            return sortCompare(pair0.key, pair1.key);
+        })
+        // Re-map to just the values
+        .map(function(tup) {
+            return tup.val;
+        })
+    );
+};
+var sortByAccessors = {
+    'number': function accessIndexOfList(elem, index) {
+        if (elem.type !== 'list') {
+            // Element is not a list
+            throw new Numbas.Error('jme.typecheck.invalid type', {
+                expected: 'list',
+                received: elem.type,
+            });
+        }
+        if (index < 0 || index >= elem.vars) {
+            // Index out-of-bounds
+            throw new Numbas.Error('jme.func.listval.invalid index', {
+                index: index,
+                size: elem.vars,
+            });
+        }
+        return elem.value[index];
+    },
+    'string': function accessKeyOfDict(elem, key) {
+        if (elem.type !== 'dict') {
+            // Element is not a dict
+            throw new Numbas.Error('jme.typecheck.invalid type', {
+                expected: 'list',
+                received: elem.type,
+            });
+        }
+        if(!elem.value.hasOwnProperty(key)) {
+            // Dict does not have the given key
+            throw new Numbas.Error('jme.func.listval.key not in dict', {
+                key: key
+            });
+        }
+        return elem.value[key];
+    },
+}
+newBuiltin('sort_by',['?', '?', '?'], TList, null, {
+    evaluate: function(args, scope)
+    {
+        var list       = jme.evaluate(args[0], scope);
+        var lambdaBody = args[1];
+        var lambdaHead = args[2];
+
+        if (list.type !== 'list') {
+            // First argument must be a list
+            // Due to the dynamical nature of the method, we must check
+            // the type manually at run-time, because we can't know
+            // the type of the first argument beforehand if it happens
+            // to be a function call, eg: sort_by(values( ... ), ...)
+            throw new Numbas.Error('jme.typecheck.invalid type', {
+                expected: 'list',
+                received: list.type
+            });
+        }
+
+        if (lambdaHead == null) {
+            // If the third argument is null, we're being called
+            // in a shorthand form, either:
+            // - sort_by([...], number)
+            // - sort_by([...], string)
+            lambdaBody = jme.evaluate(args[1], scope);
+
+            if (!(lambdaBody.type in sortByAccessors)) {
+                // First argument must be a list
+                // Due to the dynamical nature of the method, we must check
+                // the type manually at run-time, because we can't know
+                // the type of the first argument beforehand if it happens
+                // to be a function call, eg: sort_by(values( ... ), ...)
+                throw new Numbas.Error('jme.typecheck.invalid type', {
+                    expected: 'number/string',
+                    received: lambdaBody.type
+                });
+            }
+
+            return sortByHelper(
+                list,
+                sortByAccessors[lambdaBody.type],
+                lambdaBody.value
+            );
+        }
+
+        var lambdaExecutionScope = new Scope(scope);
+        var prepareScopeArgs;
+
+        if (lambdaHead.tok.type == 'name') {
+            prepareScopeArgs = function(val) {
+                lambdaExecutionScope.variables[lambdaHead.tok.name] = val;
+                return lambdaExecutionScope;
+            };
+        }
+        else {
+            prepareScopeArgs = function(vals) {
+                lambdaHead.args.forEach(function(arg, i) {
+                    lambdaExecutionScope.variables[arg.tok.name] = vals.value[i];
+                });
+                return lambdaExecutionScope;
+            }
+        }
+
+        return sortByHelper(list, function accessValueThroughLambda(elem) {
+            return prepareScopeArgs(elem).evaluate(lambdaBody);
+        });
+    }
+});
+jme.findvarsOps.sort_by = function(tree, boundvars, scope) {
+    if (tree.args.length !== 3) {
+        return jme.findvars(tree.args[0], boundvars)
+    }
+
+    boundvars = boundvars.slice();
+
+    if (tree.args[2].tok.type == 'list') {
+        tree.args[2].args.forEach(function(arg) {
+            boundvars.push(arg.tok.name.toLowerCase());
+        });
+    }
+    else {
+        boundvars.push(tree.args[2].tok.name.toLowerCase());
+    }
+
+    return jme
+        .findvars(tree.args[1], boundvars, scope)
+        .merge(jme.findvars(tree.args[0], boundvars));
+};
+jme.substituteTreeOps.sort_by = function(tree, scope, allowUnbound) {
+    tree.args[0] = jme.substituteTree(tree.args[0], scope, allowUnbound);
+
+    if (tree.args.length !== 3) {
+        tree.args[1] = jme.substituteTree(tree.args[1], scope, allowUnbound);
+    }
+
+    return tree;
+};
 newBuiltin('reverse',[TList],TList,null, {
     evaluate: function(args,scope) {
         var list = args[0];

--- a/runtime/scripts/jme.js
+++ b/runtime/scripts/jme.js
@@ -1771,7 +1771,7 @@ var funcSynonyms = jme.funcSynonyms = {
 /** Operations which evaluate lazily - they don't need to evaluate all of their arguments
  * @memberof Numbas.jme
  */
-var lazyOps = jme.lazyOps = ['if','switch','repeat','map','let','isa','satisfy','filter','isset','dict','safe'];
+var lazyOps = jme.lazyOps = ['if','switch','repeat','map','let','isa','satisfy','filter','isset','dict','safe','sort_by'];
 var rightAssociative = {
     '^': true,
     '+u': true,

--- a/tests/jme.html
+++ b/tests/jme.html
@@ -834,6 +834,36 @@
 					raisesNumbasError(assert, function(){ evaluate('switch(false,1,false,0)') },'jme.func.switch.no default case','no default case: switch(false,1,false,0)');
 				});
 
+                QUnit.test('Sorting', function(assert) {
+                    var check = function(expr, expected) {
+                        deepCloseEqual(assert,Numbas.jme.unwrapValue(evaluate(expr)),expected,expr);
+                    };
+                    var checkErr = function(expr, err) {
+                        raisesNumbasError(assert,function(){evaluate(expr)},err,expr);
+                    };
+                    // Note: sorts aren't guaranteed to be stable, so
+                    // all test cases must have an unique correct ordering.
+                    check('sort([])',[]);
+                    check('sort(list(3..1#-1))',[1,2,3]);
+                    check('sort(list(1..3))',[1,2,3]);
+                    check('sort_by([], 1)',[]);
+                    check('sort_by([[7,2],[5,3],[9,1]], 1)',[[9,1],[7,2],[5,3]]);
+                    check('sort_by([], "k")',[]);
+                    check('sort_by([["k":3],["k":1],["k":2]], "k")',[{k:1},{k:2},{k:3}]);
+                    check('sort_by([1,2,3], -n, n)',[3,2,1]);
+                    check('sort_by([], 0/0, x)',[]);
+                    check('sort_by(list(3..1#-1), radians(2*n), n)',[1,2,3]);
+                    check('sort_by(map(-n, n, 1..3), -n, n)',[-1,-2,-3]);
+                    check('sort_by([[7,2],[5,3],[9,1]], b, [a, b])',[[9,1],[7,2],[5,3]]);
+
+                    checkErr('sort_by(1)', 'jme.typecheck.invalid type');
+                    checkErr('sort_by(1, 1)', 'jme.typecheck.invalid type');
+                    checkErr('sort_by(1, 1, 1)', 'jme.typecheck.invalid type');
+                    checkErr('sort_by([["a":1]], 1)', 'jme.typecheck.invalid type');
+                    checkErr('sort_by([["a",1]], "a")', 'jme.typecheck.invalid type');
+                    checkErr('sort_by([], [1])', 'jme.typecheck.invalid type');
+                });
+
 				QUnit.test('Repetition',function(assert) {
 					deepCloseEqual(assert, evaluate('map(x+1,x,[1,2,3])').value.map(getValue),[2,3,4],'map(x+1,x,[1,2,3])');
 					deepCloseEqual(assert, evaluate('map(x+1,x,1..3)').value.map(getValue),[2,3,4],'map(x+1,x,1..3)');


### PR DESCRIPTION
- The new function has 3 variants:
  + List:   `sort_by([[1,1], [2,2], [3,3], 0)`
  + Dict:   `sort_by([["k":1], ["k":2], ["k":3], "k")`
  + Thunk:  `sort_by([[1,1], [2,2], [3,3], 4-n, n)`

- An additional localization message has been added to the en-GB locale
  for type mismatch errors.
- The unit tests now include some sort-related tests.
- The `tests/jme-runtime.js` file has been updated with only the new code.