### PR TITLE
Returning a 'submit part' button for steps with one part

### DIFF
--- a/themes/default/templates/xslt/part.xslt
+++ b/themes/default/templates/xslt/part.xslt
@@ -76,7 +76,7 @@
         <xsl:apply-templates select="." mode="correctanswer"/>
         <xsl:if test="not(ancestor::gaps)">
             <div class="submit-and-feedback">
-                <xsl:if test="count(../part) &gt; 1">
+                <xsl:if test="count(../part) &gt; 1 or count(../../steps) &gt; 0"">
                     <button class="btn btn-primary submitPart" data-bind="visible: showSubmitPart, click: controls.submit"><localise>question.submit part</localise></button>
                 </xsl:if>
                 <div class="feedbackMessages" data-bind="visible: feedbackMessages().length>0" localise-data-jme-context-description="part.feedback">


### PR DESCRIPTION
I've added a condition that returns the 'submit part' button for steps that have one part. This is necessary otherwise users are unable to easily submit steps that only have one part.

I have limited experience with xslt, so I don't suggest this is the best solution, but it does work.