### PR TITLE
Refactored the way that choices.xslt breaks rows

### DIFF
--- a/themes/default/templates/xslt/parts/choices.xslt
+++ b/themes/default/templates/xslt/parts/choices.xslt
@@ -52,12 +52,7 @@
     <xsl:variable name="cols" select="../@displaycolumns"/>
     <xsl:variable name="choicenum"><xsl:value-of select="count(preceding-sibling::choice)"/></xsl:variable>
     <li>
-        <xsl:attribute name="class">
-            <xsl:if test="($choicenum mod $cols = 0) and ($cols>0)">
-                <xsl:text>start-column</xsl:text>
-            </xsl:if>
-        </xsl:attribute>
-        <xsl:attribute name="data-bind">css: {checked: studentAnswer()==<xsl:value-of select="$choicenum"/>, correct: studentAnswer()==<xsl:value-of select="$choicenum"/> &amp;&amp; correctAnswer()==<xsl:value-of select="$choicenum"/>}</xsl:attribute>
+        <xsl:attribute name="data-bind">css: {'start-column': ((part.shuffleAnswers.filter((_,i) => i % parseInt(<xsl:value-of select="$cols"/>) == 0 &amp;&amp; i > 0)).indexOf(<xsl:value-of select="$choicenum"/>)>-1),checked: studentAnswer()==<xsl:value-of select="$choicenum"/>, correct: studentAnswer()==<xsl:value-of select="$choicenum"/> &amp;&amp; correctAnswer()==<xsl:value-of select="$choicenum"/>}</xsl:attribute>
         <label>
             <input type="radio" class="choice" name="{$path}-choice" data-bind="checked: studentAnswer, disable: revealed" value="{$choicenum}"/>
             <xsl:apply-templates select="content"/>
@@ -71,11 +66,7 @@
     <xsl:variable name="cols" select="../@displaycolumns"/>
     <xsl:variable name="choicenum"><xsl:value-of select="count(preceding-sibling::choice)"/></xsl:variable>
     <li>
-        <xsl:attribute name="class">
-            <xsl:if test="($choicenum mod $cols = 0) and ($cols>0)">
-                <xsl:text>start-column</xsl:text>
-            </xsl:if>
-        </xsl:attribute>
+        <xsl:attribute name="data-bind">css: {'start-column': ((part.shuffleAnswers.filter((_,i) => i % parseInt(<xsl:value-of select="$cols"/>) == 0 &amp;&amp; i > 0)).indexOf(<xsl:value-of select="$choicenum"/>)>-1)}</xsl:attribute>
         <label>
             <input type="radio" class="choice" name="{$path}-choice-correctanswer" data-bind="checked: correctAnswer()+''" disabled="true" value="{$choicenum}"/>
             <xsl:apply-templates select="content"/>
@@ -86,12 +77,7 @@
     <xsl:variable name="cols" select="../@displaycolumns"/>
     <xsl:variable name="choicenum"><xsl:value-of select="count(preceding-sibling::choice)"/></xsl:variable>
     <li>
-        <xsl:attribute name="class">
-            <xsl:if test="($choicenum mod $cols = 0) and ($cols>0)">
-                <xsl:text>start-column</xsl:text>
-            </xsl:if>
-        </xsl:attribute>
-        <xsl:attribute name="data-bind">css: {checked: ticks[<xsl:value-of select="$choicenum"/>], correct: ticks[<xsl:value-of select="$choicenum"/>] &amp;&amp; correctTicks[<xsl:value-of select="$choicenum"/>]}</xsl:attribute>
+        <xsl:attribute name="data-bind">css: {'start-column': ((part.shuffleAnswers.filter((_,i) => i % parseInt(<xsl:value-of select="$cols"/>) == 0 &amp;&amp; i > 0)).indexOf(<xsl:value-of select="$choicenum"/>)>-1),checked: ticks[<xsl:value-of select="$choicenum"/>], correct: ticks[<xsl:value-of select="$choicenum"/>] &amp;&amp; correctTicks[<xsl:value-of select="$choicenum"/>]}</xsl:attribute>
         <label>
             <input type="checkbox" class="choice" name="choice" data-bind="checked: ticks[{$choicenum}], disable: revealed" />
             <xsl:apply-templates select="content"/>
@@ -102,11 +88,7 @@
     <xsl:variable name="cols" select="../@displaycolumns"/>
     <xsl:variable name="choicenum"><xsl:value-of select="count(preceding-sibling::choice)"/></xsl:variable>
     <li>
-        <xsl:attribute name="class">
-            <xsl:if test="($choicenum mod $cols = 0) and ($cols>0)">
-                <xsl:text>start-column</xsl:text>
-            </xsl:if>
-        </xsl:attribute>
+        <xsl:attribute name="data-bind">css: {'start-column': ((part.shuffleAnswers.filter((_,i) => i % parseInt(<xsl:value-of select="$cols"/>) == 0 &amp;&amp; i > 0)).indexOf(<xsl:value-of select="$choicenum"/>)>-1)}</xsl:attribute>
         <label>
             <input type="checkbox" class="choice" name="choice" data-bind="checked: correctTicks[{$choicenum}]" disabled="true" />
             <xsl:apply-templates select="content"/>


### PR DESCRIPTION
Since it seems the xml has no way of knowing when it should be 
breaking the rows of choices I have change the code to use knockout 
to give the 'start-column' conditionally to the css attribute.

The condition creates a filter version of the shuffleAnswer array and
makes use that to check if the corresponding choice is one that should
have the 'start-column' css rule applied to it.

The code is not pretty, but it gets the job does in as elegant a ways 
as I could manage.

