### PR TITLE
Feature: flatFractions display flag

### DIFF
--- a/docs/Numbas.jme.rules.html
+++ b/docs/Numbas.jme.rules.html
@@ -23,7 +23,7 @@
 
 		<h1 class="page-title">Namespace: rules</h1>
 
-		
+
 
 
 
@@ -31,182 +31,182 @@
 <section>
 
 <header>
-    
+
         <h2>
             <span class="ancestors"><a href="Numbas.html">Numbas</a><a href="Numbas.jme.html">.jme</a>.</span>rules</h2>
-        
-    
+
+
 </header>
 
 <article>
     <div class="container-overview">
-		
-			
 
-			
-			
+
+
+
+
 
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L6">runtime/scripts/jme-rules.js, line 6</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
-			
 
-			
-		
+
+
+
     </div>
 
-    
 
-    
 
-	
 
-	
+
+
+
+
 	<nav class="toc">
 		<h3>Table of contents</h3>
 		<div class="toc-sections">
-			
 
-			
+
+
 				<div class="toc-section">
 					<h4 class="subsection-title">Classes</h4>
 
 					<dl>
 						<dt class="name"><a href="Numbas.jme.rules.Rule.html">Rule</a></dt>
 						<dd></dd>
-					
+
 						<dt class="name"><a href="Numbas.jme.rules.Ruleset.html">Ruleset</a></dt>
 						<dd></dd>
 					</dl>
 				</div>
-			
 
-			
+
+
 				<div class="toc-section">
 					<h4>Members</h4>
 					<ul>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.displayFlags">displayFlags</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.extend_options">extend_options</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.getTerms">getTerms</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.number_conditions">number_conditions</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.patternParser">patternParser</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.simplificationRules">simplificationRules</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.specialMatchFunctions">specialMatchFunctions</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.specialMatchNames">specialMatchNames</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.specialMatchOps">specialMatchOps</a></li>
-					
+
 					</ul>
 				</div>
-			
 
-			
+
+
 				<div class="toc-section">
 					<h4>Methods</h4>
 					<ul>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.applyPostReplacement">applyPostReplacement</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.collectRuleset">collectRuleset</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.compileRules">compileRules</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.findSequenceMatch">findSequenceMatch</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.matchAllTree">matchAllTree</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.matchExpression">matchExpression</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.matchTree">matchTree</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.transform">transform</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.transformAll">transformAll</a></li>
-					
+
 					</ul>
 				</div>
-			
 
-			
+
+
 				<div class="toc-section">
 					<h4>Typedefs</h4>
 					<ul>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.findSequenceMatch_options">findSequenceMatch_options</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.getTerms_options">getTerms_options</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.jme_pattern_match">jme_pattern_match</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.matchTree_options">matchTree_options</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.ruleset_flags">ruleset_flags</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.term">term</a></li>
-					
+
 						<li class="name"><a href="Numbas.jme.rules.html#.transform_result">transform_result</a></li>
-					
+
 					</ul>
 				</div>
-			
 
-			
+
+
 		</div>
 	</nav>
-	
 
-    
+
+
 		<div class="subsection">
         <h3 class="subsection-title">Members</h3>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".displayFlags"><span class="type-signature">(static) </span>displayFlags<span class="type-signature"></span></h4>
 
@@ -226,42 +226,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1746">runtime/scripts/jme-rules.js, line 1746</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -270,8 +270,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".extend_options"><span class="type-signature">(static) </span>extend_options<span class="type-signature"></span></h4>
 
@@ -290,42 +290,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L43">runtime/scripts/jme-rules.js, line 43</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -334,8 +334,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".getTerms"><span class="type-signature">(static) </span>getTerms<span class="type-signature"></span></h4>
 
@@ -354,42 +354,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L315">runtime/scripts/jme-rules.js, line 315</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -398,8 +398,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".number_conditions"><span class="type-signature">(static) </span>number_conditions<span class="type-signature"> :function</span></h4>
 
@@ -415,7 +415,7 @@ Values are <code>undefined</code> so they can be overridden</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
@@ -428,234 +428,234 @@ Values are <code>undefined</code> so they can be overridden</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>complex</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>imaginary</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>real</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>positive</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>nonnegative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>negative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>integer</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>decimal</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>rational</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -664,42 +664,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L489">runtime/scripts/jme-rules.js, line 489</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -708,8 +708,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".patternParser"><span class="type-signature">(static) </span>patternParser<span class="type-signature"></span></h4>
 
@@ -728,42 +728,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1689">runtime/scripts/jme-rules.js, line 1689</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -772,8 +772,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".simplificationRules"><span class="type-signature">(static) </span>simplificationRules<span class="type-signature"> :Array.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span></h4>
 
@@ -789,7 +789,7 @@ Values are <code>undefined</code> so they can be overridden</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
@@ -802,510 +802,510 @@ Values are <code>undefined</code> so they can be overridden</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>basic</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>collectComplex</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>unitFactor</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>unitPower</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>unitDenominator</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>zeroFactor</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>zeroTerm</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>zeroPower</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>noLeadingMinus</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>collectNumbers</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>simplifyFractions</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>zeroBase</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>constantsFirst</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>sqrtProduct</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>sqrtDivision</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>sqrtSquare</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>trig</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>otherNumbers</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>cancelTerms</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>cancelFactors</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>collectLikeFractions</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -1314,42 +1314,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1898">runtime/scripts/jme-rules.js, line 1898</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -1358,8 +1358,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".specialMatchFunctions"><span class="type-signature">(static) </span>specialMatchFunctions<span class="type-signature"> :function</span></h4>
 
@@ -1375,7 +1375,7 @@ Values are <code>undefined</code> so they can be overridden</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
@@ -1388,326 +1388,326 @@ Values are <code>undefined</code> so they can be overridden</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_uses</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_exactly</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_commutative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_noncommutative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_associative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_nonassociative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_strictinverse</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_gather</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_nogather</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_type</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_func</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_op</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>m_anywhere</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -1716,42 +1716,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L664">runtime/scripts/jme-rules.js, line 664</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -1760,8 +1760,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".specialMatchNames"><span class="type-signature">(static) </span>specialMatchNames<span class="type-signature"> :function</span></h4>
 
@@ -1777,7 +1777,7 @@ Values are <code>undefined</code> so they can be overridden</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
@@ -1790,119 +1790,119 @@ Values are <code>undefined</code> so they can be overridden</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"?"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>$n</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>$v</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>$z</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -1911,42 +1911,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L569">runtime/scripts/jme-rules.js, line 569</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -1955,8 +1955,8 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-            
+
+
 <div class="item member">
 <h4 class="name" id=".specialMatchOps"><span class="type-signature">(static) </span>specialMatchOps<span class="type-signature"> :function</span></h4>
 
@@ -1972,7 +1972,7 @@ Values are <code>undefined</code> so they can be overridden</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
@@ -1985,280 +1985,280 @@ Values are <code>undefined</code> so they can be overridden</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`?"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`*"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`+"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`|"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`:"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`+-"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`*/"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`!"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`&"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`where"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>"`@"</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2267,42 +2267,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L762">runtime/scripts/jme-rules.js, line 762</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -2311,25 +2311,25 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 </div>
 
-        
-		</div>
-    
 
-    
+		</div>
+
+
+
 		<div class="subsection">
         <h3 class="subsection-title">Methods</h3>
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".applyPostReplacement"><span class="type-signature">(static) </span>applyPostReplacement<span class="signature">(tree, options)</span><span class="type-signature"> &rarr; {<a href="Numbas.jme.html#.tree">Numbas.jme.tree</a>}</span></h4>
 
-    
+
 
 
 
@@ -2346,73 +2346,73 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>tree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2438,12 +2438,12 @@ Values are <code>undefined</code> so they can be overridden</p>
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
@@ -2454,7 +2454,7 @@ Values are <code>undefined</code> so they can be overridden</p>
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2466,42 +2466,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1613">runtime/scripts/jme-rules.js, line 1613</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -2509,17 +2509,17 @@ Values are <code>undefined</code> so they can be overridden</p>
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".collectRuleset"><span class="type-signature">(static) </span>collectRuleset<span class="signature">(set, scopeSets)</span><span class="type-signature"> &rarr; {<a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a>}</span></h4>
 
-    
+
 
 
 
@@ -2536,76 +2536,76 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>set</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>
 |
 
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>|<a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a>)></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>A comma-separated string of ruleset names, or an array of names/Ruleset objects.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>scopeSets</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>.&lt;<a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>Dictionary of rulesets defined in the current scope.</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2631,12 +2631,12 @@ Values are <code>undefined</code> so they can be overridden</p>
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a></span>
 
 
@@ -2647,7 +2647,7 @@ Values are <code>undefined</code> so they can be overridden</p>
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2659,42 +2659,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1840">runtime/scripts/jme-rules.js, line 1840</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -2702,17 +2702,17 @@ Values are <code>undefined</code> so they can be overridden</p>
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".compileRules"><span class="type-signature">(static) </span>compileRules<span class="signature">(rules, name)</span><span class="type-signature"> &rarr; {<a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a>}</span></h4>
 
-    
+
 
 
 
@@ -2729,73 +2729,73 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>rules</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>name</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>a name for this group of rules</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2821,12 +2821,12 @@ Values are <code>undefined</code> so they can be overridden</p>
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a></span>
 
 
@@ -2837,7 +2837,7 @@ Values are <code>undefined</code> so they can be overridden</p>
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -2849,42 +2849,42 @@ Values are <code>undefined</code> so they can be overridden</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L2030">runtime/scripts/jme-rules.js, line 2030</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -2892,17 +2892,17 @@ Values are <code>undefined</code> so they can be overridden</p>
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".findSequenceMatch"><span class="type-signature">(static) </span>findSequenceMatch<span class="signature">(pattern, input, options)</span><span class="type-signature"> &rarr; {Object}</span></h4>
 
-    
+
 
 
 
@@ -2921,96 +2921,96 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>pattern</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.html#.term">Numbas.jme.rules.term</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>input</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.html#.tree">Numbas.jme.tree</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.findSequenceMatch_options">Numbas.jme.rules.findSequenceMatch_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3036,12 +3036,12 @@ The match is greedy - input terms will match earlier pattern terms in preference
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></span>
 
 
@@ -3056,7 +3056,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3068,42 +3068,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1276">runtime/scripts/jme-rules.js, line 1276</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -3111,17 +3111,17 @@ The match is greedy - input terms will match earlier pattern terms in preference
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".matchAllTree"><span class="type-signature">(static) </span>matchAllTree<span class="signature">(ruleTree, exprTree, options)</span><span class="type-signature"> &rarr; {Array.&lt;<a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a>>}</span></h4>
 
-    
+
 
 
 
@@ -3138,96 +3138,96 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>ruleTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the pattern to match</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>exprTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the syntax tree to test</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3253,12 +3253,12 @@ The match is greedy - input terms will match earlier pattern terms in preference
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a>></span>
 
 
@@ -3269,7 +3269,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3281,42 +3281,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1580">runtime/scripts/jme-rules.js, line 1580</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -3324,17 +3324,17 @@ The match is greedy - input terms will match earlier pattern terms in preference
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".matchExpression"><span class="type-signature">(static) </span>matchExpression<span class="signature">(pattern, expr, options)</span><span class="type-signature"> &rarr; {Boolean|<a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a>}</span></h4>
 
-    
+
 
 
 
@@ -3351,96 +3351,96 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>pattern</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="global.html#JME">JME</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>expr</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="global.html#JME">JME</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>default is <code>commutative</code>, <code>associative</code>, and <code>allowOtherTerms</code> all <code>true</code>, and using <a href="Numbas.jme.html#.builtinScope"><code>Numbas.jme.builtinScope</code></a>.</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3466,12 +3466,12 @@ The match is greedy - input terms will match earlier pattern terms in preference
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 |
 
@@ -3489,7 +3489,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3501,42 +3501,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1728">runtime/scripts/jme-rules.js, line 1728</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -3544,17 +3544,17 @@ The match is greedy - input terms will match earlier pattern terms in preference
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".matchTree"><span class="type-signature">(static) </span>matchTree<span class="signature">(ruleTree, exprTree, options)</span><span class="type-signature"> &rarr; {Boolean|<a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a>}</span></h4>
 
-    
+
 
 
 
@@ -3571,96 +3571,96 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>ruleTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>exprTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>options specifying the behaviour of the matching algorithm</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3686,12 +3686,12 @@ The match is greedy - input terms will match earlier pattern terms in preference
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 |
 
@@ -3709,7 +3709,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3721,42 +3721,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L453">runtime/scripts/jme-rules.js, line 453</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -3764,17 +3764,17 @@ The match is greedy - input terms will match earlier pattern terms in preference
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".transform"><span class="type-signature">(static) </span>transform<span class="signature">(ruleTree, resultTree, exprTree, options)</span><span class="type-signature"> &rarr; {<a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a>}</span></h4>
 
-    
+
 
 
 
@@ -3791,119 +3791,119 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>ruleTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the rule to test against</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>resultTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the tree to output, with named groups from the rule substituted in.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>exprTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the expression to be tested</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>options for the match</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3929,12 +3929,12 @@ The match is greedy - input terms will match earlier pattern terms in preference
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a></span>
 
 
@@ -3945,7 +3945,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -3957,42 +3957,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1643">runtime/scripts/jme-rules.js, line 1643</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -4000,17 +4000,17 @@ The match is greedy - input terms will match earlier pattern terms in preference
 	</div>
 
 
-        
-            
 
-    
-	
+
+
+
+
 		<div class="item function">
-	
+
 
     <h4 class="name" id=".transformAll"><span class="type-signature">(static) </span>transformAll<span class="signature">(ruleTree, resultTree, exprTree, options)</span><span class="type-signature"> &rarr; {<a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a>}</span></h4>
 
-    
+
 
 
 
@@ -4027,119 +4027,119 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 
     <h5>Parameters:</h5>
-    
+
 
 <table class="params">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>ruleTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the rule to test against</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>resultTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the tree to output, with named groups from the rule substituted in.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>exprTree</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the expression to be tested</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>options</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>options for the match</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -4165,12 +4165,12 @@ The match is greedy - input terms will match earlier pattern terms in preference
         </tr>
     </thead>
     <tbody>
-    
-        
+
+
 <tr>
 <td class="type">
 
-    
+
 <span class="param-type"><a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a></span>
 
 
@@ -4181,7 +4181,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
 </td>
 </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -4193,42 +4193,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1670">runtime/scripts/jme-rules.js, line 1670</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -4236,16 +4236,16 @@ The match is greedy - input terms will match earlier pattern terms in preference
 	</div>
 
 
-        
-		</div>
-    
 
-    
+		</div>
+
+
+
 		<div class="subsection">
         <h3 class="subsection-title">Type Definitions</h3>
 
-        
-                
+
+
 <div class="item member">
 <h4 class="name" id=".findSequenceMatch_options">findSequenceMatch_options</h4>
 
@@ -4261,7 +4261,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></span>
 
 
@@ -4274,119 +4274,119 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>allowOtherTerms</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>if <code>true</code>, terms that don't match any term in the pattern can be ignored</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>commutative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>can the input terms be considered in any order?</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>constraintFn</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>function to test if the current set of matches satisfies constraints</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>checkFn</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>function to test if an input term matches a given pattern term</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -4395,42 +4395,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1255">runtime/scripts/jme-rules.js, line 1255</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -4439,8 +4439,8 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 </div>
 
-            
-                
+
+
 <div class="item member">
 <h4 class="name" id=".getTerms_options">getTerms_options</h4>
 
@@ -4456,7 +4456,7 @@ The match is greedy - input terms will match earlier pattern terms in preference
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></span>
 
 
@@ -4469,96 +4469,96 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>commutative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>should the operator be considered as commutative, for the purposes of matching ops with opposites? If yes, <code>a&gt;c</code> will produce terms <code>c</code> and <code>a</code> when <code>op='&lt;'</code>.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>associative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>should the operator be considered as associative? If yes, <code>(a+b)+c</code> will produce three terms <code>a</code>,<code>b</code> and <code>c</code>. If no, it will produce two terms, <code>(a+b)</code> and <code>c</code>.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>strictInverse</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>if <code>false</code>, <code>a-b</code> will be interpreted as <code>a+(-b)</code> when finding additive terms.</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -4567,42 +4567,42 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L138">runtime/scripts/jme-rules.js, line 138</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -4611,8 +4611,8 @@ The match is greedy - input terms will match earlier pattern terms in preference
 
 </div>
 
-            
-                
+
+
 <div class="item member">
 <h4 class="name" id=".jme_pattern_match">jme_pattern_match</h4>
 
@@ -4629,7 +4629,7 @@ Maps variable names to trees.</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>.&lt;<a href="Numbas.jme.html#.tree">Numbas.jme.tree</a>></span>
 
 
@@ -4642,49 +4642,49 @@ Maps variable names to trees.</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L437">runtime/scripts/jme-rules.js, line 437</a>
     </li></ul></dd>
-    
 
-    
 
-    
+
+
+
     <dt class="tag-see">See:</dt>
     <dd class="tag-see">
         <ul>
             <li>{Numbas.jme.rules#matchTree}</li>
         </ul>
     </dd>
-    
 
-    
+
+
 </dl>
 
 
@@ -4693,8 +4693,8 @@ Maps variable names to trees.</p>
 
 </div>
 
-            
-                
+
+
 <div class="item member">
 <h4 class="name" id=".matchTree_options">matchTree_options</h4>
 
@@ -4710,7 +4710,7 @@ Maps variable names to trees.</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></span>
 
 
@@ -4723,142 +4723,142 @@ Maps variable names to trees.</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>commutative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>should the commutativity of operations be used? If <code>false</code>, terms must appear in the same order as in the pattern.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>associative</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>should the associativity of operations be used? If <code>true</code>, all terms in nested applications of associative ops are gathered together before comparing.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>allowOtherTerms</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>when matching an associative op, if the expression contains terms that don't match any of the pattern, should they be ignored? If <code>false</code>, every term in the expression must match a term in the pattern.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>strictInverse</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>If <code>false</code>, <code>a-b</code> will be interpreted as <code>a+(-b)</code> when finding additive terms.</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>scope</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.Scope.html">Numbas.jme.Scope</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>A JME scope in which to evaluate conditions.</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -4867,42 +4867,42 @@ Maps variable names to trees.</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L12">runtime/scripts/jme-rules.js, line 12</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -4911,8 +4911,8 @@ Maps variable names to trees.</p>
 
 </div>
 
-            
-                
+
+
 <div class="item member">
 <h4 class="name" id=".ruleset_flags">ruleset_flags</h4>
 
@@ -4928,7 +4928,7 @@ Maps variable names to trees.</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>.&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></span>
 
 
@@ -4941,96 +4941,95 @@ Maps variable names to trees.</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>fractionnumbers</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>Show all numbers as fractions?</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>rowvector</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>Display vectors as a horizontal list of components?</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>alwaystimes</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>Always show the multiplication symbol between multiplicands?</p></td>
         </tr>
 
-    
     </tbody>
 </table>
 
@@ -5039,49 +5038,49 @@ Maps variable names to trees.</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1752">runtime/scripts/jme-rules.js, line 1752</a>
     </li></ul></dd>
-    
 
-    
 
-    
+
+
+
     <dt class="tag-see">See:</dt>
     <dd class="tag-see">
         <ul>
             <li><a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a></li>
         </ul>
     </dd>
-    
 
-    
+
+
 </dl>
 
 
@@ -5090,8 +5089,8 @@ Maps variable names to trees.</p>
 
 </div>
 
-            
-                
+
+
 <div class="item member">
 <h4 class="name" id=".term">term</h4>
 
@@ -5107,7 +5106,7 @@ Maps variable names to trees.</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></span>
 
 
@@ -5120,188 +5119,188 @@ Maps variable names to trees.</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>term</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>names</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>names captured by this term</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>equalnames</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>.&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>identified names captured by this term</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>quantifier</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>code describing how many times the term can appear, if it's a pattern term</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>min</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the minimum number of times the term must appear</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>max</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the maximum number of times the term can appear</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>defaultValue</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>a value to use if this term is missing</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -5310,42 +5309,42 @@ Maps variable names to trees.</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L146">runtime/scripts/jme-rules.js, line 146</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -5354,8 +5353,8 @@ Maps variable names to trees.</p>
 
 </div>
 
-            
-                
+
+
 <div class="item member">
 <h4 class="name" id=".transform_result">transform_result</h4>
 
@@ -5371,7 +5370,7 @@ Maps variable names to trees.</p>
     <h5>Type:</h5>
     <ul>
         <li>
-            
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></span>
 
 
@@ -5384,73 +5383,73 @@ Maps variable names to trees.</p>
 
     <h5 class="subsection-title">Properties:</h5>
 
-    
+
 
 <table class="props">
     <thead>
     <tr>
-        
+
         <th>Name</th>
-        
+
 
         <th>Type</th>
 
-        
 
-        
+
+
 
         <th class="last">Description</th>
     </tr>
     </thead>
 
     <tbody>
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>changed</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>Is the result expression different to the input expression?</p></td>
         </tr>
 
-    
+
 
         <tr>
-            
+
                 <td class="name"><code>expression</code></td>
-            
+
 
             <td class="type">
-            
-                
+
+
 <span class="param-type"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></span>
 
 
-            
+
             </td>
 
-            
 
-            
+
+
 
             <td class="description last"><p>the result expression</p></td>
         </tr>
 
-    
+
     </tbody>
 </table>
 
@@ -5459,42 +5458,42 @@ Maps variable names to trees.</p>
 
 <dl class="details">
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
         <a href="https://github.com/numbas/Numbas/blob/master/runtime/scripts/jme-rules.js#L1627">runtime/scripts/jme-rules.js, line 1627</a>
     </li></ul></dd>
-    
 
-    
 
-    
 
-    
+
+
+
+
 </dl>
 
 
@@ -5503,11 +5502,11 @@ Maps variable names to trees.</p>
 
 </div>
 
-            
-		</div>
-    
 
-    
+		</div>
+
+
+
 </article>
 
 </section>
@@ -5521,3397 +5520,3397 @@ Maps variable names to trees.</p>
 		<h2><a href="index.html">Home</a></h2><div class="search">
 	<input id="search-query" type="text" placeholder="Search"/>
 	<ul id="search-results">
-		
+
 			<li class="search-result" data-longname="global"><a href="global.html">global</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree"><a href="AnnotatedTree.html">AnnotatedTree</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#assign"><a href="AnnotatedTree.html#assign">AnnotatedTree#assign</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#assign_args"><a href="AnnotatedTree.html#assign_args">AnnotatedTree#assign_args</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#backtrack"><a href="AnnotatedTree.html#backtrack">AnnotatedTree#backtrack</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#next"><a href="AnnotatedTree.html#next">AnnotatedTree#next</a></li>
-		
+
 			<li class="search-result" data-longname="complex"><a href="global.html#complex">complex</a></li>
-		
+
 			<li class="search-result" data-longname="fraction"><a href="global.html#fraction">fraction</a></li>
-		
+
 			<li class="search-result" data-longname="get"><a href="global.html#get">get</a></li>
-		
+
 			<li class="search-result" data-longname="hasWarnings"><a href="global.html#hasWarnings">hasWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="JME"><a href="global.html#JME">JME</a></li>
-		
+
 			<li class="search-result" data-longname="matrix"><a href="global.html#matrix">matrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas"><a href="Numbas.html">Numbas</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.addExtension"><a href="Numbas.html#.addExtension">Numbas.addExtension</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.checkAllScriptsLoaded"><a href="Numbas.html#.checkAllScriptsLoaded">Numbas.checkAllScriptsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls"><a href="Numbas.controls.html">Numbas.controls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.backToResults"><a href="Numbas.controls.html#.backToResults">Numbas.controls.backToResults</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.beginExam"><a href="Numbas.controls.html#.beginExam">Numbas.controls.beginExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.endExam"><a href="Numbas.controls.html#.endExam">Numbas.controls.endExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.exitExam"><a href="Numbas.controls.html#.exitExam">Numbas.controls.exitExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.getAdvice"><a href="Numbas.controls.html#.getAdvice">Numbas.controls.getAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.hideSteps"><a href="Numbas.controls.html#.hideSteps">Numbas.controls.hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.jumpQuestion"><a href="Numbas.controls.html#.jumpQuestion">Numbas.controls.jumpQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.makeQuestionJumper"><a href="Numbas.controls.html#.makeQuestionJumper">Numbas.controls.makeQuestionJumper</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.nextQuestion"><a href="Numbas.controls.html#.nextQuestion">Numbas.controls.nextQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.pauseExam"><a href="Numbas.controls.html#.pauseExam">Numbas.controls.pauseExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.previousQuestion"><a href="Numbas.controls.html#.previousQuestion">Numbas.controls.previousQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.regenQuestion"><a href="Numbas.controls.html#.regenQuestion">Numbas.controls.regenQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.resumeExam"><a href="Numbas.controls.html#.resumeExam">Numbas.controls.resumeExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.revealAnswer"><a href="Numbas.controls.html#.revealAnswer">Numbas.controls.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.submitQuestion"><a href="Numbas.controls.html#.submitQuestion">Numbas.controls.submitQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPart"><a href="Numbas.html#.createPart">Numbas.createPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPartFromJSON"><a href="Numbas.html#.createPartFromJSON">Numbas.createPartFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPartFromXML"><a href="Numbas.html#.createPartFromXML">Numbas.createPartFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createQuestionFromJSON"><a href="Numbas.html#.createQuestionFromJSON">Numbas.createQuestionFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createQuestionFromXML"><a href="Numbas.html#.createQuestionFromXML">Numbas.createQuestionFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.custom_part_types"><a href="Numbas.html#.custom_part_types">Numbas.custom_part_types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.debug"><a href="Numbas.html#.debug">Numbas.debug</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display"><a href="Numbas.display.html">Numbas.display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.die"><a href="Numbas.display.html#.die">Numbas.display.die</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay"><a href="Numbas.display.ExamDisplay.html">Numbas.display.ExamDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay._endTime"><a href="Numbas.display.ExamDisplay.html#._endTime">Numbas.display.ExamDisplay._endTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay._startTime"><a href="Numbas.display.ExamDisplay.html#._startTime">Numbas.display.ExamDisplay._startTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.allowPause"><a href="Numbas.display.ExamDisplay.html#.allowPause">Numbas.display.ExamDisplay.allowPause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.applyQuestionBindings"><a href="Numbas.display.ExamDisplay.html#.applyQuestionBindings">Numbas.display.ExamDisplay.applyQuestionBindings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.beginExam"><a href="Numbas.display.ExamDisplay.html#.beginExam">Numbas.display.ExamDisplay.beginExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canAdvance"><a href="Numbas.display.ExamDisplay.html#.canAdvance">Numbas.display.ExamDisplay.canAdvance</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canBegin"><a href="Numbas.display.ExamDisplay.html#.canBegin">Numbas.display.ExamDisplay.canBegin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canReverse"><a href="Numbas.display.ExamDisplay.html#.canReverse">Numbas.display.ExamDisplay.canReverse</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.currentQuestion"><a href="Numbas.display.ExamDisplay.html#.currentQuestion">Numbas.display.ExamDisplay.currentQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.currentQuestionNumber"><a href="Numbas.display.ExamDisplay.html#.currentQuestionNumber">Numbas.display.ExamDisplay.currentQuestionNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.displayTime"><a href="Numbas.display.ExamDisplay.html#.displayTime">Numbas.display.ExamDisplay.displayTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.end"><a href="Numbas.display.ExamDisplay.html#.end">Numbas.display.ExamDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.endRegen"><a href="Numbas.display.ExamDisplay.html#.endRegen">Numbas.display.ExamDisplay.endRegen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.enteredPassword"><a href="Numbas.display.ExamDisplay.html#.enteredPassword">Numbas.display.ExamDisplay.enteredPassword</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.exam"><a href="Numbas.display.ExamDisplay.html#.exam">Numbas.display.ExamDisplay.exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.examScoreDisplay"><a href="Numbas.display.ExamDisplay.html#.examScoreDisplay">Numbas.display.ExamDisplay.examScoreDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.feedbackMessage"><a href="Numbas.display.ExamDisplay.html#.feedbackMessage">Numbas.display.ExamDisplay.feedbackMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.hideNavMenu"><a href="Numbas.display.ExamDisplay.html#.hideNavMenu">Numbas.display.ExamDisplay.hideNavMenu</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.hideTiming"><a href="Numbas.display.ExamDisplay.html#.hideTiming">Numbas.display.ExamDisplay.hideTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.infoPage"><a href="Numbas.display.ExamDisplay.html#.infoPage">Numbas.display.ExamDisplay.infoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.initQuestionList"><a href="Numbas.display.ExamDisplay.html#.initQuestionList">Numbas.display.ExamDisplay.initQuestionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.marks"><a href="Numbas.display.ExamDisplay.html#.marks">Numbas.display.ExamDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.mode"><a href="Numbas.display.ExamDisplay.html#.mode">Numbas.display.ExamDisplay.mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.passed"><a href="Numbas.display.ExamDisplay.html#.passed">Numbas.display.ExamDisplay.passed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.passwordFeedback."><a href="Numbas.display.ExamDisplay.html#.passwordFeedback.">Numbas.display.ExamDisplay.passwordFeedback.</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.percentPass"><a href="Numbas.display.ExamDisplay.html#.percentPass">Numbas.display.ExamDisplay.percentPass</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.percentScore"><a href="Numbas.display.ExamDisplay.html#.percentScore">Numbas.display.ExamDisplay.percentScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questions"><a href="Numbas.display.ExamDisplay.html#.questions">Numbas.display.ExamDisplay.questions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questionsAttempted"><a href="Numbas.display.ExamDisplay.html#.questionsAttempted">Numbas.display.ExamDisplay.questionsAttempted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questionsAttemptedDisplay"><a href="Numbas.display.ExamDisplay.html#.questionsAttemptedDisplay">Numbas.display.ExamDisplay.questionsAttemptedDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.result"><a href="Numbas.display.ExamDisplay.html#.result">Numbas.display.ExamDisplay.result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.saving"><a href="Numbas.display.ExamDisplay.html#.saving">Numbas.display.ExamDisplay.saving</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.score"><a href="Numbas.display.ExamDisplay.html#.score">Numbas.display.ExamDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showInfoPage"><a href="Numbas.display.ExamDisplay.html#.showInfoPage">Numbas.display.ExamDisplay.showInfoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showQuestion"><a href="Numbas.display.ExamDisplay.html#.showQuestion">Numbas.display.ExamDisplay.showQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showQuestionGroupNames"><a href="Numbas.display.ExamDisplay.html#.showQuestionGroupNames">Numbas.display.ExamDisplay.showQuestionGroupNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showScore"><a href="Numbas.display.ExamDisplay.html#.showScore">Numbas.display.ExamDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showTiming"><a href="Numbas.display.ExamDisplay.html#.showTiming">Numbas.display.ExamDisplay.showTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.startRegen"><a href="Numbas.display.ExamDisplay.html#.startRegen">Numbas.display.ExamDisplay.startRegen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.timeSpent"><a href="Numbas.display.ExamDisplay.html#.timeSpent">Numbas.display.ExamDisplay.timeSpent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.updateQuestionMenu"><a href="Numbas.display.ExamDisplay.html#.updateQuestionMenu">Numbas.display.ExamDisplay.updateQuestionMenu</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.viewType"><a href="Numbas.display.ExamDisplay.html#.viewType">Numbas.display.ExamDisplay.viewType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.feedback_state"><a href="Numbas.display.html#.feedback_state">Numbas.display.feedback_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.feedbackable"><a href="Numbas.display.html#.feedbackable">Numbas.display.feedbackable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.getLocalisedAttribute"><a href="Numbas.display.html#.getLocalisedAttribute">Numbas.display.getLocalisedAttribute</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.init"><a href="Numbas.display.html#.init">Numbas.display.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.localisePage"><a href="Numbas.display.html#.localisePage">Numbas.display.localisePage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.modal"><a href="Numbas.display.html#.modal">Numbas.display.modal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay"><a href="Numbas.display.PartDisplay.html">Numbas.display.PartDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.answered"><a href="Numbas.display.PartDisplay.html#.answered">Numbas.display.PartDisplay.answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.controls"><a href="Numbas.display.PartDisplay.html#.controls">Numbas.display.PartDisplay.controls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.credit"><a href="Numbas.display.PartDisplay.html#.credit">Numbas.display.PartDisplay.credit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.doesMarking"><a href="Numbas.display.PartDisplay.html#.doesMarking">Numbas.display.PartDisplay.doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.end"><a href="Numbas.display.PartDisplay.html#.end">Numbas.display.PartDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.feedbackMessages"><a href="Numbas.display.PartDisplay.html#.feedbackMessages">Numbas.display.PartDisplay.feedbackMessages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.feedbackShown"><a href="Numbas.display.PartDisplay.html#.feedbackShown">Numbas.display.PartDisplay.feedbackShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.hideSteps"><a href="Numbas.display.PartDisplay.html#.hideSteps">Numbas.display.PartDisplay.hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.hideWarnings"><a href="Numbas.display.PartDisplay.html#.hideWarnings">Numbas.display.PartDisplay.hideWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.init"><a href="Numbas.display.PartDisplay.html#.init">Numbas.display.PartDisplay.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.inputEvents"><a href="Numbas.display.PartDisplay.html#.inputEvents">Numbas.display.PartDisplay.inputEvents</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.isDirty"><a href="Numbas.display.PartDisplay.html#.isDirty">Numbas.display.PartDisplay.isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.isNotOnlyPart"><a href="Numbas.display.PartDisplay.html#.isNotOnlyPart">Numbas.display.PartDisplay.isNotOnlyPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.marks"><a href="Numbas.display.PartDisplay.html#.marks">Numbas.display.PartDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.part"><a href="Numbas.display.PartDisplay.html#.part">Numbas.display.PartDisplay.part</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.question"><a href="Numbas.display.PartDisplay.html#.question">Numbas.display.PartDisplay.question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.removeWarnings"><a href="Numbas.display.PartDisplay.html#.removeWarnings">Numbas.display.PartDisplay.removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.restoreAnswer"><a href="Numbas.display.PartDisplay.html#.restoreAnswer">Numbas.display.PartDisplay.restoreAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.revealAnswer"><a href="Numbas.display.PartDisplay.html#.revealAnswer">Numbas.display.PartDisplay.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.revealed"><a href="Numbas.display.PartDisplay.html#.revealed">Numbas.display.PartDisplay.revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.score"><a href="Numbas.display.PartDisplay.html#.score">Numbas.display.PartDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.scoreFeedback"><a href="Numbas.display.PartDisplay.html#.scoreFeedback">Numbas.display.PartDisplay.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.setWarnings"><a href="Numbas.display.PartDisplay.html#.setWarnings">Numbas.display.PartDisplay.setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.show"><a href="Numbas.display.PartDisplay.html#.show">Numbas.display.PartDisplay.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showCorrectAnswer"><a href="Numbas.display.PartDisplay.html#.showCorrectAnswer">Numbas.display.PartDisplay.showCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackBox"><a href="Numbas.display.PartDisplay.html#.showFeedbackBox">Numbas.display.PartDisplay.showFeedbackBox</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackIcon"><a href="Numbas.display.PartDisplay.html#.showFeedbackIcon">Numbas.display.PartDisplay.showFeedbackIcon</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackMessages"><a href="Numbas.display.PartDisplay.html#.showFeedbackMessages">Numbas.display.PartDisplay.showFeedbackMessages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showMarks"><a href="Numbas.display.PartDisplay.html#.showMarks">Numbas.display.PartDisplay.showMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showScore"><a href="Numbas.display.PartDisplay.html#.showScore">Numbas.display.PartDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showSteps"><a href="Numbas.display.PartDisplay.html#.showSteps">Numbas.display.PartDisplay.showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showSubmitPart"><a href="Numbas.display.PartDisplay.html#.showSubmitPart">Numbas.display.PartDisplay.showSubmitPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showWarnings"><a href="Numbas.display.PartDisplay.html#.showWarnings">Numbas.display.PartDisplay.showWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsOpen"><a href="Numbas.display.PartDisplay.html#.stepsOpen">Numbas.display.PartDisplay.stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsPenaltyMessage"><a href="Numbas.display.PartDisplay.html#.stepsPenaltyMessage">Numbas.display.PartDisplay.stepsPenaltyMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsShown"><a href="Numbas.display.PartDisplay.html#.stepsShown">Numbas.display.PartDisplay.stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.toggleFeedbackText"><a href="Numbas.display.PartDisplay.html#.toggleFeedbackText">Numbas.display.PartDisplay.toggleFeedbackText</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.updateCorrectAnswer"><a href="Numbas.display.PartDisplay.html#.updateCorrectAnswer">Numbas.display.PartDisplay.updateCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warning"><a href="Numbas.display.PartDisplay.html#.warning">Numbas.display.PartDisplay.warning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warnings"><a href="Numbas.display.PartDisplay.html#.warnings">Numbas.display.PartDisplay.warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warningsShown"><a href="Numbas.display.PartDisplay.html#.warningsShown">Numbas.display.PartDisplay.warningsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay#setName"><a href="Numbas.display.PartDisplay.html#setName">Numbas.display.PartDisplay#setName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay"><a href="Numbas.display.QuestionDisplay.html">Numbas.display.QuestionDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.adviceDisplayed"><a href="Numbas.display.QuestionDisplay.html#.adviceDisplayed">Numbas.display.QuestionDisplay.adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.answered"><a href="Numbas.display.QuestionDisplay.html#.answered">Numbas.display.QuestionDisplay.answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.anyAnswered"><a href="Numbas.display.QuestionDisplay.html#.anyAnswered">Numbas.display.QuestionDisplay.anyAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.canReveal"><a href="Numbas.display.QuestionDisplay.html#.canReveal">Numbas.display.QuestionDisplay.canReveal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.credit"><a href="Numbas.display.QuestionDisplay.html#.credit">Numbas.display.QuestionDisplay.credit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.displayName"><a href="Numbas.display.QuestionDisplay.html#.displayName">Numbas.display.QuestionDisplay.displayName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.doesMarking"><a href="Numbas.display.QuestionDisplay.html#.doesMarking">Numbas.display.QuestionDisplay.doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.end"><a href="Numbas.display.QuestionDisplay.html#.end">Numbas.display.QuestionDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.getPart"><a href="Numbas.display.QuestionDisplay.html#.getPart">Numbas.display.QuestionDisplay.getPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.html"><a href="Numbas.display.QuestionDisplay.html#.html">Numbas.display.QuestionDisplay.html</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.init"><a href="Numbas.display.QuestionDisplay.html#.init">Numbas.display.QuestionDisplay.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.isDirty"><a href="Numbas.display.QuestionDisplay.html#.isDirty">Numbas.display.QuestionDisplay.isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.leave"><a href="Numbas.display.QuestionDisplay.html#.leave">Numbas.display.QuestionDisplay.leave</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.makeHTML"><a href="Numbas.display.QuestionDisplay.html#.makeHTML">Numbas.display.QuestionDisplay.makeHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.marks"><a href="Numbas.display.QuestionDisplay.html#.marks">Numbas.display.QuestionDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.numParts"><a href="Numbas.display.QuestionDisplay.html#.numParts">Numbas.display.QuestionDisplay.numParts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.question"><a href="Numbas.display.QuestionDisplay.html#.question">Numbas.display.QuestionDisplay.question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.revealAnswer"><a href="Numbas.display.QuestionDisplay.html#.revealAnswer">Numbas.display.QuestionDisplay.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.revealed"><a href="Numbas.display.QuestionDisplay.html#.revealed">Numbas.display.QuestionDisplay.revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.review"><a href="Numbas.display.QuestionDisplay.html#.review">Numbas.display.QuestionDisplay.review</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.score"><a href="Numbas.display.QuestionDisplay.html#.score">Numbas.display.QuestionDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.scoreFeedback"><a href="Numbas.display.QuestionDisplay.html#.scoreFeedback">Numbas.display.QuestionDisplay.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.scrollToError"><a href="Numbas.display.QuestionDisplay.html#.scrollToError">Numbas.display.QuestionDisplay.scrollToError</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.show"><a href="Numbas.display.QuestionDisplay.html#.show">Numbas.display.QuestionDisplay.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.showAdvice"><a href="Numbas.display.QuestionDisplay.html#.showAdvice">Numbas.display.QuestionDisplay.showAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.showScore"><a href="Numbas.display.QuestionDisplay.html#.showScore">Numbas.display.QuestionDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.submitMessage"><a href="Numbas.display.QuestionDisplay.html#.submitMessage">Numbas.display.QuestionDisplay.submitMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.visible"><a href="Numbas.display.QuestionDisplay.html#.visible">Numbas.display.QuestionDisplay.visible</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.visited"><a href="Numbas.display.QuestionDisplay.html#.visited">Numbas.display.QuestionDisplay.visited</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.scoreFeedback"><a href="Numbas.display.html#.scoreFeedback">Numbas.display.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showAlert"><a href="Numbas.display.html#.showAlert">Numbas.display.showAlert</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showConfirm"><a href="Numbas.display.html#.showConfirm">Numbas.display.showConfirm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showLoadProgress"><a href="Numbas.display.html#.showLoadProgress">Numbas.display.showLoadProgress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showScoreFeedback"><a href="Numbas.display.html#.showScoreFeedback">Numbas.display.showScoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showScoreFeedback_settings"><a href="Numbas.display.html#.showScoreFeedback_settings">Numbas.display.showScoreFeedback_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.typeset"><a href="Numbas.display.html#.typeset">Numbas.display.typeset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Error"><a href="Numbas.Error.html">Numbas.Error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam"><a href="Numbas.Exam.html">Numbas.Exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.exam"><a href="Numbas.html#.exam">Numbas.exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#acceptPassword"><a href="Numbas.Exam.html#acceptPassword">Numbas.Exam#acceptPassword</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#begin"><a href="Numbas.Exam.html#begin">Numbas.Exam#begin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#calculateScore"><a href="Numbas.Exam.html#calculateScore">Numbas.Exam#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#changeQuestion"><a href="Numbas.Exam.html#changeQuestion">Numbas.Exam#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#chooseQuestionSubset"><a href="Numbas.Exam.html#chooseQuestionSubset">Numbas.Exam#chooseQuestionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#countDown"><a href="Numbas.Exam.html#countDown">Numbas.Exam#countDown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#currentQuestion"><a href="Numbas.Exam.html#currentQuestion">Numbas.Exam#currentQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#currentQuestionNumber"><a href="Numbas.Exam.html#currentQuestionNumber">Numbas.Exam#currentQuestionNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#displayDuration"><a href="Numbas.Exam.html#displayDuration">Numbas.Exam#displayDuration</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#end"><a href="Numbas.Exam.html#end">Numbas.Exam#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#endTime"><a href="Numbas.Exam.html#endTime">Numbas.Exam#endTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#endTiming"><a href="Numbas.Exam.html#endTiming">Numbas.Exam#endTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#event:question list initialised"><a href="Numbas.Exam.html#event:questionlistinitialised">Numbas.Exam#event:question list initialised</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#event:ready"><a href="Numbas.Exam.html#event:ready">Numbas.Exam#event:ready</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#exit"><a href="Numbas.Exam.html#exit">Numbas.Exam#exit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#init"><a href="Numbas.Exam.html#init">Numbas.Exam#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#inProgress"><a href="Numbas.Exam.html#inProgress">Numbas.Exam#inProgress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#load"><a href="Numbas.Exam.html#load">Numbas.Exam#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#makeQuestionList"><a href="Numbas.Exam.html#makeQuestionList">Numbas.Exam#makeQuestionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#mark"><a href="Numbas.Exam.html#mark">Numbas.Exam#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#mode"><a href="Numbas.Exam.html#mode">Numbas.Exam#mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#passed"><a href="Numbas.Exam.html#passed">Numbas.Exam#passed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#pause"><a href="Numbas.Exam.html#pause">Numbas.Exam#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#percentScore"><a href="Numbas.Exam.html#percentScore">Numbas.Exam#percentScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#question_groups"><a href="Numbas.Exam.html#question_groups">Numbas.Exam#question_groups</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#questionList"><a href="Numbas.Exam.html#questionList">Numbas.Exam#questionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#questionSubset"><a href="Numbas.Exam.html#questionSubset">Numbas.Exam#questionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#regenQuestion"><a href="Numbas.Exam.html#regenQuestion">Numbas.Exam#regenQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#resume"><a href="Numbas.Exam.html#resume">Numbas.Exam#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#reviewQuestion"><a href="Numbas.Exam.html#reviewQuestion">Numbas.Exam#reviewQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#scope"><a href="Numbas.Exam.html#scope">Numbas.Exam#scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#score"><a href="Numbas.Exam.html#score">Numbas.Exam#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#settings"><a href="Numbas.Exam.html#settings">Numbas.Exam#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#showInfoPage"><a href="Numbas.Exam.html#showInfoPage">Numbas.Exam#showInfoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#signals"><a href="Numbas.Exam.html#signals">Numbas.Exam#signals</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#start"><a href="Numbas.Exam.html#start">Numbas.Exam#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#startTiming"><a href="Numbas.Exam.html#startTiming">Numbas.Exam#startTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#stop"><a href="Numbas.Exam.html#stop">Numbas.Exam#stop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#stopwatch"><a href="Numbas.Exam.html#stopwatch">Numbas.Exam#stopwatch</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#store"><a href="Numbas.Exam.html#store">Numbas.Exam#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#student_id"><a href="Numbas.Exam.html#student_id">Numbas.Exam#student_id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#student_name"><a href="Numbas.Exam.html#student_name">Numbas.Exam#student_name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#timeRemaining"><a href="Numbas.Exam.html#timeRemaining">Numbas.Exam#timeRemaining</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#timeSpent"><a href="Numbas.Exam.html#timeSpent">Numbas.Exam#timeSpent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#tryChangeQuestion"><a href="Numbas.Exam.html#tryChangeQuestion">Numbas.Exam#tryChangeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#tryEnd"><a href="Numbas.Exam.html#tryEnd">Numbas.Exam#tryEnd</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#updateScore"><a href="Numbas.Exam.html#updateScore">Numbas.Exam#updateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#xml"><a href="Numbas.Exam.html#xml">Numbas.Exam#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent"><a href="Numbas.ExamEvent.html">Numbas.ExamEvent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#action"><a href="Numbas.ExamEvent.html#action">Numbas.ExamEvent#action</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#message"><a href="Numbas.ExamEvent.html#message">Numbas.ExamEvent#message</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#type"><a href="Numbas.ExamEvent.html#type">Numbas.ExamEvent#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.extensions"><a href="Numbas.html#.extensions">Numbas.extensions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.init"><a href="Numbas.html#.init">Numbas.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme"><a href="Numbas.jme.html">Numbas.jme</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addBinaryOperator"><a href="Numbas.jme.html#.addBinaryOperator">Numbas.jme.addBinaryOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addPostfixOperator"><a href="Numbas.jme.html#.addPostfixOperator">Numbas.jme.addPostfixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addPrefixOperator"><a href="Numbas.jme.html#.addPrefixOperator">Numbas.jme.addPrefixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.arity"><a href="Numbas.jme.html#.arity">Numbas.jme.arity</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.associative"><a href="Numbas.jme.html#.associative">Numbas.jme.associative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.builtinScope"><a href="Numbas.jme.html#.builtinScope">Numbas.jme.builtinScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.castToType"><a href="Numbas.jme.html#.castToType">Numbas.jme.castToType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.checkingFunction"><a href="Numbas.jme.html#.checkingFunction">Numbas.jme.checkingFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.checkingFunctions"><a href="Numbas.jme.html#.checkingFunctions">Numbas.jme.checkingFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.commutative"><a href="Numbas.jme.html#.commutative">Numbas.jme.commutative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compare"><a href="Numbas.jme.html#.compare">Numbas.jme.compare</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compare_settings"><a href="Numbas.jme.html#.compare_settings">Numbas.jme.compare_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTokens"><a href="Numbas.jme.html#.compareTokens">Numbas.jme.compareTokens</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTokensByValue"><a href="Numbas.jme.html#.compareTokensByValue">Numbas.jme.compareTokensByValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTrees"><a href="Numbas.jme.html#.compareTrees">Numbas.jme.compareTrees</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compile"><a href="Numbas.jme.html#.compile">Numbas.jme.compile</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compileList"><a href="Numbas.jme.html#.compileList">Numbas.jme.compileList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.constants"><a href="Numbas.jme.html#.constants">Numbas.jme.constants</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.contentsubvars"><a href="Numbas.jme.html#.contentsubvars">Numbas.jme.contentsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.converseOps"><a href="Numbas.jme.html#.converseOps">Numbas.jme.converseOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display"><a href="Numbas.jme.display.html">Numbas.jme.display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.exprToLaTeX"><a href="Numbas.jme.display.html#.exprToLaTeX">Numbas.jme.display.exprToLaTeX</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jme.display.specialNumbers"><a href="Numbas.jme.display.html#.jme.display.specialNumbers">Numbas.jme.display.jme.display.specialNumbers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jme_display_settings"><a href="Numbas.jme.display.html#.jme_display_settings">Numbas.jme.display.jme_display_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jmeFunctions"><a href="Numbas.jme.display.html#.jmeFunctions">Numbas.jme.display.jmeFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets"><a href="Numbas.jme.display.opBrackets.html">Numbas.jme.display.opBrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."*""><a href="Numbas.jme.display.opBrackets.html#.%22*%22">Numbas.jme.display.opBrackets."*"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."+""><a href="Numbas.jme.display.opBrackets.html#.%22+%22">Numbas.jme.display.opBrackets."+"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."+u""><a href="Numbas.jme.display.opBrackets.html#.%22+u%22">Numbas.jme.display.opBrackets."+u"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."-""><a href="Numbas.jme.display.opBrackets.html#.%22-%22">Numbas.jme.display.opBrackets."-"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."-u""><a href="Numbas.jme.display.opBrackets.html#.%22-u%22">Numbas.jme.display.opBrackets."-u"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."/""><a href="Numbas.jme.display.opBrackets.html#.%22/%22">Numbas.jme.display.opBrackets."/"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."=""><a href="Numbas.jme.display.opBrackets.html#.%22=%22">Numbas.jme.display.opBrackets."="</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."^""><a href="Numbas.jme.display.opBrackets.html#.%22%5E%22">Numbas.jme.display.opBrackets."^"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.and"><a href="Numbas.jme.display.opBrackets.html#.and">Numbas.jme.display.opBrackets.and</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.fact"><a href="Numbas.jme.display.opBrackets.html#.fact">Numbas.jme.display.opBrackets.fact</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.or"><a href="Numbas.jme.display.opBrackets.html#.or">Numbas.jme.display.opBrackets.or</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.xor"><a href="Numbas.jme.display.opBrackets.html#.xor">Numbas.jme.display.opBrackets.xor</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplify"><a href="Numbas.jme.display.html#.simplify">Numbas.jme.display.simplify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplifyExpression"><a href="Numbas.jme.display.html#.simplifyExpression">Numbas.jme.display.simplifyExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplifyTree"><a href="Numbas.jme.display.html#.simplifyTree">Numbas.jme.display.simplifyTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.special_number_definition"><a href="Numbas.jme.display.html#.special_number_definition">Numbas.jme.display.special_number_definition</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.specialNames"><a href="Numbas.jme.display.html#.specialNames">Numbas.jme.display.specialNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texify"><a href="Numbas.jme.display.html#.texify">Numbas.jme.display.texify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texify_settings"><a href="Numbas.jme.display.html#.texify_settings">Numbas.jme.display.texify_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texName"><a href="Numbas.jme.display.html#.texName">Numbas.jme.display.texName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texNameAnnotations"><a href="Numbas.jme.display.html#.texNameAnnotations">Numbas.jme.display.texNameAnnotations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texOps"><a href="Numbas.jme.display.html#.texOps">Numbas.jme.display.texOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.treeToJME"><a href="Numbas.jme.display.html#.treeToJME">Numbas.jme.display.treeToJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME"><a href="Numbas.jme.display.html#.typeToJME">Numbas.jme.display.typeToJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.boolean"><a href="Numbas.jme.display.html#.typeToJME#.boolean">Numbas.jme.display.typeToJME.boolean</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.decimal"><a href="Numbas.jme.display.html#.typeToJME#.decimal">Numbas.jme.display.typeToJME.decimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.dict"><a href="Numbas.jme.display.html#.typeToJME#.dict">Numbas.jme.display.typeToJME.dict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.expression"><a href="Numbas.jme.display.html#.typeToJME#.expression">Numbas.jme.display.typeToJME.expression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.function"><a href="Numbas.jme.display.html#.typeToJME#.function">Numbas.jme.display.typeToJME.function</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.html"><a href="Numbas.jme.display.html#.typeToJME#.html">Numbas.jme.display.typeToJME.html</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.integer"><a href="Numbas.jme.display.html#.typeToJME#.integer">Numbas.jme.display.typeToJME.integer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.keypair"><a href="Numbas.jme.display.html#.typeToJME#.keypair">Numbas.jme.display.typeToJME.keypair</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.list"><a href="Numbas.jme.display.html#.typeToJME#.list">Numbas.jme.display.typeToJME.list</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.matrix"><a href="Numbas.jme.display.html#.typeToJME#.matrix">Numbas.jme.display.typeToJME.matrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.name"><a href="Numbas.jme.display.html#.typeToJME#.name">Numbas.jme.display.typeToJME.name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.nothing"><a href="Numbas.jme.display.html#.typeToJME#.nothing">Numbas.jme.display.typeToJME.nothing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.number"><a href="Numbas.jme.display.html#.typeToJME#.number">Numbas.jme.display.typeToJME.number</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.op"><a href="Numbas.jme.display.html#.typeToJME#.op">Numbas.jme.display.typeToJME.op</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.range"><a href="Numbas.jme.display.html#.typeToJME#.range">Numbas.jme.display.typeToJME.range</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.rational"><a href="Numbas.jme.display.html#.typeToJME#.rational">Numbas.jme.display.typeToJME.rational</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.set"><a href="Numbas.jme.display.html#.typeToJME#.set">Numbas.jme.display.typeToJME.set</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.string"><a href="Numbas.jme.display.html#.typeToJME#.string">Numbas.jme.display.typeToJME.string</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.vector"><a href="Numbas.jme.display.html#.typeToJME#.vector">Numbas.jme.display.typeToJME.vector</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToTeX"><a href="Numbas.jme.display.html#.typeToTeX">Numbas.jme.display.typeToTeX</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.escape"><a href="Numbas.jme.html#.escape">Numbas.jme.escape</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.evaluate"><a href="Numbas.jme.html#.evaluate">Numbas.jme.evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.evaluate_fn"><a href="Numbas.jme.html#.evaluate_fn">Numbas.jme.evaluate_fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findCompatibleType"><a href="Numbas.jme.html#.findCompatibleType">Numbas.jme.findCompatibleType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findvars"><a href="Numbas.jme.html#.findvars">Numbas.jme.findvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findvarsOps"><a href="Numbas.jme.html#.findvarsOps">Numbas.jme.findvarsOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj"><a href="Numbas.jme.funcObj.html">Numbas.jme.funcObj</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.description"><a href="Numbas.jme.funcObj.html#.description">Numbas.jme.funcObj.description</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.evaluate"><a href="Numbas.jme.funcObj.html#.evaluate">Numbas.jme.funcObj.evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.fn"><a href="Numbas.jme.funcObj.html#.fn">Numbas.jme.funcObj.fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.id"><a href="Numbas.jme.funcObj.html#.id">Numbas.jme.funcObj.id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.intype"><a href="Numbas.jme.funcObj.html#.intype">Numbas.jme.funcObj.intype</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.name"><a href="Numbas.jme.funcObj.html#.name">Numbas.jme.funcObj.name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.outtype"><a href="Numbas.jme.funcObj.html#.outtype">Numbas.jme.funcObj.outtype</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.random"><a href="Numbas.jme.funcObj.html#.random">Numbas.jme.funcObj.random</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.typecheck"><a href="Numbas.jme.funcObj.html#.typecheck">Numbas.jme.funcObj.typecheck</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj_options"><a href="Numbas.jme.html#.funcObj_options">Numbas.jme.funcObj_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcSynonyms"><a href="Numbas.jme.html#.funcSynonyms">Numbas.jme.funcSynonyms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isFunction"><a href="Numbas.jme.html#.isFunction">Numbas.jme.isFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isMonomial"><a href="Numbas.jme.html#.isMonomial">Numbas.jme.isMonomial</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isName"><a href="Numbas.jme.html#.isName">Numbas.jme.isName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isOp"><a href="Numbas.jme.html#.isOp">Numbas.jme.isOp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isRandom"><a href="Numbas.jme.html#.isRandom">Numbas.jme.isRandom</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isType"><a href="Numbas.jme.html#.isType">Numbas.jme.isType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.jme.sortTokensBy"><a href="Numbas.jme.html#.jme.sortTokensBy">Numbas.jme.jme.sortTokensBy</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.lazyOps"><a href="Numbas.jme.html#.lazyOps">Numbas.jme.lazyOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.makeSafe"><a href="Numbas.jme.html#.makeSafe">Numbas.jme.makeSafe</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.mapFunctions"><a href="Numbas.jme.html#.mapFunctions">Numbas.jme.mapFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.operatorOptions"><a href="Numbas.jme.html#.operatorOptions">Numbas.jme.operatorOptions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.opSynonyms"><a href="Numbas.jme.html#.opSynonyms">Numbas.jme.opSynonyms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser"><a href="Numbas.jme.Parser.html">Numbas.jme.Parser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addBinaryOperator"><a href="Numbas.jme.Parser.html#addBinaryOperator">Numbas.jme.Parser#addBinaryOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addOperator"><a href="Numbas.jme.Parser.html#addOperator">Numbas.jme.Parser#addOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addPostfixOperator"><a href="Numbas.jme.Parser.html#addPostfixOperator">Numbas.jme.Parser#addPostfixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addPrefixOperator"><a href="Numbas.jme.Parser.html#addPrefixOperator">Numbas.jme.Parser#addPrefixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#compile"><a href="Numbas.jme.Parser.html#compile">Numbas.jme.Parser#compile</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#funcSynonym"><a href="Numbas.jme.Parser.html#funcSynonym">Numbas.jme.Parser#funcSynonym</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getArity"><a href="Numbas.jme.Parser.html#getArity">Numbas.jme.Parser#getArity</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getConstant"><a href="Numbas.jme.Parser.html#getConstant">Numbas.jme.Parser#getConstant</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPostfixForm"><a href="Numbas.jme.Parser.html#getPostfixForm">Numbas.jme.Parser#getPostfixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPrecedence"><a href="Numbas.jme.Parser.html#getPrecedence">Numbas.jme.Parser#getPrecedence</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPrefixForm"><a href="Numbas.jme.Parser.html#getPrefixForm">Numbas.jme.Parser#getPrefixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getSetting"><a href="Numbas.jme.Parser.html#getSetting">Numbas.jme.Parser#getSetting</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isAssociative"><a href="Numbas.jme.Parser.html#isAssociative">Numbas.jme.Parser#isAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isCommutative"><a href="Numbas.jme.Parser.html#isCommutative">Numbas.jme.Parser#isCommutative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isRightAssociative"><a href="Numbas.jme.Parser.html#isRightAssociative">Numbas.jme.Parser#isRightAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#ops"><a href="Numbas.jme.Parser.html#ops">Numbas.jme.Parser#ops</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#opSynonym"><a href="Numbas.jme.Parser.html#opSynonym">Numbas.jme.Parser#opSynonym</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#option_defaults"><a href="Numbas.jme.Parser.html#option_defaults">Numbas.jme.Parser#option_defaults</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#re"><a href="Numbas.jme.Parser.html#re">Numbas.jme.Parser#re</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#setOperatorProperties"><a href="Numbas.jme.Parser.html#setOperatorProperties">Numbas.jme.Parser#setOperatorProperties</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#shunt"><a href="Numbas.jme.Parser.html#shunt">Numbas.jme.Parser#shunt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#shunt_type_actions.op"><a href="Numbas.jme.Parser_shunt_type_actions.op.html">Numbas.jme.Parser#shunt_type_actions.op</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#tokenise"><a href="Numbas.jme.Parser.html#tokenise">Numbas.jme.Parser#tokenise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#tokeniser_types"><a href="Numbas.jme.Parser.html#tokeniser_types">Numbas.jme.Parser#tokeniser_types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.parser_options"><a href="Numbas.jme.html#.parser_options">Numbas.jme.parser_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.postfixForm"><a href="Numbas.jme.html#.postfixForm">Numbas.jme.postfixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.precedence"><a href="Numbas.jme.html#.precedence">Numbas.jme.precedence</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.prefixForm"><a href="Numbas.jme.html#.prefixForm">Numbas.jme.prefixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.resultsEqual"><a href="Numbas.jme.html#.resultsEqual">Numbas.jme.resultsEqual</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rightAssociative"><a href="Numbas.jme.html#.rightAssociative">Numbas.jme.rightAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules"><a href="Numbas.jme.rules.html">Numbas.jme.rules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.applyPostReplacement"><a href="Numbas.jme.rules.html#.applyPostReplacement">Numbas.jme.rules.applyPostReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.collectRuleset"><a href="Numbas.jme.rules.html#.collectRuleset">Numbas.jme.rules.collectRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.compileRules"><a href="Numbas.jme.rules.html#.compileRules">Numbas.jme.rules.compileRules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.displayFlags"><a href="Numbas.jme.rules.html#.displayFlags">Numbas.jme.rules.displayFlags</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.extend_options"><a href="Numbas.jme.rules.html#.extend_options">Numbas.jme.rules.extend_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.findSequenceMatch"><a href="Numbas.jme.rules.html#.findSequenceMatch">Numbas.jme.rules.findSequenceMatch</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.findSequenceMatch_options"><a href="Numbas.jme.rules.html#.findSequenceMatch_options">Numbas.jme.rules.findSequenceMatch_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.getTerms"><a href="Numbas.jme.rules.html#.getTerms">Numbas.jme.rules.getTerms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.getTerms_options"><a href="Numbas.jme.rules.html#.getTerms_options">Numbas.jme.rules.getTerms_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.jme_pattern_match"><a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchAllTree"><a href="Numbas.jme.rules.html#.matchAllTree">Numbas.jme.rules.matchAllTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchExpression"><a href="Numbas.jme.rules.html#.matchExpression">Numbas.jme.rules.matchExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchTree"><a href="Numbas.jme.rules.html#.matchTree">Numbas.jme.rules.matchTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchTree_options"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.number_conditions"><a href="Numbas.jme.rules.html#.number_conditions">Numbas.jme.rules.number_conditions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.patternParser"><a href="Numbas.jme.rules.html#.patternParser">Numbas.jme.rules.patternParser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule"><a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#get_options"><a href="Numbas.jme.rules.Rule.html#get_options">Numbas.jme.rules.Rule#get_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#match"><a href="Numbas.jme.rules.Rule.html#match">Numbas.jme.rules.Rule#match</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#matchAll"><a href="Numbas.jme.rules.Rule.html#matchAll">Numbas.jme.rules.Rule#matchAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#replace"><a href="Numbas.jme.rules.Rule.html#replace">Numbas.jme.rules.Rule#replace</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#replaceAll"><a href="Numbas.jme.rules.Rule.html#replaceAll">Numbas.jme.rules.Rule#replaceAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset"><a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset#flagSet"><a href="Numbas.jme.rules.Ruleset.html#flagSet">Numbas.jme.rules.Ruleset#flagSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset#simplify"><a href="Numbas.jme.rules.Ruleset.html#simplify">Numbas.jme.rules.Ruleset#simplify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.ruleset_flags"><a href="Numbas.jme.rules.html#.ruleset_flags">Numbas.jme.rules.ruleset_flags</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.simplificationRules"><a href="Numbas.jme.rules.html#.simplificationRules">Numbas.jme.rules.simplificationRules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchFunctions"><a href="Numbas.jme.rules.html#.specialMatchFunctions">Numbas.jme.rules.specialMatchFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchNames"><a href="Numbas.jme.rules.html#.specialMatchNames">Numbas.jme.rules.specialMatchNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchOps"><a href="Numbas.jme.rules.html#.specialMatchOps">Numbas.jme.rules.specialMatchOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.term"><a href="Numbas.jme.rules.html#.term">Numbas.jme.rules.term</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Term"><a href="Numbas.jme.rules.Term.html">Numbas.jme.rules.Term</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transform"><a href="Numbas.jme.rules.html#.transform">Numbas.jme.rules.transform</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transform_result"><a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transformAll"><a href="Numbas.jme.rules.html#.transformAll">Numbas.jme.rules.transformAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope"><a href="Numbas.jme.Scope.html">Numbas.jme.Scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#addFunction"><a href="Numbas.jme.Scope.html#addFunction">Numbas.jme.Scope#addFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#addRuleset"><a href="Numbas.jme.Scope.html#addRuleset">Numbas.jme.Scope#addRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allFunctions"><a href="Numbas.jme.Scope.html#allFunctions">Numbas.jme.Scope#allFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allRulesets"><a href="Numbas.jme.Scope.html#allRulesets">Numbas.jme.Scope#allRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allVariables"><a href="Numbas.jme.Scope.html#allVariables">Numbas.jme.Scope#allVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#collect"><a href="Numbas.jme.Scope.html#collect">Numbas.jme.Scope#collect</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteFunction"><a href="Numbas.jme.Scope.html#deleteFunction">Numbas.jme.Scope#deleteFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteRuleset"><a href="Numbas.jme.Scope.html#deleteRuleset">Numbas.jme.Scope#deleteRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteVariable"><a href="Numbas.jme.Scope.html#deleteVariable">Numbas.jme.Scope#deleteVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#evaluate"><a href="Numbas.jme.Scope.html#evaluate">Numbas.jme.Scope#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#flatten"><a href="Numbas.jme.Scope.html#flatten">Numbas.jme.Scope#flatten</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getFunction"><a href="Numbas.jme.Scope.html#getFunction">Numbas.jme.Scope#getFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getRuleset"><a href="Numbas.jme.Scope.html#getRuleset">Numbas.jme.Scope#getRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getVariable"><a href="Numbas.jme.Scope.html#getVariable">Numbas.jme.Scope#getVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#matchFunctionToArguments"><a href="Numbas.jme.Scope.html#matchFunctionToArguments">Numbas.jme.Scope#matchFunctionToArguments</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#resolve"><a href="Numbas.jme.Scope.html#resolve">Numbas.jme.Scope#resolve</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#setRuleset"><a href="Numbas.jme.Scope.html#setRuleset">Numbas.jme.Scope#setRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#setVariable"><a href="Numbas.jme.Scope.html#setVariable">Numbas.jme.Scope#setVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#unset"><a href="Numbas.jme.Scope.html#unset">Numbas.jme.Scope#unset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.scope_deletions"><a href="Numbas.jme.html#.scope_deletions">Numbas.jme.scope_deletions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.shunt"><a href="Numbas.jme.html#.shunt">Numbas.jme.shunt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature"><a href="Numbas.jme.html#.signature">Numbas.jme.signature</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature_result"><a href="Numbas.jme.html#.signature_result">Numbas.jme.signature_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature_result_argument"><a href="Numbas.jme.html#.signature_result_argument">Numbas.jme.signature_result_argument</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.standardParser"><a href="Numbas.jme.html#.standardParser">Numbas.jme.standardParser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.substituteTree"><a href="Numbas.jme.html#.substituteTree">Numbas.jme.substituteTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.substituteTreeOps"><a href="Numbas.jme.html#.substituteTreeOps">Numbas.jme.substituteTreeOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.subvars"><a href="Numbas.jme.html#.subvars">Numbas.jme.subvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.texsplit"><a href="Numbas.jme.html#.texsplit">Numbas.jme.texsplit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.token"><a href="Numbas.jme.html#.token">Numbas.jme.token</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenComparisons"><a href="Numbas.jme.html#.tokenComparisons">Numbas.jme.tokenComparisons</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenise"><a href="Numbas.jme.html#.tokenise">Numbas.jme.tokenise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenToDisplayString"><a href="Numbas.jme.html#.tokenToDisplayString">Numbas.jme.tokenToDisplayString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tree"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.treesSame"><a href="Numbas.jme.html#.treesSame">Numbas.jme.treesSame</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.typecheck_fn"><a href="Numbas.jme.html#.typecheck_fn">Numbas.jme.typecheck_fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types"><a href="Numbas.jme.types.html">Numbas.jme.types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TBool"><a href="Numbas.jme.types.TBool.html">Numbas.jme.types.TBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TDict"><a href="Numbas.jme.types.TDict.html">Numbas.jme.types.TDict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TExpression"><a href="Numbas.jme.types.TExpression.html">Numbas.jme.types.TExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TFunc"><a href="Numbas.jme.types.TFunc.html">Numbas.jme.types.TFunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.THTML"><a href="Numbas.jme.types.THTML.html">Numbas.jme.types.THTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TKeyPair"><a href="Numbas.jme.types.TKeyPair.html">Numbas.jme.types.TKeyPair</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TList"><a href="Numbas.jme.types.TList.html">Numbas.jme.types.TList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TMatrix"><a href="Numbas.jme.types.TMatrix.html">Numbas.jme.types.TMatrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TName"><a href="Numbas.jme.types.TName.html">Numbas.jme.types.TName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TNothing"><a href="Numbas.jme.types.TNothing.html">Numbas.jme.types.TNothing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TNum"><a href="Numbas.jme.types.TNum.html">Numbas.jme.types.TNum</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TOp"><a href="Numbas.jme.types.TOp.html">Numbas.jme.types.TOp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TPunc"><a href="Numbas.jme.types.TPunc.html">Numbas.jme.types.TPunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TRange"><a href="Numbas.jme.types.TRange.html">Numbas.jme.types.TRange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TSet"><a href="Numbas.jme.types.TSet.html">Numbas.jme.types.TSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TString"><a href="Numbas.jme.types.TString.html">Numbas.jme.types.TString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TVector"><a href="Numbas.jme.types.TVector.html">Numbas.jme.types.TVector</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.typeToDisplayString"><a href="Numbas.jme.html#.typeToDisplayString">Numbas.jme.typeToDisplayString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.unescape"><a href="Numbas.jme.html#.unescape">Numbas.jme.unescape</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.unwrapValue"><a href="Numbas.jme.html#.unwrapValue">Numbas.jme.unwrapValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables"><a href="Numbas.jme.variables.html">Numbas.jme.variables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.computeRuleset"><a href="Numbas.jme.variables.html#.computeRuleset">Numbas.jme.variables.computeRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.computeVariable"><a href="Numbas.jme.variables.html#.computeVariable">Numbas.jme.variables.computeVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubber"><a href="Numbas.jme.variables.DOMcontentsubber.html">Numbas.jme.variables.DOMcontentsubber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubber#sub_element"><a href="Numbas.jme.variables.DOMcontentsubber_sub_element.html">Numbas.jme.variables.DOMcontentsubber#sub_element</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubvars"><a href="Numbas.jme.variables.html#.DOMcontentsubvars">Numbas.jme.variables.DOMcontentsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMsubvars"><a href="Numbas.jme.variables.html#.DOMsubvars">Numbas.jme.variables.DOMsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.func_data"><a href="Numbas.jme.variables.html#.func_data">Numbas.jme.variables.func_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeFunction"><a href="Numbas.jme.variables.html#.makeFunction">Numbas.jme.variables.makeFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeFunctions"><a href="Numbas.jme.variables.html#.makeFunctions">Numbas.jme.variables.makeFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeJavascriptFunction"><a href="Numbas.jme.variables.html#.makeJavascriptFunction">Numbas.jme.variables.makeJavascriptFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeJMEFunction"><a href="Numbas.jme.variables.html#.makeJMEFunction">Numbas.jme.variables.makeJMEFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeRulesets"><a href="Numbas.jme.variables.html#.makeRulesets">Numbas.jme.variables.makeRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeVariables"><a href="Numbas.jme.variables.html#.makeVariables">Numbas.jme.variables.makeVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.variable_data_dict"><a href="Numbas.jme.variables.html#.variable_data_dict">Numbas.jme.variables.variable_data_dict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.variableDependants"><a href="Numbas.jme.variables.html#.variableDependants">Numbas.jme.variables.variableDependants</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.varsUsed"><a href="Numbas.jme.html#.varsUsed">Numbas.jme.varsUsed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.wrapValue"><a href="Numbas.jme.html#.wrapValue">Numbas.jme.wrapValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart"><a href="Numbas.JMEPart.html">Numbas.JMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#addValueGenerator"><a href="Numbas.JMEPart.html#addValueGenerator">Numbas.JMEPart#addValueGenerator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#baseMarkingScript"><a href="Numbas.JMEPart.html#baseMarkingScript">Numbas.JMEPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#getCorrectAnswer"><a href="Numbas.JMEPart.html#getCorrectAnswer">Numbas.JMEPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#input_options"><a href="Numbas.JMEPart.html#input_options">Numbas.JMEPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#input_widget"><a href="Numbas.JMEPart.html#input_widget">Numbas.JMEPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#rawStudentAnswerAsJME"><a href="Numbas.JMEPart.html#rawStudentAnswerAsJME">Numbas.JMEPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#setStudentAnswer"><a href="Numbas.JMEPart.html#setStudentAnswer">Numbas.JMEPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#settings"><a href="Numbas.JMEPart.html#settings">Numbas.JMEPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#studentAnswer"><a href="Numbas.JMEPart.html#studentAnswer">Numbas.JMEPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json"><a href="Numbas.json.html">Numbas.json</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json.tryGet"><a href="Numbas.json.html#.tryGet">Numbas.json.tryGet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json.tryLoad"><a href="Numbas.json.html#.tryLoad">Numbas.json.tryLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.loadScript"><a href="Numbas.html#.loadScript">Numbas.loadScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.locale"><a href="Numbas.html#.locale">Numbas.locale</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking"><a href="Numbas.marking.html">Numbas.marking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.compute_note"><a href="Numbas.marking.html#.compute_note">Numbas.marking.compute_note</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.feedback"><a href="Numbas.marking.html#.feedback">Numbas.marking.feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.feedback_item"><a href="Numbas.marking.html#.feedback_item">Numbas.marking.feedback_item</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps"><a href="Numbas.marking.html#.FeedbackOps">Numbas.marking.FeedbackOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.ADD_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.ADD_CREDIT">Numbas.marking.FeedbackOps.ADD_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.CONCAT"><a href="Numbas.marking.html#.FeedbackOps#.CONCAT">Numbas.marking.FeedbackOps.CONCAT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.END"><a href="Numbas.marking.html#.FeedbackOps#.END">Numbas.marking.FeedbackOps.END</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.FEEDBACK"><a href="Numbas.marking.html#.FeedbackOps#.FEEDBACK">Numbas.marking.FeedbackOps.FEEDBACK</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.MULTIPLY_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.MULTIPLY_CREDIT">Numbas.marking.FeedbackOps.MULTIPLY_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.SET_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.SET_CREDIT">Numbas.marking.FeedbackOps.SET_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.SUB_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.SUB_CREDIT">Numbas.marking.FeedbackOps.SUB_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.WARNING"><a href="Numbas.marking.html#.FeedbackOps#.WARNING">Numbas.marking.FeedbackOps.WARNING</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.finalise_state"><a href="Numbas.marking.html#.finalise_state">Numbas.marking.finalise_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.finalised_state"><a href="Numbas.marking.html#.finalised_state">Numbas.marking.finalised_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.marking_script_result"><a href="Numbas.marking.html#.marking_script_result">Numbas.marking.marking_script_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingNote"><a href="Numbas.marking.MarkingNote.html">Numbas.marking.MarkingNote</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript"><a href="Numbas.marking.MarkingScript.html">Numbas.marking.MarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript#evaluate"><a href="Numbas.marking.MarkingScript.html#evaluate">Numbas.marking.MarkingScript#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript#source"><a href="Numbas.marking.MarkingScript.html#source">Numbas.marking.MarkingScript#source</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.note_definition"><a href="Numbas.marking.html#.note_definition">Numbas.marking.note_definition</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope"><a href="Numbas.marking.StatefulScope.html">Numbas.marking.StatefulScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#addFunction"><a href="Numbas.marking.StatefulScope.html#addFunction">Numbas.marking.StatefulScope#addFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#addRuleset"><a href="Numbas.marking.StatefulScope.html#addRuleset">Numbas.marking.StatefulScope#addRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allFunctions"><a href="Numbas.marking.StatefulScope.html#allFunctions">Numbas.marking.StatefulScope#allFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allRulesets"><a href="Numbas.marking.StatefulScope.html#allRulesets">Numbas.marking.StatefulScope#allRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allVariables"><a href="Numbas.marking.StatefulScope.html#allVariables">Numbas.marking.StatefulScope#allVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#collect"><a href="Numbas.marking.StatefulScope.html#collect">Numbas.marking.StatefulScope#collect</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteFunction"><a href="Numbas.marking.StatefulScope.html#deleteFunction">Numbas.marking.StatefulScope#deleteFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteRuleset"><a href="Numbas.marking.StatefulScope.html#deleteRuleset">Numbas.marking.StatefulScope#deleteRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteVariable"><a href="Numbas.marking.StatefulScope.html#deleteVariable">Numbas.marking.StatefulScope#deleteVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#evaluate"><a href="Numbas.marking.StatefulScope.html#evaluate">Numbas.marking.StatefulScope#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#flatten"><a href="Numbas.marking.StatefulScope.html#flatten">Numbas.marking.StatefulScope#flatten</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getFunction"><a href="Numbas.marking.StatefulScope.html#getFunction">Numbas.marking.StatefulScope#getFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getRuleset"><a href="Numbas.marking.StatefulScope.html#getRuleset">Numbas.marking.StatefulScope#getRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getVariable"><a href="Numbas.marking.StatefulScope.html#getVariable">Numbas.marking.StatefulScope#getVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#matchFunctionToArguments"><a href="Numbas.marking.StatefulScope.html#matchFunctionToArguments">Numbas.marking.StatefulScope#matchFunctionToArguments</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#resolve"><a href="Numbas.marking.StatefulScope.html#resolve">Numbas.marking.StatefulScope#resolve</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#setRuleset"><a href="Numbas.marking.StatefulScope.html#setRuleset">Numbas.marking.StatefulScope#setRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#setVariable"><a href="Numbas.marking.StatefulScope.html#setVariable">Numbas.marking.StatefulScope#setVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#unset"><a href="Numbas.marking.StatefulScope.html#unset">Numbas.marking.StatefulScope#unset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking_scripts"><a href="Numbas.html#.marking_scripts">Numbas.marking_scripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math"><a href="Numbas.math.html">Numbas.math</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.abs"><a href="Numbas.math.html#.abs">Numbas.math.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.add"><a href="Numbas.math.html#.add">Numbas.math.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.addDigits"><a href="Numbas.math.html#.addDigits">Numbas.math.addDigits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arccos"><a href="Numbas.math.html#.arccos">Numbas.math.arccos</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arccosh"><a href="Numbas.math.html#.arccosh">Numbas.math.arccosh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arcsin"><a href="Numbas.math.html#.arcsin">Numbas.math.arcsin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arcsinh"><a href="Numbas.math.html#.arcsinh">Numbas.math.arcsinh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arctan"><a href="Numbas.math.html#.arctan">Numbas.math.arctan</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arctanh"><a href="Numbas.math.html#.arctanh">Numbas.math.arctanh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arg"><a href="Numbas.math.html#.arg">Numbas.math.arg</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.binomialCoefficients"><a href="Numbas.math.html#.binomialCoefficients">Numbas.math.binomialCoefficients</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.ceil"><a href="Numbas.math.html#.ceil">Numbas.math.ceil</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.choose"><a href="Numbas.math.html#.choose">Numbas.math.choose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.combinations"><a href="Numbas.math.html#.combinations">Numbas.math.combinations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.complex"><a href="Numbas.math.html#.complex">Numbas.math.complex</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.ComplexDecimal"><a href="Numbas.math.ComplexDecimal.html">Numbas.math.ComplexDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.complexToString"><a href="Numbas.math.html#.complexToString">Numbas.math.complexToString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.conjugate"><a href="Numbas.math.html#.conjugate">Numbas.math.conjugate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.coprime"><a href="Numbas.math.html#.coprime">Numbas.math.coprime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cos"><a href="Numbas.math.html#.cos">Numbas.math.cos</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosec"><a href="Numbas.math.html#.cosec">Numbas.math.cosec</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosech"><a href="Numbas.math.html#.cosech">Numbas.math.cosech</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosh"><a href="Numbas.math.html#.cosh">Numbas.math.cosh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cot"><a href="Numbas.math.html#.cot">Numbas.math.cot</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.coth"><a href="Numbas.math.html#.coth">Numbas.math.coth</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.countDP"><a href="Numbas.math.html#.countDP">Numbas.math.countDP</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.countSigFigs"><a href="Numbas.math.html#.countSigFigs">Numbas.math.countSigFigs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.deal"><a href="Numbas.math.html#.deal">Numbas.math.deal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.defineRange"><a href="Numbas.math.html#.defineRange">Numbas.math.defineRange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.degrees"><a href="Numbas.math.html#.degrees">Numbas.math.degrees</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.div"><a href="Numbas.math.html#.div">Numbas.math.div</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.divides"><a href="Numbas.math.html#.divides">Numbas.math.divides</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.eq"><a href="Numbas.math.html#.eq">Numbas.math.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.except"><a href="Numbas.math.html#.except">Numbas.math.except</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.exp"><a href="Numbas.math.html#.exp">Numbas.math.exp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.factorial"><a href="Numbas.math.html#.factorial">Numbas.math.factorial</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.factorise"><a href="Numbas.math.html#.factorise">Numbas.math.factorise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.floor"><a href="Numbas.math.html#.floor">Numbas.math.floor</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.fract"><a href="Numbas.math.html#.fract">Numbas.math.fract</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.Fraction"><a href="Numbas.math.Fraction.html">Numbas.math.Fraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gamma"><a href="Numbas.math.html#.gamma">Numbas.math.gamma</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gcd"><a href="Numbas.math.html#.gcd">Numbas.math.gcd</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.geq"><a href="Numbas.math.html#.geq">Numbas.math.geq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gt"><a href="Numbas.math.html#.gt">Numbas.math.gt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.im"><a href="Numbas.math.html#.im">Numbas.math.im</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.inverse"><a href="Numbas.math.html#.inverse">Numbas.math.inverse</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.isclose"><a href="Numbas.math.html#.isclose">Numbas.math.isclose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.lcm"><a href="Numbas.math.html#.lcm">Numbas.math.lcm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.leq"><a href="Numbas.math.html#.leq">Numbas.math.leq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.listmax"><a href="Numbas.math.html#.listmax">Numbas.math.listmax</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.listmin"><a href="Numbas.math.html#.listmin">Numbas.math.listmin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log"><a href="Numbas.math.html#.log">Numbas.math.log</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log10"><a href="Numbas.math.html#.log10">Numbas.math.log10</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log_base"><a href="Numbas.math.html#.log_base">Numbas.math.log_base</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.lt"><a href="Numbas.math.html#.lt">Numbas.math.lt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.max"><a href="Numbas.math.html#.max">Numbas.math.max</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.min"><a href="Numbas.math.html#.min">Numbas.math.min</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.mod"><a href="Numbas.math.html#.mod">Numbas.math.mod</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.mul"><a href="Numbas.math.html#.mul">Numbas.math.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.negate"><a href="Numbas.math.html#.negate">Numbas.math.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.negative"><a href="Numbas.math.html#.negative">Numbas.math.negative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.neq"><a href="Numbas.math.html#.neq">Numbas.math.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceComplexDecimal"><a href="Numbas.math.html#.niceComplexDecimal">Numbas.math.niceComplexDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceDecimal"><a href="Numbas.math.html#.niceDecimal">Numbas.math.niceDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceNumber"><a href="Numbas.math.html#.niceNumber">Numbas.math.niceNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceNumber_settings"><a href="Numbas.math.html#.niceNumber_settings">Numbas.math.niceNumber_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.nonnegative"><a href="Numbas.math.html#.nonnegative">Numbas.math.nonnegative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.parseScientific"><a href="Numbas.math.html#.parseScientific">Numbas.math.parseScientific</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.permutations"><a href="Numbas.math.html#.permutations">Numbas.math.permutations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.piDegree"><a href="Numbas.math.html#.piDegree">Numbas.math.piDegree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.positive"><a href="Numbas.math.html#.positive">Numbas.math.positive</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.pow"><a href="Numbas.math.html#.pow">Numbas.math.pow</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.precround"><a href="Numbas.math.html#.precround">Numbas.math.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.primes"><a href="Numbas.math.html#.primes">Numbas.math.primes</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.radians"><a href="Numbas.math.html#.radians">Numbas.math.radians</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.random"><a href="Numbas.math.html#.random">Numbas.math.random</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.randomint"><a href="Numbas.math.html#.randomint">Numbas.math.randomint</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.randomrange"><a href="Numbas.math.html#.randomrange">Numbas.math.randomrange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeSize"><a href="Numbas.math.html#.rangeSize">Numbas.math.rangeSize</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeSteps"><a href="Numbas.math.html#.rangeSteps">Numbas.math.rangeSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeToList"><a href="Numbas.math.html#.rangeToList">Numbas.math.rangeToList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rationalApproximation"><a href="Numbas.math.html#.rationalApproximation">Numbas.math.rationalApproximation</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.re"><a href="Numbas.math.html#.re">Numbas.math.re</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.re_scientificNumber"><a href="Numbas.math.html#.re_scientificNumber">Numbas.math.re_scientificNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.root"><a href="Numbas.math.html#.root">Numbas.math.root</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.round"><a href="Numbas.math.html#.round">Numbas.math.round</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sec"><a href="Numbas.math.html#.sec">Numbas.math.sec</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sech"><a href="Numbas.math.html#.sech">Numbas.math.sech</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.shuffle"><a href="Numbas.math.html#.shuffle">Numbas.math.shuffle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sign"><a href="Numbas.math.html#.sign">Numbas.math.sign</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.siground"><a href="Numbas.math.html#.siground">Numbas.math.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sin"><a href="Numbas.math.html#.sin">Numbas.math.sin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sinh"><a href="Numbas.math.html#.sinh">Numbas.math.sinh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sqrt"><a href="Numbas.math.html#.sqrt">Numbas.math.sqrt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sub"><a href="Numbas.math.html#.sub">Numbas.math.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sum"><a href="Numbas.math.html#.sum">Numbas.math.sum</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.tan"><a href="Numbas.math.html#.tan">Numbas.math.tan</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.tanh"><a href="Numbas.math.html#.tanh">Numbas.math.tanh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.toGivenPrecision"><a href="Numbas.math.html#.toGivenPrecision">Numbas.math.toGivenPrecision</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.toNearest"><a href="Numbas.math.html#.toNearest">Numbas.math.toNearest</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.trunc"><a href="Numbas.math.html#.trunc">Numbas.math.trunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.unscientific"><a href="Numbas.math.html#.unscientific">Numbas.math.unscientific</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.withinTolerance"><a href="Numbas.math.html#.withinTolerance">Numbas.math.withinTolerance</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath"><a href="Numbas.matrixmath.html">Numbas.matrixmath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.abs"><a href="Numbas.matrixmath.html#.abs">Numbas.matrixmath.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.add"><a href="Numbas.matrixmath.html#.add">Numbas.matrixmath.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.eq"><a href="Numbas.matrixmath.html#.eq">Numbas.matrixmath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.id"><a href="Numbas.matrixmath.html#.id">Numbas.matrixmath.id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.map"><a href="Numbas.matrixmath.html#.map">Numbas.matrixmath.map</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.mul"><a href="Numbas.matrixmath.html#.mul">Numbas.matrixmath.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.negate"><a href="Numbas.matrixmath.html#.negate">Numbas.matrixmath.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.neq"><a href="Numbas.matrixmath.html#.neq">Numbas.matrixmath.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.precround"><a href="Numbas.matrixmath.html#.precround">Numbas.matrixmath.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.scalardiv"><a href="Numbas.matrixmath.html#.scalardiv">Numbas.matrixmath.scalardiv</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.scalarmul"><a href="Numbas.matrixmath.html#.scalarmul">Numbas.matrixmath.scalarmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.siground"><a href="Numbas.matrixmath.html#.siground">Numbas.matrixmath.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.sub"><a href="Numbas.matrixmath.html#.sub">Numbas.matrixmath.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.sum_cells"><a href="Numbas.matrixmath.html#.sum_cells">Numbas.matrixmath.sum_cells</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.transpose"><a href="Numbas.matrixmath.html#.transpose">Numbas.matrixmath.transpose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.partConstructors"><a href="Numbas.html#.partConstructors">Numbas.partConstructors</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts"><a href="Numbas.parts.html">Numbas.parts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart"><a href="Numbas.parts.CustomPart.html">Numbas.parts.CustomPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addCredit"><a href="Numbas.parts.CustomPart.html#addCredit">Numbas.parts.CustomPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addStep"><a href="Numbas.parts.CustomPart.html#addStep">Numbas.parts.CustomPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addVariableReplacement"><a href="Numbas.parts.CustomPart.html#addVariableReplacement">Numbas.parts.CustomPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#answered"><a href="Numbas.parts.CustomPart.html#answered">Numbas.parts.CustomPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#apply_feedback"><a href="Numbas.parts.CustomPart.html#apply_feedback">Numbas.parts.CustomPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#applyScoreLimits"><a href="Numbas.parts.CustomPart.html#applyScoreLimits">Numbas.parts.CustomPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#assignName"><a href="Numbas.parts.CustomPart.html#assignName">Numbas.parts.CustomPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#baseMarkingScript"><a href="Numbas.parts.CustomPart.html#baseMarkingScript">Numbas.parts.CustomPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#calculateScore"><a href="Numbas.parts.CustomPart.html#calculateScore">Numbas.parts.CustomPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#creditFraction"><a href="Numbas.parts.CustomPart.html#creditFraction">Numbas.parts.CustomPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#customName"><a href="Numbas.parts.CustomPart.html#customName">Numbas.parts.CustomPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#display"><a href="Numbas.parts.CustomPart.html#display">Numbas.parts.CustomPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#doesMarking"><a href="Numbas.parts.CustomPart.html#doesMarking">Numbas.parts.CustomPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#error"><a href="Numbas.parts.CustomPart.html#error">Numbas.parts.CustomPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#errorCarriedForwardScope"><a href="Numbas.parts.CustomPart.html#errorCarriedForwardScope">Numbas.parts.CustomPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#finalised_result"><a href="Numbas.parts.CustomPart.html#finalised_result">Numbas.parts.CustomPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#finaliseLoad"><a href="Numbas.parts.CustomPart.html#finaliseLoad">Numbas.parts.CustomPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#gaps"><a href="Numbas.parts.CustomPart.html#gaps">Numbas.parts.CustomPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#getCorrectAnswer"><a href="Numbas.parts.CustomPart.html#getCorrectAnswer">Numbas.parts.CustomPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#getScope"><a href="Numbas.parts.CustomPart.html#getScope">Numbas.parts.CustomPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#giveWarning"><a href="Numbas.parts.CustomPart.html#giveWarning">Numbas.parts.CustomPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#hasStagedAnswer"><a href="Numbas.parts.CustomPart.html#hasStagedAnswer">Numbas.parts.CustomPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#hideSteps"><a href="Numbas.parts.CustomPart.html#hideSteps">Numbas.parts.CustomPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#input_options"><a href="Numbas.parts.CustomPart.html#input_options">Numbas.parts.CustomPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#input_widget"><a href="Numbas.parts.CustomPart.html#input_widget">Numbas.parts.CustomPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#isDirty"><a href="Numbas.parts.CustomPart.html#isDirty">Numbas.parts.CustomPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#loadFromJSON"><a href="Numbas.parts.CustomPart.html#loadFromJSON">Numbas.parts.CustomPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#loadFromXML"><a href="Numbas.parts.CustomPart.html#loadFromXML">Numbas.parts.CustomPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#mark"><a href="Numbas.parts.CustomPart.html#mark">Numbas.parts.CustomPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#mark_answer"><a href="Numbas.parts.CustomPart.html#mark_answer">Numbas.parts.CustomPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markAgainstScope"><a href="Numbas.parts.CustomPart.html#markAgainstScope">Numbas.parts.CustomPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingComment"><a href="Numbas.parts.CustomPart.html#markingComment">Numbas.parts.CustomPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingFeedback"><a href="Numbas.parts.CustomPart.html#markingFeedback">Numbas.parts.CustomPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingScript"><a href="Numbas.parts.CustomPart.html#markingScript">Numbas.parts.CustomPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#marks"><a href="Numbas.parts.CustomPart.html#marks">Numbas.parts.CustomPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#multCredit"><a href="Numbas.parts.CustomPart.html#multCredit">Numbas.parts.CustomPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#name"><a href="Numbas.parts.CustomPart.html#name">Numbas.parts.CustomPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#openSteps"><a href="Numbas.parts.CustomPart.html#openSteps">Numbas.parts.CustomPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#parentPart"><a href="Numbas.parts.CustomPart.html#parentPart">Numbas.parts.CustomPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#path"><a href="Numbas.parts.CustomPart.html#path">Numbas.parts.CustomPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#pleaseResubmit"><a href="Numbas.parts.CustomPart.html#pleaseResubmit">Numbas.parts.CustomPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#question"><a href="Numbas.parts.CustomPart.html#question">Numbas.parts.CustomPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#rawStudentAnswerAsJME"><a href="Numbas.parts.CustomPart.html#rawStudentAnswerAsJME">Numbas.parts.CustomPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#removeWarnings"><a href="Numbas.parts.CustomPart.html#removeWarnings">Numbas.parts.CustomPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#resume"><a href="Numbas.parts.CustomPart.html#resume">Numbas.parts.CustomPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#revealAnswer"><a href="Numbas.parts.CustomPart.html#revealAnswer">Numbas.parts.CustomPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#score"><a href="Numbas.parts.CustomPart.html#score">Numbas.parts.CustomPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setCredit"><a href="Numbas.parts.CustomPart.html#setCredit">Numbas.parts.CustomPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setDirty"><a href="Numbas.parts.CustomPart.html#setDirty">Numbas.parts.CustomPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setMarkingScript"><a href="Numbas.parts.CustomPart.html#setMarkingScript">Numbas.parts.CustomPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setScript"><a href="Numbas.parts.CustomPart.html#setScript">Numbas.parts.CustomPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setStudentAnswer"><a href="Numbas.parts.CustomPart.html#setStudentAnswer">Numbas.parts.CustomPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#settings"><a href="Numbas.parts.CustomPart.html#settings">Numbas.parts.CustomPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setWarnings"><a href="Numbas.parts.CustomPart.html#setWarnings">Numbas.parts.CustomPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#shouldResubmit"><a href="Numbas.parts.CustomPart.html#shouldResubmit">Numbas.parts.CustomPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#showSteps"><a href="Numbas.parts.CustomPart.html#showSteps">Numbas.parts.CustomPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stagedAnswer"><a href="Numbas.parts.CustomPart.html#stagedAnswer">Numbas.parts.CustomPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#steps"><a href="Numbas.parts.CustomPart.html#steps">Numbas.parts.CustomPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsMarks"><a href="Numbas.parts.CustomPart.html#stepsMarks">Numbas.parts.CustomPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsOpen"><a href="Numbas.parts.CustomPart.html#stepsOpen">Numbas.parts.CustomPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsShown"><a href="Numbas.parts.CustomPart.html#stepsShown">Numbas.parts.CustomPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#store"><a href="Numbas.parts.CustomPart.html#store">Numbas.parts.CustomPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#storeAnswer"><a href="Numbas.parts.CustomPart.html#storeAnswer">Numbas.parts.CustomPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#studentAnswerAsJME"><a href="Numbas.parts.CustomPart.html#studentAnswerAsJME">Numbas.parts.CustomPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#subCredit"><a href="Numbas.parts.CustomPart.html#subCredit">Numbas.parts.CustomPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#submit"><a href="Numbas.parts.CustomPart.html#submit">Numbas.parts.CustomPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#type"><a href="Numbas.parts.CustomPart.html#type">Numbas.parts.CustomPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#useCustomName"><a href="Numbas.parts.CustomPart.html#useCustomName">Numbas.parts.CustomPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#warnings"><a href="Numbas.parts.CustomPart.html#warnings">Numbas.parts.CustomPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#xml"><a href="Numbas.parts.CustomPart.html#xml">Numbas.parts.CustomPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart"><a href="Numbas.parts.ExtensionPart.html">Numbas.parts.ExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addCredit"><a href="Numbas.parts.ExtensionPart.html#addCredit">Numbas.parts.ExtensionPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addStep"><a href="Numbas.parts.ExtensionPart.html#addStep">Numbas.parts.ExtensionPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addVariableReplacement"><a href="Numbas.parts.ExtensionPart.html#addVariableReplacement">Numbas.parts.ExtensionPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#answered"><a href="Numbas.parts.ExtensionPart.html#answered">Numbas.parts.ExtensionPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#apply_feedback"><a href="Numbas.parts.ExtensionPart.html#apply_feedback">Numbas.parts.ExtensionPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#applyScoreLimits"><a href="Numbas.parts.ExtensionPart.html#applyScoreLimits">Numbas.parts.ExtensionPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#assignName"><a href="Numbas.parts.ExtensionPart.html#assignName">Numbas.parts.ExtensionPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#baseMarkingScript"><a href="Numbas.parts.ExtensionPart.html#baseMarkingScript">Numbas.parts.ExtensionPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#calculateScore"><a href="Numbas.parts.ExtensionPart.html#calculateScore">Numbas.parts.ExtensionPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#createSuspendData"><a href="Numbas.parts.ExtensionPart.html#createSuspendData">Numbas.parts.ExtensionPart#createSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#creditFraction"><a href="Numbas.parts.ExtensionPart.html#creditFraction">Numbas.parts.ExtensionPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#customName"><a href="Numbas.parts.ExtensionPart.html#customName">Numbas.parts.ExtensionPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#display"><a href="Numbas.parts.ExtensionPart.html#display">Numbas.parts.ExtensionPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#doesMarking"><a href="Numbas.parts.ExtensionPart.html#doesMarking">Numbas.parts.ExtensionPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#error"><a href="Numbas.parts.ExtensionPart.html#error">Numbas.parts.ExtensionPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#errorCarriedForwardScope"><a href="Numbas.parts.ExtensionPart.html#errorCarriedForwardScope">Numbas.parts.ExtensionPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#finalised_result"><a href="Numbas.parts.ExtensionPart.html#finalised_result">Numbas.parts.ExtensionPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#finaliseLoad"><a href="Numbas.parts.ExtensionPart.html#finaliseLoad">Numbas.parts.ExtensionPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#gaps"><a href="Numbas.parts.ExtensionPart.html#gaps">Numbas.parts.ExtensionPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#getCorrectAnswer"><a href="Numbas.parts.ExtensionPart.html#getCorrectAnswer">Numbas.parts.ExtensionPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#getScope"><a href="Numbas.parts.ExtensionPart.html#getScope">Numbas.parts.ExtensionPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#giveWarning"><a href="Numbas.parts.ExtensionPart.html#giveWarning">Numbas.parts.ExtensionPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#hasStagedAnswer"><a href="Numbas.parts.ExtensionPart.html#hasStagedAnswer">Numbas.parts.ExtensionPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#hideSteps"><a href="Numbas.parts.ExtensionPart.html#hideSteps">Numbas.parts.ExtensionPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#input_options"><a href="Numbas.parts.ExtensionPart.html#input_options">Numbas.parts.ExtensionPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#input_widget"><a href="Numbas.parts.ExtensionPart.html#input_widget">Numbas.parts.ExtensionPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#isDirty"><a href="Numbas.parts.ExtensionPart.html#isDirty">Numbas.parts.ExtensionPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadFromJSON"><a href="Numbas.parts.ExtensionPart.html#loadFromJSON">Numbas.parts.ExtensionPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadFromXML"><a href="Numbas.parts.ExtensionPart.html#loadFromXML">Numbas.parts.ExtensionPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadSuspendData"><a href="Numbas.parts.ExtensionPart.html#loadSuspendData">Numbas.parts.ExtensionPart#loadSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#mark"><a href="Numbas.parts.ExtensionPart.html#mark">Numbas.parts.ExtensionPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#mark_answer"><a href="Numbas.parts.ExtensionPart.html#mark_answer">Numbas.parts.ExtensionPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markAgainstScope"><a href="Numbas.parts.ExtensionPart.html#markAgainstScope">Numbas.parts.ExtensionPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingComment"><a href="Numbas.parts.ExtensionPart.html#markingComment">Numbas.parts.ExtensionPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingFeedback"><a href="Numbas.parts.ExtensionPart.html#markingFeedback">Numbas.parts.ExtensionPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingScript"><a href="Numbas.parts.ExtensionPart.html#markingScript">Numbas.parts.ExtensionPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#marks"><a href="Numbas.parts.ExtensionPart.html#marks">Numbas.parts.ExtensionPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#multCredit"><a href="Numbas.parts.ExtensionPart.html#multCredit">Numbas.parts.ExtensionPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#name"><a href="Numbas.parts.ExtensionPart.html#name">Numbas.parts.ExtensionPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#openSteps"><a href="Numbas.parts.ExtensionPart.html#openSteps">Numbas.parts.ExtensionPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#parentPart"><a href="Numbas.parts.ExtensionPart.html#parentPart">Numbas.parts.ExtensionPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#path"><a href="Numbas.parts.ExtensionPart.html#path">Numbas.parts.ExtensionPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#pleaseResubmit"><a href="Numbas.parts.ExtensionPart.html#pleaseResubmit">Numbas.parts.ExtensionPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#question"><a href="Numbas.parts.ExtensionPart.html#question">Numbas.parts.ExtensionPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#rawStudentAnswerAsJME"><a href="Numbas.parts.ExtensionPart.html#rawStudentAnswerAsJME">Numbas.parts.ExtensionPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#removeWarnings"><a href="Numbas.parts.ExtensionPart.html#removeWarnings">Numbas.parts.ExtensionPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#resume"><a href="Numbas.parts.ExtensionPart.html#resume">Numbas.parts.ExtensionPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#revealAnswer"><a href="Numbas.parts.ExtensionPart.html#revealAnswer">Numbas.parts.ExtensionPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#score"><a href="Numbas.parts.ExtensionPart.html#score">Numbas.parts.ExtensionPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setCredit"><a href="Numbas.parts.ExtensionPart.html#setCredit">Numbas.parts.ExtensionPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setDirty"><a href="Numbas.parts.ExtensionPart.html#setDirty">Numbas.parts.ExtensionPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setMarkingScript"><a href="Numbas.parts.ExtensionPart.html#setMarkingScript">Numbas.parts.ExtensionPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setScript"><a href="Numbas.parts.ExtensionPart.html#setScript">Numbas.parts.ExtensionPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setStudentAnswer"><a href="Numbas.parts.ExtensionPart.html#setStudentAnswer">Numbas.parts.ExtensionPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#settings"><a href="Numbas.parts.ExtensionPart.html#settings">Numbas.parts.ExtensionPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setWarnings"><a href="Numbas.parts.ExtensionPart.html#setWarnings">Numbas.parts.ExtensionPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#shouldResubmit"><a href="Numbas.parts.ExtensionPart.html#shouldResubmit">Numbas.parts.ExtensionPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#showSteps"><a href="Numbas.parts.ExtensionPart.html#showSteps">Numbas.parts.ExtensionPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stagedAnswer"><a href="Numbas.parts.ExtensionPart.html#stagedAnswer">Numbas.parts.ExtensionPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#steps"><a href="Numbas.parts.ExtensionPart.html#steps">Numbas.parts.ExtensionPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsMarks"><a href="Numbas.parts.ExtensionPart.html#stepsMarks">Numbas.parts.ExtensionPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsOpen"><a href="Numbas.parts.ExtensionPart.html#stepsOpen">Numbas.parts.ExtensionPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsShown"><a href="Numbas.parts.ExtensionPart.html#stepsShown">Numbas.parts.ExtensionPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#store"><a href="Numbas.parts.ExtensionPart.html#store">Numbas.parts.ExtensionPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#storeAnswer"><a href="Numbas.parts.ExtensionPart.html#storeAnswer">Numbas.parts.ExtensionPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#studentAnswerAsJME"><a href="Numbas.parts.ExtensionPart.html#studentAnswerAsJME">Numbas.parts.ExtensionPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#subCredit"><a href="Numbas.parts.ExtensionPart.html#subCredit">Numbas.parts.ExtensionPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#submit"><a href="Numbas.parts.ExtensionPart.html#submit">Numbas.parts.ExtensionPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#type"><a href="Numbas.parts.ExtensionPart.html#type">Numbas.parts.ExtensionPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#useCustomName"><a href="Numbas.parts.ExtensionPart.html#useCustomName">Numbas.parts.ExtensionPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#warnings"><a href="Numbas.parts.ExtensionPart.html#warnings">Numbas.parts.ExtensionPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#xml"><a href="Numbas.parts.ExtensionPart.html#xml">Numbas.parts.ExtensionPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.feedbackmessage"><a href="Numbas.parts.html#.feedbackmessage">Numbas.parts.feedbackmessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart"><a href="Numbas.parts.GapFillPart.html">Numbas.parts.GapFillPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addCredit"><a href="Numbas.parts.GapFillPart.html#addCredit">Numbas.parts.GapFillPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addGap"><a href="Numbas.parts.GapFillPart.html#addGap">Numbas.parts.GapFillPart#addGap</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addStep"><a href="Numbas.parts.GapFillPart.html#addStep">Numbas.parts.GapFillPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addVariableReplacement"><a href="Numbas.parts.GapFillPart.html#addVariableReplacement">Numbas.parts.GapFillPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#answered"><a href="Numbas.parts.GapFillPart.html#answered">Numbas.parts.GapFillPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#apply_feedback"><a href="Numbas.parts.GapFillPart.html#apply_feedback">Numbas.parts.GapFillPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#applyScoreLimits"><a href="Numbas.parts.GapFillPart.html#applyScoreLimits">Numbas.parts.GapFillPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#assignName"><a href="Numbas.parts.GapFillPart.html#assignName">Numbas.parts.GapFillPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#baseMarkingScript"><a href="Numbas.parts.GapFillPart.html#baseMarkingScript">Numbas.parts.GapFillPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#calculateScore"><a href="Numbas.parts.GapFillPart.html#calculateScore">Numbas.parts.GapFillPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#creditFraction"><a href="Numbas.parts.GapFillPart.html#creditFraction">Numbas.parts.GapFillPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#customName"><a href="Numbas.parts.GapFillPart.html#customName">Numbas.parts.GapFillPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#display"><a href="Numbas.parts.GapFillPart.html#display">Numbas.parts.GapFillPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#doesMarking"><a href="Numbas.parts.GapFillPart.html#doesMarking">Numbas.parts.GapFillPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#error"><a href="Numbas.parts.GapFillPart.html#error">Numbas.parts.GapFillPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#errorCarriedForwardScope"><a href="Numbas.parts.GapFillPart.html#errorCarriedForwardScope">Numbas.parts.GapFillPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#finalised_result"><a href="Numbas.parts.GapFillPart.html#finalised_result">Numbas.parts.GapFillPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#finaliseLoad"><a href="Numbas.parts.GapFillPart.html#finaliseLoad">Numbas.parts.GapFillPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#gaps"><a href="Numbas.parts.GapFillPart.html#gaps">Numbas.parts.GapFillPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#getCorrectAnswer"><a href="Numbas.parts.GapFillPart.html#getCorrectAnswer">Numbas.parts.GapFillPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#getScope"><a href="Numbas.parts.GapFillPart.html#getScope">Numbas.parts.GapFillPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#giveWarning"><a href="Numbas.parts.GapFillPart.html#giveWarning">Numbas.parts.GapFillPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#hasStagedAnswer"><a href="Numbas.parts.GapFillPart.html#hasStagedAnswer">Numbas.parts.GapFillPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#hideSteps"><a href="Numbas.parts.GapFillPart.html#hideSteps">Numbas.parts.GapFillPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#input_options"><a href="Numbas.parts.GapFillPart.html#input_options">Numbas.parts.GapFillPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#input_widget"><a href="Numbas.parts.GapFillPart.html#input_widget">Numbas.parts.GapFillPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#isDirty"><a href="Numbas.parts.GapFillPart.html#isDirty">Numbas.parts.GapFillPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#loadFromJSON"><a href="Numbas.parts.GapFillPart.html#loadFromJSON">Numbas.parts.GapFillPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#loadFromXML"><a href="Numbas.parts.GapFillPart.html#loadFromXML">Numbas.parts.GapFillPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#mark"><a href="Numbas.parts.GapFillPart.html#mark">Numbas.parts.GapFillPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#mark_answer"><a href="Numbas.parts.GapFillPart.html#mark_answer">Numbas.parts.GapFillPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markAgainstScope"><a href="Numbas.parts.GapFillPart.html#markAgainstScope">Numbas.parts.GapFillPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingComment"><a href="Numbas.parts.GapFillPart.html#markingComment">Numbas.parts.GapFillPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingFeedback"><a href="Numbas.parts.GapFillPart.html#markingFeedback">Numbas.parts.GapFillPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingScript"><a href="Numbas.parts.GapFillPart.html#markingScript">Numbas.parts.GapFillPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#marks"><a href="Numbas.parts.GapFillPart.html#marks">Numbas.parts.GapFillPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#multCredit"><a href="Numbas.parts.GapFillPart.html#multCredit">Numbas.parts.GapFillPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#name"><a href="Numbas.parts.GapFillPart.html#name">Numbas.parts.GapFillPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#openSteps"><a href="Numbas.parts.GapFillPart.html#openSteps">Numbas.parts.GapFillPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#parentPart"><a href="Numbas.parts.GapFillPart.html#parentPart">Numbas.parts.GapFillPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#path"><a href="Numbas.parts.GapFillPart.html#path">Numbas.parts.GapFillPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#pleaseResubmit"><a href="Numbas.parts.GapFillPart.html#pleaseResubmit">Numbas.parts.GapFillPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#question"><a href="Numbas.parts.GapFillPart.html#question">Numbas.parts.GapFillPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#rawStudentAnswerAsJME"><a href="Numbas.parts.GapFillPart.html#rawStudentAnswerAsJME">Numbas.parts.GapFillPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#removeWarnings"><a href="Numbas.parts.GapFillPart.html#removeWarnings">Numbas.parts.GapFillPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#resume"><a href="Numbas.parts.GapFillPart.html#resume">Numbas.parts.GapFillPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#revealAnswer"><a href="Numbas.parts.GapFillPart.html#revealAnswer">Numbas.parts.GapFillPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#score"><a href="Numbas.parts.GapFillPart.html#score">Numbas.parts.GapFillPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setCredit"><a href="Numbas.parts.GapFillPart.html#setCredit">Numbas.parts.GapFillPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setDirty"><a href="Numbas.parts.GapFillPart.html#setDirty">Numbas.parts.GapFillPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setMarkingScript"><a href="Numbas.parts.GapFillPart.html#setMarkingScript">Numbas.parts.GapFillPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setScript"><a href="Numbas.parts.GapFillPart.html#setScript">Numbas.parts.GapFillPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setStudentAnswer"><a href="Numbas.parts.GapFillPart.html#setStudentAnswer">Numbas.parts.GapFillPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#settings"><a href="Numbas.parts.GapFillPart.html#settings">Numbas.parts.GapFillPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setWarnings"><a href="Numbas.parts.GapFillPart.html#setWarnings">Numbas.parts.GapFillPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#shouldResubmit"><a href="Numbas.parts.GapFillPart.html#shouldResubmit">Numbas.parts.GapFillPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#showSteps"><a href="Numbas.parts.GapFillPart.html#showSteps">Numbas.parts.GapFillPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stagedAnswer"><a href="Numbas.parts.GapFillPart.html#stagedAnswer">Numbas.parts.GapFillPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#steps"><a href="Numbas.parts.GapFillPart.html#steps">Numbas.parts.GapFillPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsMarks"><a href="Numbas.parts.GapFillPart.html#stepsMarks">Numbas.parts.GapFillPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsOpen"><a href="Numbas.parts.GapFillPart.html#stepsOpen">Numbas.parts.GapFillPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsShown"><a href="Numbas.parts.GapFillPart.html#stepsShown">Numbas.parts.GapFillPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#store"><a href="Numbas.parts.GapFillPart.html#store">Numbas.parts.GapFillPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#storeAnswer"><a href="Numbas.parts.GapFillPart.html#storeAnswer">Numbas.parts.GapFillPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#studentAnswerAsJME"><a href="Numbas.parts.GapFillPart.html#studentAnswerAsJME">Numbas.parts.GapFillPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#subCredit"><a href="Numbas.parts.GapFillPart.html#subCredit">Numbas.parts.GapFillPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#submit"><a href="Numbas.parts.GapFillPart.html#submit">Numbas.parts.GapFillPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#type"><a href="Numbas.parts.GapFillPart.html#type">Numbas.parts.GapFillPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#useCustomName"><a href="Numbas.parts.GapFillPart.html#useCustomName">Numbas.parts.GapFillPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#warnings"><a href="Numbas.parts.GapFillPart.html#warnings">Numbas.parts.GapFillPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#xml"><a href="Numbas.parts.GapFillPart.html#xml">Numbas.parts.GapFillPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart"><a href="Numbas.parts.InformationOnlyPart.html">Numbas.parts.InformationOnlyPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart#setDirty"><a href="Numbas.parts.InformationOnlyPart.html#setDirty">Numbas.parts.InformationOnlyPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart#validate"><a href="Numbas.parts.InformationOnlyPart.html#validate">Numbas.parts.InformationOnlyPart#validate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart"><a href="Numbas.parts.InformationPart.html">Numbas.parts.InformationPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addCredit"><a href="Numbas.parts.InformationPart.html#addCredit">Numbas.parts.InformationPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addStep"><a href="Numbas.parts.InformationPart.html#addStep">Numbas.parts.InformationPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addVariableReplacement"><a href="Numbas.parts.InformationPart.html#addVariableReplacement">Numbas.parts.InformationPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#answered"><a href="Numbas.parts.InformationPart.html#answered">Numbas.parts.InformationPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#apply_feedback"><a href="Numbas.parts.InformationPart.html#apply_feedback">Numbas.parts.InformationPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#applyScoreLimits"><a href="Numbas.parts.InformationPart.html#applyScoreLimits">Numbas.parts.InformationPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#assignName"><a href="Numbas.parts.InformationPart.html#assignName">Numbas.parts.InformationPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#baseMarkingScript"><a href="Numbas.parts.InformationPart.html#baseMarkingScript">Numbas.parts.InformationPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#calculateScore"><a href="Numbas.parts.InformationPart.html#calculateScore">Numbas.parts.InformationPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#creditFraction"><a href="Numbas.parts.InformationPart.html#creditFraction">Numbas.parts.InformationPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#customName"><a href="Numbas.parts.InformationPart.html#customName">Numbas.parts.InformationPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#display"><a href="Numbas.parts.InformationPart.html#display">Numbas.parts.InformationPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#doesMarking"><a href="Numbas.parts.InformationPart.html#doesMarking">Numbas.parts.InformationPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#error"><a href="Numbas.parts.InformationPart.html#error">Numbas.parts.InformationPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#errorCarriedForwardScope"><a href="Numbas.parts.InformationPart.html#errorCarriedForwardScope">Numbas.parts.InformationPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#finalised_result"><a href="Numbas.parts.InformationPart.html#finalised_result">Numbas.parts.InformationPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#finaliseLoad"><a href="Numbas.parts.InformationPart.html#finaliseLoad">Numbas.parts.InformationPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#gaps"><a href="Numbas.parts.InformationPart.html#gaps">Numbas.parts.InformationPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#getCorrectAnswer"><a href="Numbas.parts.InformationPart.html#getCorrectAnswer">Numbas.parts.InformationPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#getScope"><a href="Numbas.parts.InformationPart.html#getScope">Numbas.parts.InformationPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#giveWarning"><a href="Numbas.parts.InformationPart.html#giveWarning">Numbas.parts.InformationPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#hasStagedAnswer"><a href="Numbas.parts.InformationPart.html#hasStagedAnswer">Numbas.parts.InformationPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#hideSteps"><a href="Numbas.parts.InformationPart.html#hideSteps">Numbas.parts.InformationPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#input_options"><a href="Numbas.parts.InformationPart.html#input_options">Numbas.parts.InformationPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#input_widget"><a href="Numbas.parts.InformationPart.html#input_widget">Numbas.parts.InformationPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#isDirty"><a href="Numbas.parts.InformationPart.html#isDirty">Numbas.parts.InformationPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#loadFromJSON"><a href="Numbas.parts.InformationPart.html#loadFromJSON">Numbas.parts.InformationPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#loadFromXML"><a href="Numbas.parts.InformationPart.html#loadFromXML">Numbas.parts.InformationPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#mark"><a href="Numbas.parts.InformationPart.html#mark">Numbas.parts.InformationPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#mark_answer"><a href="Numbas.parts.InformationPart.html#mark_answer">Numbas.parts.InformationPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markAgainstScope"><a href="Numbas.parts.InformationPart.html#markAgainstScope">Numbas.parts.InformationPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingComment"><a href="Numbas.parts.InformationPart.html#markingComment">Numbas.parts.InformationPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingFeedback"><a href="Numbas.parts.InformationPart.html#markingFeedback">Numbas.parts.InformationPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingScript"><a href="Numbas.parts.InformationPart.html#markingScript">Numbas.parts.InformationPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#marks"><a href="Numbas.parts.InformationPart.html#marks">Numbas.parts.InformationPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#multCredit"><a href="Numbas.parts.InformationPart.html#multCredit">Numbas.parts.InformationPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#name"><a href="Numbas.parts.InformationPart.html#name">Numbas.parts.InformationPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#openSteps"><a href="Numbas.parts.InformationPart.html#openSteps">Numbas.parts.InformationPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#parentPart"><a href="Numbas.parts.InformationPart.html#parentPart">Numbas.parts.InformationPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#path"><a href="Numbas.parts.InformationPart.html#path">Numbas.parts.InformationPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#pleaseResubmit"><a href="Numbas.parts.InformationPart.html#pleaseResubmit">Numbas.parts.InformationPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#question"><a href="Numbas.parts.InformationPart.html#question">Numbas.parts.InformationPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#rawStudentAnswerAsJME"><a href="Numbas.parts.InformationPart.html#rawStudentAnswerAsJME">Numbas.parts.InformationPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#removeWarnings"><a href="Numbas.parts.InformationPart.html#removeWarnings">Numbas.parts.InformationPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#resume"><a href="Numbas.parts.InformationPart.html#resume">Numbas.parts.InformationPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#revealAnswer"><a href="Numbas.parts.InformationPart.html#revealAnswer">Numbas.parts.InformationPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#score"><a href="Numbas.parts.InformationPart.html#score">Numbas.parts.InformationPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setCredit"><a href="Numbas.parts.InformationPart.html#setCredit">Numbas.parts.InformationPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setDirty"><a href="Numbas.parts.InformationPart.html#setDirty">Numbas.parts.InformationPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setMarkingScript"><a href="Numbas.parts.InformationPart.html#setMarkingScript">Numbas.parts.InformationPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setScript"><a href="Numbas.parts.InformationPart.html#setScript">Numbas.parts.InformationPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setStudentAnswer"><a href="Numbas.parts.InformationPart.html#setStudentAnswer">Numbas.parts.InformationPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#settings"><a href="Numbas.parts.InformationPart.html#settings">Numbas.parts.InformationPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setWarnings"><a href="Numbas.parts.InformationPart.html#setWarnings">Numbas.parts.InformationPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#shouldResubmit"><a href="Numbas.parts.InformationPart.html#shouldResubmit">Numbas.parts.InformationPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#showSteps"><a href="Numbas.parts.InformationPart.html#showSteps">Numbas.parts.InformationPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stagedAnswer"><a href="Numbas.parts.InformationPart.html#stagedAnswer">Numbas.parts.InformationPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#steps"><a href="Numbas.parts.InformationPart.html#steps">Numbas.parts.InformationPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsMarks"><a href="Numbas.parts.InformationPart.html#stepsMarks">Numbas.parts.InformationPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsOpen"><a href="Numbas.parts.InformationPart.html#stepsOpen">Numbas.parts.InformationPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsShown"><a href="Numbas.parts.InformationPart.html#stepsShown">Numbas.parts.InformationPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#store"><a href="Numbas.parts.InformationPart.html#store">Numbas.parts.InformationPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#storeAnswer"><a href="Numbas.parts.InformationPart.html#storeAnswer">Numbas.parts.InformationPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#studentAnswerAsJME"><a href="Numbas.parts.InformationPart.html#studentAnswerAsJME">Numbas.parts.InformationPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#subCredit"><a href="Numbas.parts.InformationPart.html#subCredit">Numbas.parts.InformationPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#submit"><a href="Numbas.parts.InformationPart.html#submit">Numbas.parts.InformationPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#type"><a href="Numbas.parts.InformationPart.html#type">Numbas.parts.InformationPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#useCustomName"><a href="Numbas.parts.InformationPart.html#useCustomName">Numbas.parts.InformationPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#warnings"><a href="Numbas.parts.InformationPart.html#warnings">Numbas.parts.InformationPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#xml"><a href="Numbas.parts.InformationPart.html#xml">Numbas.parts.InformationPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart"><a href="Numbas.parts.JMEPart.html">Numbas.parts.JMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addCredit"><a href="Numbas.parts.JMEPart.html#addCredit">Numbas.parts.JMEPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addStep"><a href="Numbas.parts.JMEPart.html#addStep">Numbas.parts.JMEPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addVariableReplacement"><a href="Numbas.parts.JMEPart.html#addVariableReplacement">Numbas.parts.JMEPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#answered"><a href="Numbas.parts.JMEPart.html#answered">Numbas.parts.JMEPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#apply_feedback"><a href="Numbas.parts.JMEPart.html#apply_feedback">Numbas.parts.JMEPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#applyScoreLimits"><a href="Numbas.parts.JMEPart.html#applyScoreLimits">Numbas.parts.JMEPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#assignName"><a href="Numbas.parts.JMEPart.html#assignName">Numbas.parts.JMEPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#baseMarkingScript"><a href="Numbas.parts.JMEPart.html#baseMarkingScript">Numbas.parts.JMEPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#calculateScore"><a href="Numbas.parts.JMEPart.html#calculateScore">Numbas.parts.JMEPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#creditFraction"><a href="Numbas.parts.JMEPart.html#creditFraction">Numbas.parts.JMEPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#customName"><a href="Numbas.parts.JMEPart.html#customName">Numbas.parts.JMEPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#display"><a href="Numbas.parts.JMEPart.html#display">Numbas.parts.JMEPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#doesMarking"><a href="Numbas.parts.JMEPart.html#doesMarking">Numbas.parts.JMEPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#error"><a href="Numbas.parts.JMEPart.html#error">Numbas.parts.JMEPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#errorCarriedForwardScope"><a href="Numbas.parts.JMEPart.html#errorCarriedForwardScope">Numbas.parts.JMEPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#finalised_result"><a href="Numbas.parts.JMEPart.html#finalised_result">Numbas.parts.JMEPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#finaliseLoad"><a href="Numbas.parts.JMEPart.html#finaliseLoad">Numbas.parts.JMEPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#gaps"><a href="Numbas.parts.JMEPart.html#gaps">Numbas.parts.JMEPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#getCorrectAnswer"><a href="Numbas.parts.JMEPart.html#getCorrectAnswer">Numbas.parts.JMEPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#getScope"><a href="Numbas.parts.JMEPart.html#getScope">Numbas.parts.JMEPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#giveWarning"><a href="Numbas.parts.JMEPart.html#giveWarning">Numbas.parts.JMEPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#hasStagedAnswer"><a href="Numbas.parts.JMEPart.html#hasStagedAnswer">Numbas.parts.JMEPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#hideSteps"><a href="Numbas.parts.JMEPart.html#hideSteps">Numbas.parts.JMEPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#input_options"><a href="Numbas.parts.JMEPart.html#input_options">Numbas.parts.JMEPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#input_widget"><a href="Numbas.parts.JMEPart.html#input_widget">Numbas.parts.JMEPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#isDirty"><a href="Numbas.parts.JMEPart.html#isDirty">Numbas.parts.JMEPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#loadFromJSON"><a href="Numbas.parts.JMEPart.html#loadFromJSON">Numbas.parts.JMEPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#loadFromXML"><a href="Numbas.parts.JMEPart.html#loadFromXML">Numbas.parts.JMEPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#mark"><a href="Numbas.parts.JMEPart.html#mark">Numbas.parts.JMEPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#mark_answer"><a href="Numbas.parts.JMEPart.html#mark_answer">Numbas.parts.JMEPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markAgainstScope"><a href="Numbas.parts.JMEPart.html#markAgainstScope">Numbas.parts.JMEPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingComment"><a href="Numbas.parts.JMEPart.html#markingComment">Numbas.parts.JMEPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingFeedback"><a href="Numbas.parts.JMEPart.html#markingFeedback">Numbas.parts.JMEPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingScript"><a href="Numbas.parts.JMEPart.html#markingScript">Numbas.parts.JMEPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#marks"><a href="Numbas.parts.JMEPart.html#marks">Numbas.parts.JMEPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#multCredit"><a href="Numbas.parts.JMEPart.html#multCredit">Numbas.parts.JMEPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#name"><a href="Numbas.parts.JMEPart.html#name">Numbas.parts.JMEPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#openSteps"><a href="Numbas.parts.JMEPart.html#openSteps">Numbas.parts.JMEPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#parentPart"><a href="Numbas.parts.JMEPart.html#parentPart">Numbas.parts.JMEPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#path"><a href="Numbas.parts.JMEPart.html#path">Numbas.parts.JMEPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#pleaseResubmit"><a href="Numbas.parts.JMEPart.html#pleaseResubmit">Numbas.parts.JMEPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#question"><a href="Numbas.parts.JMEPart.html#question">Numbas.parts.JMEPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#rawStudentAnswerAsJME"><a href="Numbas.parts.JMEPart.html#rawStudentAnswerAsJME">Numbas.parts.JMEPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#removeWarnings"><a href="Numbas.parts.JMEPart.html#removeWarnings">Numbas.parts.JMEPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#resume"><a href="Numbas.parts.JMEPart.html#resume">Numbas.parts.JMEPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#revealAnswer"><a href="Numbas.parts.JMEPart.html#revealAnswer">Numbas.parts.JMEPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#score"><a href="Numbas.parts.JMEPart.html#score">Numbas.parts.JMEPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setCredit"><a href="Numbas.parts.JMEPart.html#setCredit">Numbas.parts.JMEPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setDirty"><a href="Numbas.parts.JMEPart.html#setDirty">Numbas.parts.JMEPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setMarkingScript"><a href="Numbas.parts.JMEPart.html#setMarkingScript">Numbas.parts.JMEPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setScript"><a href="Numbas.parts.JMEPart.html#setScript">Numbas.parts.JMEPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setStudentAnswer"><a href="Numbas.parts.JMEPart.html#setStudentAnswer">Numbas.parts.JMEPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#settings"><a href="Numbas.parts.JMEPart.html#settings">Numbas.parts.JMEPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setWarnings"><a href="Numbas.parts.JMEPart.html#setWarnings">Numbas.parts.JMEPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#shouldResubmit"><a href="Numbas.parts.JMEPart.html#shouldResubmit">Numbas.parts.JMEPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#showSteps"><a href="Numbas.parts.JMEPart.html#showSteps">Numbas.parts.JMEPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stagedAnswer"><a href="Numbas.parts.JMEPart.html#stagedAnswer">Numbas.parts.JMEPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#steps"><a href="Numbas.parts.JMEPart.html#steps">Numbas.parts.JMEPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsMarks"><a href="Numbas.parts.JMEPart.html#stepsMarks">Numbas.parts.JMEPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsOpen"><a href="Numbas.parts.JMEPart.html#stepsOpen">Numbas.parts.JMEPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsShown"><a href="Numbas.parts.JMEPart.html#stepsShown">Numbas.parts.JMEPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#store"><a href="Numbas.parts.JMEPart.html#store">Numbas.parts.JMEPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#storeAnswer"><a href="Numbas.parts.JMEPart.html#storeAnswer">Numbas.parts.JMEPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#studentAnswerAsJME"><a href="Numbas.parts.JMEPart.html#studentAnswerAsJME">Numbas.parts.JMEPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#subCredit"><a href="Numbas.parts.JMEPart.html#subCredit">Numbas.parts.JMEPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#submit"><a href="Numbas.parts.JMEPart.html#submit">Numbas.parts.JMEPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#type"><a href="Numbas.parts.JMEPart.html#type">Numbas.parts.JMEPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#useCustomName"><a href="Numbas.parts.JMEPart.html#useCustomName">Numbas.parts.JMEPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#warnings"><a href="Numbas.parts.JMEPart.html#warnings">Numbas.parts.JMEPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#xml"><a href="Numbas.parts.JMEPart.html#xml">Numbas.parts.JMEPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.marking_results"><a href="Numbas.parts.html#.marking_results">Numbas.parts.marking_results</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart"><a href="Numbas.parts.MatrixEntryPart.html">Numbas.parts.MatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addCredit"><a href="Numbas.parts.MatrixEntryPart.html#addCredit">Numbas.parts.MatrixEntryPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addStep"><a href="Numbas.parts.MatrixEntryPart.html#addStep">Numbas.parts.MatrixEntryPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addVariableReplacement"><a href="Numbas.parts.MatrixEntryPart.html#addVariableReplacement">Numbas.parts.MatrixEntryPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#answered"><a href="Numbas.parts.MatrixEntryPart.html#answered">Numbas.parts.MatrixEntryPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#apply_feedback"><a href="Numbas.parts.MatrixEntryPart.html#apply_feedback">Numbas.parts.MatrixEntryPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#applyScoreLimits"><a href="Numbas.parts.MatrixEntryPart.html#applyScoreLimits">Numbas.parts.MatrixEntryPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#assignName"><a href="Numbas.parts.MatrixEntryPart.html#assignName">Numbas.parts.MatrixEntryPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#baseMarkingScript"><a href="Numbas.parts.MatrixEntryPart.html#baseMarkingScript">Numbas.parts.MatrixEntryPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#calculateScore"><a href="Numbas.parts.MatrixEntryPart.html#calculateScore">Numbas.parts.MatrixEntryPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#creditFraction"><a href="Numbas.parts.MatrixEntryPart.html#creditFraction">Numbas.parts.MatrixEntryPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#customName"><a href="Numbas.parts.MatrixEntryPart.html#customName">Numbas.parts.MatrixEntryPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#display"><a href="Numbas.parts.MatrixEntryPart.html#display">Numbas.parts.MatrixEntryPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#doesMarking"><a href="Numbas.parts.MatrixEntryPart.html#doesMarking">Numbas.parts.MatrixEntryPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#error"><a href="Numbas.parts.MatrixEntryPart.html#error">Numbas.parts.MatrixEntryPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#errorCarriedForwardScope"><a href="Numbas.parts.MatrixEntryPart.html#errorCarriedForwardScope">Numbas.parts.MatrixEntryPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#finalised_result"><a href="Numbas.parts.MatrixEntryPart.html#finalised_result">Numbas.parts.MatrixEntryPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#finaliseLoad"><a href="Numbas.parts.MatrixEntryPart.html#finaliseLoad">Numbas.parts.MatrixEntryPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#gaps"><a href="Numbas.parts.MatrixEntryPart.html#gaps">Numbas.parts.MatrixEntryPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#getCorrectAnswer"><a href="Numbas.parts.MatrixEntryPart.html#getCorrectAnswer">Numbas.parts.MatrixEntryPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#getScope"><a href="Numbas.parts.MatrixEntryPart.html#getScope">Numbas.parts.MatrixEntryPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#giveWarning"><a href="Numbas.parts.MatrixEntryPart.html#giveWarning">Numbas.parts.MatrixEntryPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#hasStagedAnswer"><a href="Numbas.parts.MatrixEntryPart.html#hasStagedAnswer">Numbas.parts.MatrixEntryPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#hideSteps"><a href="Numbas.parts.MatrixEntryPart.html#hideSteps">Numbas.parts.MatrixEntryPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#input_options"><a href="Numbas.parts.MatrixEntryPart.html#input_options">Numbas.parts.MatrixEntryPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#input_widget"><a href="Numbas.parts.MatrixEntryPart.html#input_widget">Numbas.parts.MatrixEntryPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#isDirty"><a href="Numbas.parts.MatrixEntryPart.html#isDirty">Numbas.parts.MatrixEntryPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#loadFromJSON"><a href="Numbas.parts.MatrixEntryPart.html#loadFromJSON">Numbas.parts.MatrixEntryPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#loadFromXML"><a href="Numbas.parts.MatrixEntryPart.html#loadFromXML">Numbas.parts.MatrixEntryPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#mark"><a href="Numbas.parts.MatrixEntryPart.html#mark">Numbas.parts.MatrixEntryPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#mark_answer"><a href="Numbas.parts.MatrixEntryPart.html#mark_answer">Numbas.parts.MatrixEntryPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markAgainstScope"><a href="Numbas.parts.MatrixEntryPart.html#markAgainstScope">Numbas.parts.MatrixEntryPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingComment"><a href="Numbas.parts.MatrixEntryPart.html#markingComment">Numbas.parts.MatrixEntryPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingFeedback"><a href="Numbas.parts.MatrixEntryPart.html#markingFeedback">Numbas.parts.MatrixEntryPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingScript"><a href="Numbas.parts.MatrixEntryPart.html#markingScript">Numbas.parts.MatrixEntryPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#marks"><a href="Numbas.parts.MatrixEntryPart.html#marks">Numbas.parts.MatrixEntryPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#multCredit"><a href="Numbas.parts.MatrixEntryPart.html#multCredit">Numbas.parts.MatrixEntryPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#name"><a href="Numbas.parts.MatrixEntryPart.html#name">Numbas.parts.MatrixEntryPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#openSteps"><a href="Numbas.parts.MatrixEntryPart.html#openSteps">Numbas.parts.MatrixEntryPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#parentPart"><a href="Numbas.parts.MatrixEntryPart.html#parentPart">Numbas.parts.MatrixEntryPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#path"><a href="Numbas.parts.MatrixEntryPart.html#path">Numbas.parts.MatrixEntryPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#pleaseResubmit"><a href="Numbas.parts.MatrixEntryPart.html#pleaseResubmit">Numbas.parts.MatrixEntryPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#question"><a href="Numbas.parts.MatrixEntryPart.html#question">Numbas.parts.MatrixEntryPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#rawStudentAnswerAsJME"><a href="Numbas.parts.MatrixEntryPart.html#rawStudentAnswerAsJME">Numbas.parts.MatrixEntryPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#removeWarnings"><a href="Numbas.parts.MatrixEntryPart.html#removeWarnings">Numbas.parts.MatrixEntryPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#resume"><a href="Numbas.parts.MatrixEntryPart.html#resume">Numbas.parts.MatrixEntryPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#revealAnswer"><a href="Numbas.parts.MatrixEntryPart.html#revealAnswer">Numbas.parts.MatrixEntryPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#score"><a href="Numbas.parts.MatrixEntryPart.html#score">Numbas.parts.MatrixEntryPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setCredit"><a href="Numbas.parts.MatrixEntryPart.html#setCredit">Numbas.parts.MatrixEntryPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setDirty"><a href="Numbas.parts.MatrixEntryPart.html#setDirty">Numbas.parts.MatrixEntryPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setMarkingScript"><a href="Numbas.parts.MatrixEntryPart.html#setMarkingScript">Numbas.parts.MatrixEntryPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setScript"><a href="Numbas.parts.MatrixEntryPart.html#setScript">Numbas.parts.MatrixEntryPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setStudentAnswer"><a href="Numbas.parts.MatrixEntryPart.html#setStudentAnswer">Numbas.parts.MatrixEntryPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#settings"><a href="Numbas.parts.MatrixEntryPart.html#settings">Numbas.parts.MatrixEntryPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setWarnings"><a href="Numbas.parts.MatrixEntryPart.html#setWarnings">Numbas.parts.MatrixEntryPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#shouldResubmit"><a href="Numbas.parts.MatrixEntryPart.html#shouldResubmit">Numbas.parts.MatrixEntryPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#showSteps"><a href="Numbas.parts.MatrixEntryPart.html#showSteps">Numbas.parts.MatrixEntryPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stagedAnswer"><a href="Numbas.parts.MatrixEntryPart.html#stagedAnswer">Numbas.parts.MatrixEntryPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#steps"><a href="Numbas.parts.MatrixEntryPart.html#steps">Numbas.parts.MatrixEntryPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsMarks"><a href="Numbas.parts.MatrixEntryPart.html#stepsMarks">Numbas.parts.MatrixEntryPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsOpen"><a href="Numbas.parts.MatrixEntryPart.html#stepsOpen">Numbas.parts.MatrixEntryPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsShown"><a href="Numbas.parts.MatrixEntryPart.html#stepsShown">Numbas.parts.MatrixEntryPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#store"><a href="Numbas.parts.MatrixEntryPart.html#store">Numbas.parts.MatrixEntryPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#storeAnswer"><a href="Numbas.parts.MatrixEntryPart.html#storeAnswer">Numbas.parts.MatrixEntryPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#studentAnswer"><a href="Numbas.parts.MatrixEntryPart.html#studentAnswer">Numbas.parts.MatrixEntryPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#studentAnswerAsJME"><a href="Numbas.parts.MatrixEntryPart.html#studentAnswerAsJME">Numbas.parts.MatrixEntryPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#subCredit"><a href="Numbas.parts.MatrixEntryPart.html#subCredit">Numbas.parts.MatrixEntryPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#submit"><a href="Numbas.parts.MatrixEntryPart.html#submit">Numbas.parts.MatrixEntryPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#type"><a href="Numbas.parts.MatrixEntryPart.html#type">Numbas.parts.MatrixEntryPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#useCustomName"><a href="Numbas.parts.MatrixEntryPart.html#useCustomName">Numbas.parts.MatrixEntryPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#warnings"><a href="Numbas.parts.MatrixEntryPart.html#warnings">Numbas.parts.MatrixEntryPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#xml"><a href="Numbas.parts.MatrixEntryPart.html#xml">Numbas.parts.MatrixEntryPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart"><a href="Numbas.parts.MultipleResponsePart.html">Numbas.parts.MultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart.layoutTypes"><a href="Numbas.parts.MultipleResponsePart.html#.layoutTypes">Numbas.parts.MultipleResponsePart.layoutTypes</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addCredit"><a href="Numbas.parts.MultipleResponsePart.html#addCredit">Numbas.parts.MultipleResponsePart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addStep"><a href="Numbas.parts.MultipleResponsePart.html#addStep">Numbas.parts.MultipleResponsePart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addVariableReplacement"><a href="Numbas.parts.MultipleResponsePart.html#addVariableReplacement">Numbas.parts.MultipleResponsePart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#answered"><a href="Numbas.parts.MultipleResponsePart.html#answered">Numbas.parts.MultipleResponsePart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#apply_feedback"><a href="Numbas.parts.MultipleResponsePart.html#apply_feedback">Numbas.parts.MultipleResponsePart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#applyScoreLimits"><a href="Numbas.parts.MultipleResponsePart.html#applyScoreLimits">Numbas.parts.MultipleResponsePart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#assignName"><a href="Numbas.parts.MultipleResponsePart.html#assignName">Numbas.parts.MultipleResponsePart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#baseMarkingScript"><a href="Numbas.parts.MultipleResponsePart.html#baseMarkingScript">Numbas.parts.MultipleResponsePart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#calculateScore"><a href="Numbas.parts.MultipleResponsePart.html#calculateScore">Numbas.parts.MultipleResponsePart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#creditFraction"><a href="Numbas.parts.MultipleResponsePart.html#creditFraction">Numbas.parts.MultipleResponsePart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#customName"><a href="Numbas.parts.MultipleResponsePart.html#customName">Numbas.parts.MultipleResponsePart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#display"><a href="Numbas.parts.MultipleResponsePart.html#display">Numbas.parts.MultipleResponsePart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#doesMarking"><a href="Numbas.parts.MultipleResponsePart.html#doesMarking">Numbas.parts.MultipleResponsePart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#error"><a href="Numbas.parts.MultipleResponsePart.html#error">Numbas.parts.MultipleResponsePart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#errorCarriedForwardScope"><a href="Numbas.parts.MultipleResponsePart.html#errorCarriedForwardScope">Numbas.parts.MultipleResponsePart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#finalised_result"><a href="Numbas.parts.MultipleResponsePart.html#finalised_result">Numbas.parts.MultipleResponsePart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#finaliseLoad"><a href="Numbas.parts.MultipleResponsePart.html#finaliseLoad">Numbas.parts.MultipleResponsePart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#flipped"><a href="Numbas.parts.MultipleResponsePart.html#flipped">Numbas.parts.MultipleResponsePart#flipped</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#gaps"><a href="Numbas.parts.MultipleResponsePart.html#gaps">Numbas.parts.MultipleResponsePart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#getCorrectAnswer"><a href="Numbas.parts.MultipleResponsePart.html#getCorrectAnswer">Numbas.parts.MultipleResponsePart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#getScope"><a href="Numbas.parts.MultipleResponsePart.html#getScope">Numbas.parts.MultipleResponsePart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#giveWarning"><a href="Numbas.parts.MultipleResponsePart.html#giveWarning">Numbas.parts.MultipleResponsePart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#hasStagedAnswer"><a href="Numbas.parts.MultipleResponsePart.html#hasStagedAnswer">Numbas.parts.MultipleResponsePart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#hideSteps"><a href="Numbas.parts.MultipleResponsePart.html#hideSteps">Numbas.parts.MultipleResponsePart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#input_options"><a href="Numbas.parts.MultipleResponsePart.html#input_options">Numbas.parts.MultipleResponsePart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#input_widget"><a href="Numbas.parts.MultipleResponsePart.html#input_widget">Numbas.parts.MultipleResponsePart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#isDirty"><a href="Numbas.parts.MultipleResponsePart.html#isDirty">Numbas.parts.MultipleResponsePart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#loadFromJSON"><a href="Numbas.parts.MultipleResponsePart.html#loadFromJSON">Numbas.parts.MultipleResponsePart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#loadFromXML"><a href="Numbas.parts.MultipleResponsePart.html#loadFromXML">Numbas.parts.MultipleResponsePart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#mark"><a href="Numbas.parts.MultipleResponsePart.html#mark">Numbas.parts.MultipleResponsePart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#mark_answer"><a href="Numbas.parts.MultipleResponsePart.html#mark_answer">Numbas.parts.MultipleResponsePart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markAgainstScope"><a href="Numbas.parts.MultipleResponsePart.html#markAgainstScope">Numbas.parts.MultipleResponsePart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingComment"><a href="Numbas.parts.MultipleResponsePart.html#markingComment">Numbas.parts.MultipleResponsePart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingFeedback"><a href="Numbas.parts.MultipleResponsePart.html#markingFeedback">Numbas.parts.MultipleResponsePart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingScript"><a href="Numbas.parts.MultipleResponsePart.html#markingScript">Numbas.parts.MultipleResponsePart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#marks"><a href="Numbas.parts.MultipleResponsePart.html#marks">Numbas.parts.MultipleResponsePart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#multCredit"><a href="Numbas.parts.MultipleResponsePart.html#multCredit">Numbas.parts.MultipleResponsePart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#name"><a href="Numbas.parts.MultipleResponsePart.html#name">Numbas.parts.MultipleResponsePart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#numAnswers"><a href="Numbas.parts.MultipleResponsePart.html#numAnswers">Numbas.parts.MultipleResponsePart#numAnswers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#numChoices"><a href="Numbas.parts.MultipleResponsePart.html#numChoices">Numbas.parts.MultipleResponsePart#numChoices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#openSteps"><a href="Numbas.parts.MultipleResponsePart.html#openSteps">Numbas.parts.MultipleResponsePart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#parentPart"><a href="Numbas.parts.MultipleResponsePart.html#parentPart">Numbas.parts.MultipleResponsePart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#path"><a href="Numbas.parts.MultipleResponsePart.html#path">Numbas.parts.MultipleResponsePart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#pleaseResubmit"><a href="Numbas.parts.MultipleResponsePart.html#pleaseResubmit">Numbas.parts.MultipleResponsePart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#question"><a href="Numbas.parts.MultipleResponsePart.html#question">Numbas.parts.MultipleResponsePart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#rawStudentAnswerAsJME"><a href="Numbas.parts.MultipleResponsePart.html#rawStudentAnswerAsJME">Numbas.parts.MultipleResponsePart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#removeWarnings"><a href="Numbas.parts.MultipleResponsePart.html#removeWarnings">Numbas.parts.MultipleResponsePart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#resume"><a href="Numbas.parts.MultipleResponsePart.html#resume">Numbas.parts.MultipleResponsePart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#revealAnswer"><a href="Numbas.parts.MultipleResponsePart.html#revealAnswer">Numbas.parts.MultipleResponsePart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#score"><a href="Numbas.parts.MultipleResponsePart.html#score">Numbas.parts.MultipleResponsePart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setCredit"><a href="Numbas.parts.MultipleResponsePart.html#setCredit">Numbas.parts.MultipleResponsePart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setDirty"><a href="Numbas.parts.MultipleResponsePart.html#setDirty">Numbas.parts.MultipleResponsePart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setMarkingScript"><a href="Numbas.parts.MultipleResponsePart.html#setMarkingScript">Numbas.parts.MultipleResponsePart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setScript"><a href="Numbas.parts.MultipleResponsePart.html#setScript">Numbas.parts.MultipleResponsePart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setStudentAnswer"><a href="Numbas.parts.MultipleResponsePart.html#setStudentAnswer">Numbas.parts.MultipleResponsePart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#settings"><a href="Numbas.parts.MultipleResponsePart.html#settings">Numbas.parts.MultipleResponsePart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setWarnings"><a href="Numbas.parts.MultipleResponsePart.html#setWarnings">Numbas.parts.MultipleResponsePart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#shouldResubmit"><a href="Numbas.parts.MultipleResponsePart.html#shouldResubmit">Numbas.parts.MultipleResponsePart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#showSteps"><a href="Numbas.parts.MultipleResponsePart.html#showSteps">Numbas.parts.MultipleResponsePart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stagedAnswer"><a href="Numbas.parts.MultipleResponsePart.html#stagedAnswer">Numbas.parts.MultipleResponsePart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#steps"><a href="Numbas.parts.MultipleResponsePart.html#steps">Numbas.parts.MultipleResponsePart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsMarks"><a href="Numbas.parts.MultipleResponsePart.html#stepsMarks">Numbas.parts.MultipleResponsePart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsOpen"><a href="Numbas.parts.MultipleResponsePart.html#stepsOpen">Numbas.parts.MultipleResponsePart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsShown"><a href="Numbas.parts.MultipleResponsePart.html#stepsShown">Numbas.parts.MultipleResponsePart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#store"><a href="Numbas.parts.MultipleResponsePart.html#store">Numbas.parts.MultipleResponsePart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#storeAnswer"><a href="Numbas.parts.MultipleResponsePart.html#storeAnswer">Numbas.parts.MultipleResponsePart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#storeTick"><a href="Numbas.parts.MultipleResponsePart.html#storeTick">Numbas.parts.MultipleResponsePart#storeTick</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#studentAnswerAsJME"><a href="Numbas.parts.MultipleResponsePart.html#studentAnswerAsJME">Numbas.parts.MultipleResponsePart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#subCredit"><a href="Numbas.parts.MultipleResponsePart.html#subCredit">Numbas.parts.MultipleResponsePart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#submit"><a href="Numbas.parts.MultipleResponsePart.html#submit">Numbas.parts.MultipleResponsePart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#ticks"><a href="Numbas.parts.MultipleResponsePart.html#ticks">Numbas.parts.MultipleResponsePart#ticks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#type"><a href="Numbas.parts.MultipleResponsePart.html#type">Numbas.parts.MultipleResponsePart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#useCustomName"><a href="Numbas.parts.MultipleResponsePart.html#useCustomName">Numbas.parts.MultipleResponsePart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#warnings"><a href="Numbas.parts.MultipleResponsePart.html#warnings">Numbas.parts.MultipleResponsePart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#xml"><a href="Numbas.parts.MultipleResponsePart.html#xml">Numbas.parts.MultipleResponsePart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart"><a href="Numbas.parts.NumberEntryPart.html">Numbas.parts.NumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addCredit"><a href="Numbas.parts.NumberEntryPart.html#addCredit">Numbas.parts.NumberEntryPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addStep"><a href="Numbas.parts.NumberEntryPart.html#addStep">Numbas.parts.NumberEntryPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addVariableReplacement"><a href="Numbas.parts.NumberEntryPart.html#addVariableReplacement">Numbas.parts.NumberEntryPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#answered"><a href="Numbas.parts.NumberEntryPart.html#answered">Numbas.parts.NumberEntryPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#apply_feedback"><a href="Numbas.parts.NumberEntryPart.html#apply_feedback">Numbas.parts.NumberEntryPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#applyScoreLimits"><a href="Numbas.parts.NumberEntryPart.html#applyScoreLimits">Numbas.parts.NumberEntryPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#assignName"><a href="Numbas.parts.NumberEntryPart.html#assignName">Numbas.parts.NumberEntryPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#baseMarkingScript"><a href="Numbas.parts.NumberEntryPart.html#baseMarkingScript">Numbas.parts.NumberEntryPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#calculateScore"><a href="Numbas.parts.NumberEntryPart.html#calculateScore">Numbas.parts.NumberEntryPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#cleanAnswer"><a href="Numbas.parts.NumberEntryPart.html#cleanAnswer">Numbas.parts.NumberEntryPart#cleanAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#creditFraction"><a href="Numbas.parts.NumberEntryPart.html#creditFraction">Numbas.parts.NumberEntryPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#customName"><a href="Numbas.parts.NumberEntryPart.html#customName">Numbas.parts.NumberEntryPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#display"><a href="Numbas.parts.NumberEntryPart.html#display">Numbas.parts.NumberEntryPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#doesMarking"><a href="Numbas.parts.NumberEntryPart.html#doesMarking">Numbas.parts.NumberEntryPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#error"><a href="Numbas.parts.NumberEntryPart.html#error">Numbas.parts.NumberEntryPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#errorCarriedForwardScope"><a href="Numbas.parts.NumberEntryPart.html#errorCarriedForwardScope">Numbas.parts.NumberEntryPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#finalised_result"><a href="Numbas.parts.NumberEntryPart.html#finalised_result">Numbas.parts.NumberEntryPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#finaliseLoad"><a href="Numbas.parts.NumberEntryPart.html#finaliseLoad">Numbas.parts.NumberEntryPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#gaps"><a href="Numbas.parts.NumberEntryPart.html#gaps">Numbas.parts.NumberEntryPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#getCorrectAnswer"><a href="Numbas.parts.NumberEntryPart.html#getCorrectAnswer">Numbas.parts.NumberEntryPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#getScope"><a href="Numbas.parts.NumberEntryPart.html#getScope">Numbas.parts.NumberEntryPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#giveWarning"><a href="Numbas.parts.NumberEntryPart.html#giveWarning">Numbas.parts.NumberEntryPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#hasStagedAnswer"><a href="Numbas.parts.NumberEntryPart.html#hasStagedAnswer">Numbas.parts.NumberEntryPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#hideSteps"><a href="Numbas.parts.NumberEntryPart.html#hideSteps">Numbas.parts.NumberEntryPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#input_options"><a href="Numbas.parts.NumberEntryPart.html#input_options">Numbas.parts.NumberEntryPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#input_widget"><a href="Numbas.parts.NumberEntryPart.html#input_widget">Numbas.parts.NumberEntryPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#isDirty"><a href="Numbas.parts.NumberEntryPart.html#isDirty">Numbas.parts.NumberEntryPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#loadFromJSON"><a href="Numbas.parts.NumberEntryPart.html#loadFromJSON">Numbas.parts.NumberEntryPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#loadFromXML"><a href="Numbas.parts.NumberEntryPart.html#loadFromXML">Numbas.parts.NumberEntryPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#mark"><a href="Numbas.parts.NumberEntryPart.html#mark">Numbas.parts.NumberEntryPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#mark_answer"><a href="Numbas.parts.NumberEntryPart.html#mark_answer">Numbas.parts.NumberEntryPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markAgainstScope"><a href="Numbas.parts.NumberEntryPart.html#markAgainstScope">Numbas.parts.NumberEntryPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingComment"><a href="Numbas.parts.NumberEntryPart.html#markingComment">Numbas.parts.NumberEntryPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingFeedback"><a href="Numbas.parts.NumberEntryPart.html#markingFeedback">Numbas.parts.NumberEntryPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingScript"><a href="Numbas.parts.NumberEntryPart.html#markingScript">Numbas.parts.NumberEntryPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#marks"><a href="Numbas.parts.NumberEntryPart.html#marks">Numbas.parts.NumberEntryPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#multCredit"><a href="Numbas.parts.NumberEntryPart.html#multCredit">Numbas.parts.NumberEntryPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#name"><a href="Numbas.parts.NumberEntryPart.html#name">Numbas.parts.NumberEntryPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#openSteps"><a href="Numbas.parts.NumberEntryPart.html#openSteps">Numbas.parts.NumberEntryPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#parentPart"><a href="Numbas.parts.NumberEntryPart.html#parentPart">Numbas.parts.NumberEntryPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#path"><a href="Numbas.parts.NumberEntryPart.html#path">Numbas.parts.NumberEntryPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#pleaseResubmit"><a href="Numbas.parts.NumberEntryPart.html#pleaseResubmit">Numbas.parts.NumberEntryPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#question"><a href="Numbas.parts.NumberEntryPart.html#question">Numbas.parts.NumberEntryPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#rawStudentAnswerAsJME"><a href="Numbas.parts.NumberEntryPart.html#rawStudentAnswerAsJME">Numbas.parts.NumberEntryPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#removeWarnings"><a href="Numbas.parts.NumberEntryPart.html#removeWarnings">Numbas.parts.NumberEntryPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#resume"><a href="Numbas.parts.NumberEntryPart.html#resume">Numbas.parts.NumberEntryPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#revealAnswer"><a href="Numbas.parts.NumberEntryPart.html#revealAnswer">Numbas.parts.NumberEntryPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#score"><a href="Numbas.parts.NumberEntryPart.html#score">Numbas.parts.NumberEntryPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setCredit"><a href="Numbas.parts.NumberEntryPart.html#setCredit">Numbas.parts.NumberEntryPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setDirty"><a href="Numbas.parts.NumberEntryPart.html#setDirty">Numbas.parts.NumberEntryPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setMarkingScript"><a href="Numbas.parts.NumberEntryPart.html#setMarkingScript">Numbas.parts.NumberEntryPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setScript"><a href="Numbas.parts.NumberEntryPart.html#setScript">Numbas.parts.NumberEntryPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setStudentAnswer"><a href="Numbas.parts.NumberEntryPart.html#setStudentAnswer">Numbas.parts.NumberEntryPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#settings"><a href="Numbas.parts.NumberEntryPart.html#settings">Numbas.parts.NumberEntryPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setWarnings"><a href="Numbas.parts.NumberEntryPart.html#setWarnings">Numbas.parts.NumberEntryPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#shouldResubmit"><a href="Numbas.parts.NumberEntryPart.html#shouldResubmit">Numbas.parts.NumberEntryPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#showSteps"><a href="Numbas.parts.NumberEntryPart.html#showSteps">Numbas.parts.NumberEntryPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stagedAnswer"><a href="Numbas.parts.NumberEntryPart.html#stagedAnswer">Numbas.parts.NumberEntryPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#steps"><a href="Numbas.parts.NumberEntryPart.html#steps">Numbas.parts.NumberEntryPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsMarks"><a href="Numbas.parts.NumberEntryPart.html#stepsMarks">Numbas.parts.NumberEntryPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsOpen"><a href="Numbas.parts.NumberEntryPart.html#stepsOpen">Numbas.parts.NumberEntryPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsShown"><a href="Numbas.parts.NumberEntryPart.html#stepsShown">Numbas.parts.NumberEntryPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#store"><a href="Numbas.parts.NumberEntryPart.html#store">Numbas.parts.NumberEntryPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#storeAnswer"><a href="Numbas.parts.NumberEntryPart.html#storeAnswer">Numbas.parts.NumberEntryPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#studentAnswer"><a href="Numbas.parts.NumberEntryPart.html#studentAnswer">Numbas.parts.NumberEntryPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#studentAnswerAsJME"><a href="Numbas.parts.NumberEntryPart.html#studentAnswerAsJME">Numbas.parts.NumberEntryPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#subCredit"><a href="Numbas.parts.NumberEntryPart.html#subCredit">Numbas.parts.NumberEntryPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#submit"><a href="Numbas.parts.NumberEntryPart.html#submit">Numbas.parts.NumberEntryPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#type"><a href="Numbas.parts.NumberEntryPart.html#type">Numbas.parts.NumberEntryPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#useCustomName"><a href="Numbas.parts.NumberEntryPart.html#useCustomName">Numbas.parts.NumberEntryPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#warnings"><a href="Numbas.parts.NumberEntryPart.html#warnings">Numbas.parts.NumberEntryPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#xml"><a href="Numbas.parts.NumberEntryPart.html#xml">Numbas.parts.NumberEntryPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part"><a href="Numbas.parts.Part_.html">Numbas.parts.Part</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addCredit"><a href="Numbas.parts.Part.html#addCredit">Numbas.parts.Part#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addStep"><a href="Numbas.parts.Part.html#addStep">Numbas.parts.Part#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addVariableReplacement"><a href="Numbas.parts.Part.html#addVariableReplacement">Numbas.parts.Part#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#answered"><a href="Numbas.parts.Part.html#answered">Numbas.parts.Part#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#apply_feedback"><a href="Numbas.parts.Part.html#apply_feedback">Numbas.parts.Part#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#applyScoreLimits"><a href="Numbas.parts.Part.html#applyScoreLimits">Numbas.parts.Part#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#applyScripts"><a href="Numbas.parts.Part_applyScripts.html">Numbas.parts.Part#applyScripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#assignName"><a href="Numbas.parts.Part.html#assignName">Numbas.parts.Part#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#baseMarkingScript"><a href="Numbas.parts.Part.html#baseMarkingScript">Numbas.parts.Part#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#calculateScore"><a href="Numbas.parts.Part.html#calculateScore">Numbas.parts.Part#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#creditFraction"><a href="Numbas.parts.Part.html#creditFraction">Numbas.parts.Part#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#customName"><a href="Numbas.parts.Part.html#customName">Numbas.parts.Part#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#display"><a href="Numbas.parts.Part.html#display">Numbas.parts.Part#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#doesMarking"><a href="Numbas.parts.Part.html#doesMarking">Numbas.parts.Part#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#error"><a href="Numbas.parts.Part.html#error">Numbas.parts.Part#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#errorCarriedForwardScope"><a href="Numbas.parts.Part.html#errorCarriedForwardScope">Numbas.parts.Part#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#finalised_result"><a href="Numbas.parts.Part.html#finalised_result">Numbas.parts.Part#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#finaliseLoad"><a href="Numbas.parts.Part.html#finaliseLoad">Numbas.parts.Part#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#gaps"><a href="Numbas.parts.Part.html#gaps">Numbas.parts.Part#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#getCorrectAnswer"><a href="Numbas.parts.Part.html#getCorrectAnswer">Numbas.parts.Part#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#getScope"><a href="Numbas.parts.Part.html#getScope">Numbas.parts.Part#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#giveWarning"><a href="Numbas.parts.Part.html#giveWarning">Numbas.parts.Part#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#hasStagedAnswer"><a href="Numbas.parts.Part.html#hasStagedAnswer">Numbas.parts.Part#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#hideSteps"><a href="Numbas.parts.Part.html#hideSteps">Numbas.parts.Part#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#input_options"><a href="Numbas.parts.Part.html#input_options">Numbas.parts.Part#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#input_widget"><a href="Numbas.parts.Part.html#input_widget">Numbas.parts.Part#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#isDirty"><a href="Numbas.parts.Part.html#isDirty">Numbas.parts.Part#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#loadFromJSON"><a href="Numbas.parts.Part.html#loadFromJSON">Numbas.parts.Part#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#loadFromXML"><a href="Numbas.parts.Part.html#loadFromXML">Numbas.parts.Part#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#mark"><a href="Numbas.parts.Part.html#mark">Numbas.parts.Part#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#mark_answer"><a href="Numbas.parts.Part.html#mark_answer">Numbas.parts.Part#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markAgainstScope"><a href="Numbas.parts.Part.html#markAgainstScope">Numbas.parts.Part#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingComment"><a href="Numbas.parts.Part.html#markingComment">Numbas.parts.Part#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingFeedback"><a href="Numbas.parts.Part.html#markingFeedback">Numbas.parts.Part#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingScript"><a href="Numbas.parts.Part.html#markingScript">Numbas.parts.Part#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#marks"><a href="Numbas.parts.Part.html#marks">Numbas.parts.Part#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#multCredit"><a href="Numbas.parts.Part.html#multCredit">Numbas.parts.Part#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#name"><a href="Numbas.parts.Part.html#name">Numbas.parts.Part#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#openSteps"><a href="Numbas.parts.Part.html#openSteps">Numbas.parts.Part#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#parentPart"><a href="Numbas.parts.Part.html#parentPart">Numbas.parts.Part#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#path"><a href="Numbas.parts.Part.html#path">Numbas.parts.Part#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#pleaseResubmit"><a href="Numbas.parts.Part.html#pleaseResubmit">Numbas.parts.Part#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#question"><a href="Numbas.parts.Part_.html#question">Numbas.parts.Part#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#rawStudentAnswerAsJME"><a href="Numbas.parts.Part_.html#rawStudentAnswerAsJME">Numbas.parts.Part#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#removeWarnings"><a href="Numbas.parts.Part_.html#removeWarnings">Numbas.parts.Part#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#resume"><a href="Numbas.parts.Part_.html#resume">Numbas.parts.Part#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#revealAnswer"><a href="Numbas.parts.Part_.html#revealAnswer">Numbas.parts.Part#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#score"><a href="Numbas.parts.Part_.html#score">Numbas.parts.Part#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setCredit"><a href="Numbas.parts.Part_.html#setCredit">Numbas.parts.Part#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setDirty"><a href="Numbas.parts.Part_.html#setDirty">Numbas.parts.Part#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setMarkingScript"><a href="Numbas.parts.Part_.html#setMarkingScript">Numbas.parts.Part#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setScript"><a href="Numbas.parts.Part_.html#setScript">Numbas.parts.Part#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setStudentAnswer"><a href="Numbas.parts.Part_.html#setStudentAnswer">Numbas.parts.Part#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#settings"><a href="Numbas.parts.Part_.html#settings">Numbas.parts.Part#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setWarnings"><a href="Numbas.parts.Part_.html#setWarnings">Numbas.parts.Part#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#shouldResubmit"><a href="Numbas.parts.Part_.html#shouldResubmit">Numbas.parts.Part#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#showSteps"><a href="Numbas.parts.Part_.html#showSteps">Numbas.parts.Part#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stagedAnswer"><a href="Numbas.parts.Part_.html#stagedAnswer">Numbas.parts.Part#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#steps"><a href="Numbas.parts.Part_.html#steps">Numbas.parts.Part#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsMarks"><a href="Numbas.parts.Part_.html#stepsMarks">Numbas.parts.Part#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsOpen"><a href="Numbas.parts.Part_.html#stepsOpen">Numbas.parts.Part#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsShown"><a href="Numbas.parts.Part_.html#stepsShown">Numbas.parts.Part#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#store"><a href="Numbas.parts.Part_.html#store">Numbas.parts.Part#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#storeAnswer"><a href="Numbas.parts.Part_.html#storeAnswer">Numbas.parts.Part#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#studentAnswerAsJME"><a href="Numbas.parts.Part_.html#studentAnswerAsJME">Numbas.parts.Part#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#subCredit"><a href="Numbas.parts.Part_.html#subCredit">Numbas.parts.Part#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#submit"><a href="Numbas.parts.Part_.html#submit">Numbas.parts.Part#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#type"><a href="Numbas.parts.Part_.html#type">Numbas.parts.Part#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#useCustomName"><a href="Numbas.parts.Part_.html#useCustomName">Numbas.parts.Part#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#warnings"><a href="Numbas.parts.Part_.html#warnings">Numbas.parts.Part#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#xml"><a href="Numbas.parts.Part_.html#xml">Numbas.parts.Part#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.partpath"><a href="Numbas.parts.html#.partpath">Numbas.parts.partpath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart"><a href="Numbas.parts.PatternMatchPart.html">Numbas.parts.PatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addCredit"><a href="Numbas.parts.PatternMatchPart.html#addCredit">Numbas.parts.PatternMatchPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addStep"><a href="Numbas.parts.PatternMatchPart.html#addStep">Numbas.parts.PatternMatchPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addVariableReplacement"><a href="Numbas.parts.PatternMatchPart.html#addVariableReplacement">Numbas.parts.PatternMatchPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#answered"><a href="Numbas.parts.PatternMatchPart.html#answered">Numbas.parts.PatternMatchPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#apply_feedback"><a href="Numbas.parts.PatternMatchPart.html#apply_feedback">Numbas.parts.PatternMatchPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#applyScoreLimits"><a href="Numbas.parts.PatternMatchPart.html#applyScoreLimits">Numbas.parts.PatternMatchPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#assignName"><a href="Numbas.parts.PatternMatchPart.html#assignName">Numbas.parts.PatternMatchPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#baseMarkingScript"><a href="Numbas.parts.PatternMatchPart.html#baseMarkingScript">Numbas.parts.PatternMatchPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#calculateScore"><a href="Numbas.parts.PatternMatchPart.html#calculateScore">Numbas.parts.PatternMatchPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#creditFraction"><a href="Numbas.parts.PatternMatchPart.html#creditFraction">Numbas.parts.PatternMatchPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#customName"><a href="Numbas.parts.PatternMatchPart.html#customName">Numbas.parts.PatternMatchPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#display"><a href="Numbas.parts.PatternMatchPart.html#display">Numbas.parts.PatternMatchPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#doesMarking"><a href="Numbas.parts.PatternMatchPart.html#doesMarking">Numbas.parts.PatternMatchPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#error"><a href="Numbas.parts.PatternMatchPart.html#error">Numbas.parts.PatternMatchPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#errorCarriedForwardScope"><a href="Numbas.parts.PatternMatchPart.html#errorCarriedForwardScope">Numbas.parts.PatternMatchPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#finalised_result"><a href="Numbas.parts.PatternMatchPart.html#finalised_result">Numbas.parts.PatternMatchPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#finaliseLoad"><a href="Numbas.parts.PatternMatchPart.html#finaliseLoad">Numbas.parts.PatternMatchPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#gaps"><a href="Numbas.parts.PatternMatchPart.html#gaps">Numbas.parts.PatternMatchPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#getCorrectAnswer"><a href="Numbas.parts.PatternMatchPart.html#getCorrectAnswer">Numbas.parts.PatternMatchPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#getScope"><a href="Numbas.parts.PatternMatchPart.html#getScope">Numbas.parts.PatternMatchPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#giveWarning"><a href="Numbas.parts.PatternMatchPart.html#giveWarning">Numbas.parts.PatternMatchPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#hasStagedAnswer"><a href="Numbas.parts.PatternMatchPart.html#hasStagedAnswer">Numbas.parts.PatternMatchPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#hideSteps"><a href="Numbas.parts.PatternMatchPart.html#hideSteps">Numbas.parts.PatternMatchPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#input_options"><a href="Numbas.parts.PatternMatchPart.html#input_options">Numbas.parts.PatternMatchPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#input_widget"><a href="Numbas.parts.PatternMatchPart.html#input_widget">Numbas.parts.PatternMatchPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#isDirty"><a href="Numbas.parts.PatternMatchPart.html#isDirty">Numbas.parts.PatternMatchPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#loadFromJSON"><a href="Numbas.parts.PatternMatchPart.html#loadFromJSON">Numbas.parts.PatternMatchPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#loadFromXML"><a href="Numbas.parts.PatternMatchPart.html#loadFromXML">Numbas.parts.PatternMatchPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#mark"><a href="Numbas.parts.PatternMatchPart.html#mark">Numbas.parts.PatternMatchPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#mark_answer"><a href="Numbas.parts.PatternMatchPart.html#mark_answer">Numbas.parts.PatternMatchPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markAgainstScope"><a href="Numbas.parts.PatternMatchPart.html#markAgainstScope">Numbas.parts.PatternMatchPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingComment"><a href="Numbas.parts.PatternMatchPart.html#markingComment">Numbas.parts.PatternMatchPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingFeedback"><a href="Numbas.parts.PatternMatchPart.html#markingFeedback">Numbas.parts.PatternMatchPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingScript"><a href="Numbas.parts.PatternMatchPart.html#markingScript">Numbas.parts.PatternMatchPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#marks"><a href="Numbas.parts.PatternMatchPart.html#marks">Numbas.parts.PatternMatchPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#multCredit"><a href="Numbas.parts.PatternMatchPart.html#multCredit">Numbas.parts.PatternMatchPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#name"><a href="Numbas.parts.PatternMatchPart.html#name">Numbas.parts.PatternMatchPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#openSteps"><a href="Numbas.parts.PatternMatchPart.html#openSteps">Numbas.parts.PatternMatchPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#parentPart"><a href="Numbas.parts.PatternMatchPart.html#parentPart">Numbas.parts.PatternMatchPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#path"><a href="Numbas.parts.PatternMatchPart.html#path">Numbas.parts.PatternMatchPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#pleaseResubmit"><a href="Numbas.parts.PatternMatchPart.html#pleaseResubmit">Numbas.parts.PatternMatchPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#question"><a href="Numbas.parts.PatternMatchPart.html#question">Numbas.parts.PatternMatchPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#rawStudentAnswerAsJME"><a href="Numbas.parts.PatternMatchPart.html#rawStudentAnswerAsJME">Numbas.parts.PatternMatchPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#removeWarnings"><a href="Numbas.parts.PatternMatchPart.html#removeWarnings">Numbas.parts.PatternMatchPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#resume"><a href="Numbas.parts.PatternMatchPart.html#resume">Numbas.parts.PatternMatchPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#revealAnswer"><a href="Numbas.parts.PatternMatchPart.html#revealAnswer">Numbas.parts.PatternMatchPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#score"><a href="Numbas.parts.PatternMatchPart.html#score">Numbas.parts.PatternMatchPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setCredit"><a href="Numbas.parts.PatternMatchPart.html#setCredit">Numbas.parts.PatternMatchPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setDirty"><a href="Numbas.parts.PatternMatchPart.html#setDirty">Numbas.parts.PatternMatchPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setMarkingScript"><a href="Numbas.parts.PatternMatchPart.html#setMarkingScript">Numbas.parts.PatternMatchPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setScript"><a href="Numbas.parts.PatternMatchPart.html#setScript">Numbas.parts.PatternMatchPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setStudentAnswer"><a href="Numbas.parts.PatternMatchPart.html#setStudentAnswer">Numbas.parts.PatternMatchPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#settings"><a href="Numbas.parts.PatternMatchPart.html#settings">Numbas.parts.PatternMatchPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setWarnings"><a href="Numbas.parts.PatternMatchPart.html#setWarnings">Numbas.parts.PatternMatchPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#shouldResubmit"><a href="Numbas.parts.PatternMatchPart.html#shouldResubmit">Numbas.parts.PatternMatchPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#showSteps"><a href="Numbas.parts.PatternMatchPart.html#showSteps">Numbas.parts.PatternMatchPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stagedAnswer"><a href="Numbas.parts.PatternMatchPart.html#stagedAnswer">Numbas.parts.PatternMatchPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#steps"><a href="Numbas.parts.PatternMatchPart.html#steps">Numbas.parts.PatternMatchPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsMarks"><a href="Numbas.parts.PatternMatchPart.html#stepsMarks">Numbas.parts.PatternMatchPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsOpen"><a href="Numbas.parts.PatternMatchPart.html#stepsOpen">Numbas.parts.PatternMatchPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsShown"><a href="Numbas.parts.PatternMatchPart.html#stepsShown">Numbas.parts.PatternMatchPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#store"><a href="Numbas.parts.PatternMatchPart.html#store">Numbas.parts.PatternMatchPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#storeAnswer"><a href="Numbas.parts.PatternMatchPart.html#storeAnswer">Numbas.parts.PatternMatchPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#studentAnswerAsJME"><a href="Numbas.parts.PatternMatchPart.html#studentAnswerAsJME">Numbas.parts.PatternMatchPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#subCredit"><a href="Numbas.parts.PatternMatchPart.html#subCredit">Numbas.parts.PatternMatchPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#submit"><a href="Numbas.parts.PatternMatchPart.html#submit">Numbas.parts.PatternMatchPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#type"><a href="Numbas.parts.PatternMatchPart.html#type">Numbas.parts.PatternMatchPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#useCustomName"><a href="Numbas.parts.PatternMatchPart.html#useCustomName">Numbas.parts.PatternMatchPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#warnings"><a href="Numbas.parts.PatternMatchPart.html#warnings">Numbas.parts.PatternMatchPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#xml"><a href="Numbas.parts.PatternMatchPart.html#xml">Numbas.parts.PatternMatchPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart"><a href="Numbas.PatternMatchPart.html">Numbas.PatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#baseMarkingScript"><a href="Numbas.PatternMatchPart.html#baseMarkingScript">Numbas.PatternMatchPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#getCorrectAnswer"><a href="Numbas.PatternMatchPart.html#getCorrectAnswer">Numbas.PatternMatchPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#input_options"><a href="Numbas.PatternMatchPart.html#input_options">Numbas.PatternMatchPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#input_widget"><a href="Numbas.PatternMatchPart.html#input_widget">Numbas.PatternMatchPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#rawStudentAnswerAsJME"><a href="Numbas.PatternMatchPart.html#rawStudentAnswerAsJME">Numbas.PatternMatchPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#setStudentAnswer"><a href="Numbas.PatternMatchPart.html#setStudentAnswer">Numbas.PatternMatchPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#settings"><a href="Numbas.PatternMatchPart.html#settings">Numbas.PatternMatchPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#studentAnswer"><a href="Numbas.PatternMatchPart.html#studentAnswer">Numbas.PatternMatchPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question"><a href="Numbas.Question.html">Numbas.Question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#addPart"><a href="Numbas.Question.html#addPart">Numbas.Question#addPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#adviceDisplayed"><a href="Numbas.Question.html#adviceDisplayed">Numbas.Question#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#answered"><a href="Numbas.Question.html#answered">Numbas.Question#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#calculateScore"><a href="Numbas.Question.html#calculateScore">Numbas.Question#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#callbacks"><a href="Numbas.Question.html#callbacks">Numbas.Question#callbacks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#display"><a href="Numbas.Question.html#display">Numbas.Question#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:functionsLoaded"><a href="Numbas.Question.html#event:functionsLoaded">Numbas.Question#event:functionsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:functionsMade"><a href="Numbas.Question.html#event:functionsMade">Numbas.Question#event:functionsMade</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:generateVariables"><a href="Numbas.Question.html#event:generateVariables">Numbas.Question#event:generateVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:HTMLAttached"><a href="Numbas.Question.html#event:HTMLAttached">Numbas.Question#event:HTMLAttached</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:partsGenerated"><a href="Numbas.Question.html#event:partsGenerated">Numbas.Question#event:partsGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:partsResumed"><a href="Numbas.Question.html#event:partsResumed">Numbas.Question#event:partsResumed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:preambleLoaded"><a href="Numbas.Question.html#event:preambleLoaded">Numbas.Question#event:preambleLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:preambleRun"><a href="Numbas.Question.html#event:preambleRun">Numbas.Question#event:preambleRun</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:ready"><a href="Numbas.Question.html#event:ready">Numbas.Question#event:ready</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:rulesetsLoaded"><a href="Numbas.Question.html#event:rulesetsLoaded">Numbas.Question#event:rulesetsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:rulesetsMade"><a href="Numbas.Question.html#event:rulesetsMade">Numbas.Question#event:rulesetsMade</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variableDefinitionsLoaded"><a href="Numbas.Question.html#event:variableDefinitionsLoaded">Numbas.Question#event:variableDefinitionsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variablesGenerated"><a href="Numbas.Question.html#event:variablesGenerated">Numbas.Question#event:variablesGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variablesSet"><a href="Numbas.Question.html#event:variablesSet">Numbas.Question#event:variablesSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#finaliseLoad"><a href="Numbas.Question.html#finaliseLoad">Numbas.Question#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#getAdvice"><a href="Numbas.Question.html#getAdvice">Numbas.Question#getAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#getPart"><a href="Numbas.Question.html#getPart">Numbas.Question#getPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#isDirty"><a href="Numbas.Question.html#isDirty">Numbas.Question#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#leave"><a href="Numbas.Question.html#leave">Numbas.Question#leave</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#leavingDirtyQuestion"><a href="Numbas.Question.html#leavingDirtyQuestion">Numbas.Question#leavingDirtyQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#loadFromJSON"><a href="Numbas.Question.html#loadFromJSON">Numbas.Question#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#loadFromXML"><a href="Numbas.Question.html#loadFromXML">Numbas.Question#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#marks"><a href="Numbas.Question.html#marks">Numbas.Question#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#name"><a href="Numbas.Question.html#name">Numbas.Question#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#number"><a href="Numbas.Question.html#number">Numbas.Question#number</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#onHTMLAttached"><a href="Numbas.Question.html#onHTMLAttached">Numbas.Question#onHTMLAttached</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#onVariablesGenerated"><a href="Numbas.Question.html#onVariablesGenerated">Numbas.Question#onVariablesGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#partDictionary"><a href="Numbas.Question.html#partDictionary">Numbas.Question#partDictionary</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#parts"><a href="Numbas.Question.html#parts">Numbas.Question#parts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#resume"><a href="Numbas.Question.html#resume">Numbas.Question#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#revealAnswer"><a href="Numbas.Question.html#revealAnswer">Numbas.Question#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#revealed"><a href="Numbas.Question.html#revealed">Numbas.Question#revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#runPreamble"><a href="Numbas.Question.html#runPreamble">Numbas.Question#runPreamble</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#scope"><a href="Numbas.Question.html#scope">Numbas.Question#scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#score"><a href="Numbas.Question.html#score">Numbas.Question#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#signals"><a href="Numbas.Question.html#signals">Numbas.Question#signals</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#store"><a href="Numbas.Question.html#store">Numbas.Question#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#submit"><a href="Numbas.Question.html#submit">Numbas.Question#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#submitted"><a href="Numbas.Question.html#submitted">Numbas.Question#submitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#updateScore"><a href="Numbas.Question.html#updateScore">Numbas.Question#updateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#validate"><a href="Numbas.Question.html#validate">Numbas.Question#validate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#visited"><a href="Numbas.Question.html#visited">Numbas.Question#visited</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#xml"><a href="Numbas.Question.html#xml">Numbas.Question#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup"><a href="Numbas.QuestionGroup.html">Numbas.QuestionGroup</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup#chooseQuestionSubset"><a href="Numbas.QuestionGroup.html#chooseQuestionSubset">Numbas.QuestionGroup#chooseQuestionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup#settings"><a href="Numbas.QuestionGroup.html#settings">Numbas.QuestionGroup#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.queueScript"><a href="Numbas.html#.queueScript">Numbas.queueScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.raw_marking_scripts"><a href="Numbas.html#.raw_marking_scripts">Numbas.raw_marking_scripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.rawxml"><a href="Numbas.html#.rawxml">Numbas.rawxml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule"><a href="Numbas.schedule.html">Numbas.schedule</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.add"><a href="Numbas.schedule.html#.add">Numbas.schedule.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.callback"><a href="Numbas.schedule.html#.callback">Numbas.schedule.callback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.calls"><a href="Numbas.schedule.html#.calls">Numbas.schedule.calls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.completed"><a href="Numbas.schedule.html#.completed">Numbas.schedule.completed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.drop"><a href="Numbas.schedule.html#.drop">Numbas.schedule.drop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halt"><a href="Numbas.schedule.html#.halt">Numbas.schedule.halt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halt_error"><a href="Numbas.schedule.html#.halt_error">Numbas.schedule.halt_error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halted"><a href="Numbas.schedule.html#.halted">Numbas.schedule.halted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.lift"><a href="Numbas.schedule.html#.lift">Numbas.schedule.lift</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.lifts"><a href="Numbas.schedule.html#.lifts">Numbas.schedule.lifts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.pop"><a href="Numbas.schedule.html#.pop">Numbas.schedule.pop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox"><a href="Numbas.schedule.SignalBox.html">Numbas.schedule.SignalBox</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#getCallback"><a href="Numbas.schedule.SignalBox.html#getCallback">Numbas.schedule.SignalBox#getCallback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#on"><a href="Numbas.schedule.SignalBox.html#on">Numbas.schedule.SignalBox#on</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#trigger"><a href="Numbas.schedule.SignalBox.html#trigger">Numbas.schedule.SignalBox#trigger</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.task_object"><a href="Numbas.schedule.html#.task_object">Numbas.schedule.task_object</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.total"><a href="Numbas.schedule.html#.total">Numbas.schedule.total</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath"><a href="Numbas.setmath.html">Numbas.setmath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.contains"><a href="Numbas.setmath.html#.contains">Numbas.setmath.contains</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.eq"><a href="Numbas.setmath.html#.eq">Numbas.setmath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.intersection"><a href="Numbas.setmath.html#.intersection">Numbas.setmath.intersection</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.minus"><a href="Numbas.setmath.html#.minus">Numbas.setmath.minus</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.size"><a href="Numbas.setmath.html#.size">Numbas.setmath.size</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.union"><a href="Numbas.setmath.html#.union">Numbas.setmath.union</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.showError"><a href="Numbas.html#.showError">Numbas.showError</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage"><a href="Numbas.storage.html">Numbas.storage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage"><a href="Numbas.storage.BlankStorage.html">Numbas.storage.BlankStorage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#adviceDisplayed"><a href="Numbas.storage.BlankStorage.html#adviceDisplayed">Numbas.storage.BlankStorage#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#answerRevealed"><a href="Numbas.storage.BlankStorage.html#answerRevealed">Numbas.storage.BlankStorage#answerRevealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#changeQuestion"><a href="Numbas.storage.BlankStorage.html#changeQuestion">Numbas.storage.BlankStorage#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#end"><a href="Numbas.storage.BlankStorage.html#end">Numbas.storage.BlankStorage#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getEntry"><a href="Numbas.storage.BlankStorage.html#getEntry">Numbas.storage.BlankStorage#getEntry</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getMode"><a href="Numbas.storage.BlankStorage.html#getMode">Numbas.storage.BlankStorage#getMode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getStudentID"><a href="Numbas.storage.BlankStorage.html#getStudentID">Numbas.storage.BlankStorage#getStudentID</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#init"><a href="Numbas.storage.BlankStorage.html#init">Numbas.storage.BlankStorage#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#load"><a href="Numbas.storage.BlankStorage.html#load">Numbas.storage.BlankStorage#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadExtensionPart"><a href="Numbas.storage.BlankStorage.html#loadExtensionPart">Numbas.storage.BlankStorage#loadExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadJMEPart"><a href="Numbas.storage.BlankStorage.html#loadJMEPart">Numbas.storage.BlankStorage#loadJMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadMatrixEntryPart"><a href="Numbas.storage.BlankStorage.html#loadMatrixEntryPart">Numbas.storage.BlankStorage#loadMatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadMultipleResponsePart"><a href="Numbas.storage.BlankStorage.html#loadMultipleResponsePart">Numbas.storage.BlankStorage#loadMultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadNumberEntryPart"><a href="Numbas.storage.BlankStorage.html#loadNumberEntryPart">Numbas.storage.BlankStorage#loadNumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadPart"><a href="Numbas.storage.BlankStorage.html#loadPart">Numbas.storage.BlankStorage#loadPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadPatternMatchPart"><a href="Numbas.storage.BlankStorage.html#loadPatternMatchPart">Numbas.storage.BlankStorage#loadPatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadQuestion"><a href="Numbas.storage.BlankStorage.html#loadQuestion">Numbas.storage.BlankStorage#loadQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#partAnswered"><a href="Numbas.storage.BlankStorage.html#partAnswered">Numbas.storage.BlankStorage#partAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#pause"><a href="Numbas.storage.BlankStorage.html#pause">Numbas.storage.BlankStorage#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#questionSubmitted"><a href="Numbas.storage.BlankStorage.html#questionSubmitted">Numbas.storage.BlankStorage#questionSubmitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#resume"><a href="Numbas.storage.BlankStorage.html#resume">Numbas.storage.BlankStorage#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#save"><a href="Numbas.storage.BlankStorage.html#save">Numbas.storage.BlankStorage#save</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#saveExam"><a href="Numbas.storage.BlankStorage.html#saveExam">Numbas.storage.BlankStorage#saveExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#start"><a href="Numbas.storage.BlankStorage.html#start">Numbas.storage.BlankStorage#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#stepsHidden"><a href="Numbas.storage.BlankStorage.html#stepsHidden">Numbas.storage.BlankStorage#stepsHidden</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#stepsShown"><a href="Numbas.storage.BlankStorage.html#stepsShown">Numbas.storage.BlankStorage#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.exam_suspend_data"><a href="Numbas.storage.html#.exam_suspend_data">Numbas.storage.exam_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.part_suspend_data"><a href="Numbas.storage.html#.part_suspend_data">Numbas.storage.part_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.question_suspend_data"><a href="Numbas.storage.html#.question_suspend_data">Numbas.storage.question_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage"><a href="Numbas.storage.SCORMStorage.html">Numbas.storage.SCORMStorage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#adviceDisplayed"><a href="Numbas.storage.SCORMStorage.html#adviceDisplayed">Numbas.storage.SCORMStorage#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#answerRevealed"><a href="Numbas.storage.SCORMStorage.html#answerRevealed">Numbas.storage.SCORMStorage#answerRevealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#changeQuestion"><a href="Numbas.storage.SCORMStorage.html#changeQuestion">Numbas.storage.SCORMStorage#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#end"><a href="Numbas.storage.SCORMStorage.html#end">Numbas.storage.SCORMStorage#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#exam"><a href="Numbas.storage.SCORMStorage.html#exam">Numbas.storage.SCORMStorage#exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#get"><a href="Numbas.storage.SCORMStorage.html#get">Numbas.storage.SCORMStorage#get</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#get_student_name"><a href="Numbas.storage.SCORMStorage.html#get_student_name">Numbas.storage.SCORMStorage#get_student_name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getEntry"><a href="Numbas.storage.SCORMStorage.html#getEntry">Numbas.storage.SCORMStorage#getEntry</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getMode"><a href="Numbas.storage.SCORMStorage.html#getMode">Numbas.storage.SCORMStorage#getMode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getPartId"><a href="Numbas.storage.SCORMStorage.html#getPartId">Numbas.storage.SCORMStorage#getPartId</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getQuestionId"><a href="Numbas.storage.SCORMStorage.html#getQuestionId">Numbas.storage.SCORMStorage#getQuestionId</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getStudentID"><a href="Numbas.storage.SCORMStorage.html#getStudentID">Numbas.storage.SCORMStorage#getStudentID</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getSuspendData"><a href="Numbas.storage.SCORMStorage.html#getSuspendData">Numbas.storage.SCORMStorage#getSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#init"><a href="Numbas.storage.SCORMStorage.html#init">Numbas.storage.SCORMStorage#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#initPart"><a href="Numbas.storage.SCORMStorage.html#initPart">Numbas.storage.SCORMStorage#initPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#initQuestion"><a href="Numbas.storage.SCORMStorage.html#initQuestion">Numbas.storage.SCORMStorage#initQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#lmsConnected"><a href="Numbas.storage.SCORMStorage.html#lmsConnected">Numbas.storage.SCORMStorage#lmsConnected</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#load"><a href="Numbas.storage.SCORMStorage.html#load">Numbas.storage.SCORMStorage#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadExtensionPart"><a href="Numbas.storage.SCORMStorage.html#loadExtensionPart">Numbas.storage.SCORMStorage#loadExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadJMEPart"><a href="Numbas.storage.SCORMStorage.html#loadJMEPart">Numbas.storage.SCORMStorage#loadJMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadMatrixEntryPart"><a href="Numbas.storage.SCORMStorage.html#loadMatrixEntryPart">Numbas.storage.SCORMStorage#loadMatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadMultipleResponsePart"><a href="Numbas.storage.SCORMStorage.html#loadMultipleResponsePart">Numbas.storage.SCORMStorage#loadMultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadNumberEntryPart"><a href="Numbas.storage.SCORMStorage.html#loadNumberEntryPart">Numbas.storage.SCORMStorage#loadNumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadPart"><a href="Numbas.storage.SCORMStorage.html#loadPart">Numbas.storage.SCORMStorage#loadPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadPatternMatchPart"><a href="Numbas.storage.SCORMStorage.html#loadPatternMatchPart">Numbas.storage.SCORMStorage#loadPatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadQuestion"><a href="Numbas.storage.SCORMStorage.html#loadQuestion">Numbas.storage.SCORMStorage#loadQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#mode"><a href="Numbas.storage.SCORMStorage.html#mode">Numbas.storage.SCORMStorage#mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partAnswered"><a href="Numbas.storage.SCORMStorage.html#partAnswered">Numbas.storage.SCORMStorage#partAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partIndices"><a href="Numbas.storage.SCORMStorage.html#partIndices">Numbas.storage.SCORMStorage#partIndices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partSuspendData"><a href="Numbas.storage.SCORMStorage.html#partSuspendData">Numbas.storage.SCORMStorage#partSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#pause"><a href="Numbas.storage.SCORMStorage.html#pause">Numbas.storage.SCORMStorage#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionIndices"><a href="Numbas.storage.SCORMStorage.html#questionIndices">Numbas.storage.SCORMStorage#questionIndices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionSubmitted"><a href="Numbas.storage.SCORMStorage.html#questionSubmitted">Numbas.storage.SCORMStorage#questionSubmitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionSuspendData"><a href="Numbas.storage.SCORMStorage.html#questionSuspendData">Numbas.storage.SCORMStorage#questionSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#resume"><a href="Numbas.storage.SCORMStorage.html#resume">Numbas.storage.SCORMStorage#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#save"><a href="Numbas.storage.SCORMStorage.html#save">Numbas.storage.SCORMStorage#save</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#saveExam"><a href="Numbas.storage.SCORMStorage.html#saveExam">Numbas.storage.SCORMStorage#saveExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#saveQuestion"><a href="Numbas.storage.SCORMStorage.html#saveQuestion">Numbas.storage.SCORMStorage#saveQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#set"><a href="Numbas.storage.SCORMStorage.html#set">Numbas.storage.SCORMStorage#set</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#setSessionTime"><a href="Numbas.storage.SCORMStorage.html#setSessionTime">Numbas.storage.SCORMStorage#setSessionTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#setSuspendData"><a href="Numbas.storage.SCORMStorage.html#setSuspendData">Numbas.storage.SCORMStorage#setSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#start"><a href="Numbas.storage.SCORMStorage.html#start">Numbas.storage.SCORMStorage#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#stepsHidden"><a href="Numbas.storage.SCORMStorage.html#stepsHidden">Numbas.storage.SCORMStorage#stepsHidden</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#stepsShown"><a href="Numbas.storage.SCORMStorage.html#stepsShown">Numbas.storage.SCORMStorage#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#suspendData"><a href="Numbas.storage.SCORMStorage.html#suspendData">Numbas.storage.SCORMStorage#suspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.store"><a href="Numbas.html#.store">Numbas.store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing"><a href="Numbas.timing.html">Numbas.timing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.accs"><a href="Numbas.timing.html#.accs">Numbas.timing.accs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.displayDate"><a href="Numbas.timing.html#.displayDate">Numbas.timing.displayDate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.end"><a href="Numbas.timing.html#.end">Numbas.timing.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.endacc"><a href="Numbas.timing.html#.endacc">Numbas.timing.endacc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.messages"><a href="Numbas.timing.html#.messages">Numbas.timing.messages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.secsToDisplayTime"><a href="Numbas.timing.html#.secsToDisplayTime">Numbas.timing.secsToDisplayTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.show"><a href="Numbas.timing.html#.show">Numbas.timing.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.start"><a href="Numbas.timing.html#.start">Numbas.timing.start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.startacc"><a href="Numbas.timing.html#.startacc">Numbas.timing.startacc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.stress"><a href="Numbas.timing.html#.stress">Numbas.timing.stress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.timers"><a href="Numbas.timing.html#.timers">Numbas.timing.timers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.tryInit"><a href="Numbas.html#.tryInit">Numbas.tryInit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util"><a href="Numbas.util.html">Numbas.util</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.arraysEqual"><a href="Numbas.util.html#.arraysEqual">Numbas.util.arraysEqual</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.capitalise"><a href="Numbas.util.html#.capitalise">Numbas.util.capitalise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.cartesian_power"><a href="Numbas.util.html#.cartesian_power">Numbas.util.cartesian_power</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.cleanNumber"><a href="Numbas.util.html#.cleanNumber">Numbas.util.cleanNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.combinations"><a href="Numbas.util.html#.combinations">Numbas.util.combinations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.combinations_with_replacement"><a href="Numbas.util.html#.combinations_with_replacement">Numbas.util.combinations_with_replacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.contains"><a href="Numbas.util.html#.contains">Numbas.util.contains</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.contentsplitbrackets"><a href="Numbas.util.html#.contentsplitbrackets">Numbas.util.contentsplitbrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyarray"><a href="Numbas.util.html#.copyarray">Numbas.util.copyarray</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyinto"><a href="Numbas.util.html#.copyinto">Numbas.util.copyinto</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyobj"><a href="Numbas.util.html#.copyobj">Numbas.util.copyobj</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.currency"><a href="Numbas.util.html#.currency">Numbas.util.currency</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.distinct"><a href="Numbas.util.html#.distinct">Numbas.util.distinct</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.eq"><a href="Numbas.util.html#.eq">Numbas.util.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.equalityTests"><a href="Numbas.util.html#.equalityTests">Numbas.util.equalityTests</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.escapeHTML"><a href="Numbas.util.html#.escapeHTML">Numbas.util.escapeHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.except"><a href="Numbas.util.html#.except">Numbas.util.except</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.extend"><a href="Numbas.util.html#.extend">Numbas.util.extend</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.extend_object"><a href="Numbas.util.html#.extend_object">Numbas.util.extend_object</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.formatString"><a href="Numbas.util.html#.formatString">Numbas.util.formatString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.formatTime"><a href="Numbas.util.html#.formatTime">Numbas.util.formatTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.hashCode"><a href="Numbas.util.html#.hashCode">Numbas.util.hashCode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isBool"><a href="Numbas.util.html#.isBool">Numbas.util.isBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isFloat"><a href="Numbas.util.html#.isFloat">Numbas.util.isFloat</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isFraction"><a href="Numbas.util.html#.isFraction">Numbas.util.isFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isInt"><a href="Numbas.util.html#.isInt">Numbas.util.isInt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isNonemptyHTML"><a href="Numbas.util.html#.isNonemptyHTML">Numbas.util.isNonemptyHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isNumber"><a href="Numbas.util.html#.isNumber">Numbas.util.isNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.letterOrdinal"><a href="Numbas.util.html#.letterOrdinal">Numbas.util.letterOrdinal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.lpad"><a href="Numbas.util.html#.lpad">Numbas.util.lpad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.matchNotationStyle"><a href="Numbas.util.html#.matchNotationStyle">Numbas.util.matchNotationStyle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.neq"><a href="Numbas.util.html#.neq">Numbas.util.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.nicePartName"><a href="Numbas.util.html#.nicePartName">Numbas.util.nicePartName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.numberNotationStyles"><a href="Numbas.util.html#.numberNotationStyles">Numbas.util.numberNotationStyles</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.objects_equal"><a href="Numbas.util.html#.objects_equal">Numbas.util.objects_equal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseBool"><a href="Numbas.util.html#.parseBool">Numbas.util.parseBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseDecimal"><a href="Numbas.util.html#.parseDecimal">Numbas.util.parseDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseFraction"><a href="Numbas.util.html#.parseFraction">Numbas.util.parseFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseNumber"><a href="Numbas.util.html#.parseNumber">Numbas.util.parseNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.permutations"><a href="Numbas.util.html#.permutations">Numbas.util.permutations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.pluralise"><a href="Numbas.util.html#.pluralise">Numbas.util.pluralise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.product"><a href="Numbas.util.html#.product">Numbas.util.product</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.re_fraction"><a href="Numbas.util.html#.re_fraction">Numbas.util.re_fraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.rpad"><a href="Numbas.util.html#.rpad">Numbas.util.rpad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.separateThousands"><a href="Numbas.util.html#.separateThousands">Numbas.util.separateThousands</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.sortBy"><a href="Numbas.util.html#.sortBy">Numbas.util.sortBy</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.splitbrackets"><a href="Numbas.util.html#.splitbrackets">Numbas.util.splitbrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.standardNumberFormatter"><a href="Numbas.util.html#.standardNumberFormatter">Numbas.util.standardNumberFormatter</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.unPercent"><a href="Numbas.util.html#.unPercent">Numbas.util.unPercent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.wrapListIndex"><a href="Numbas.util.html#.wrapListIndex">Numbas.util.wrapListIndex</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.zip"><a href="Numbas.util.html#.zip">Numbas.util.zip</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath"><a href="Numbas.vectormath.html">Numbas.vectormath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.abs"><a href="Numbas.vectormath.html#.abs">Numbas.vectormath.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.abs_squared"><a href="Numbas.vectormath.html#.abs_squared">Numbas.vectormath.abs_squared</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.add"><a href="Numbas.vectormath.html#.add">Numbas.vectormath.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.angle"><a href="Numbas.vectormath.html#.angle">Numbas.vectormath.angle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.cross"><a href="Numbas.vectormath.html#.cross">Numbas.vectormath.cross</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.div"><a href="Numbas.vectormath.html#.div">Numbas.vectormath.div</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.dot"><a href="Numbas.vectormath.html#.dot">Numbas.vectormath.dot</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.eq"><a href="Numbas.vectormath.html#.eq">Numbas.vectormath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.is_zero"><a href="Numbas.vectormath.html#.is_zero">Numbas.vectormath.is_zero</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.map"><a href="Numbas.vectormath.html#.map">Numbas.vectormath.map</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.matrixmul"><a href="Numbas.vectormath.html#.matrixmul">Numbas.vectormath.matrixmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.mul"><a href="Numbas.vectormath.html#.mul">Numbas.vectormath.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.negate"><a href="Numbas.vectormath.html#.negate">Numbas.vectormath.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.neq"><a href="Numbas.vectormath.html#.neq">Numbas.vectormath.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.precround"><a href="Numbas.vectormath.html#.precround">Numbas.vectormath.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.siground"><a href="Numbas.vectormath.html#.siground">Numbas.vectormath.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.sub"><a href="Numbas.vectormath.html#.sub">Numbas.vectormath.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.toMatrix"><a href="Numbas.vectormath.html#.toMatrix">Numbas.vectormath.toMatrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.transpose"><a href="Numbas.vectormath.html#.transpose">Numbas.vectormath.transpose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.vectormatrixmul"><a href="Numbas.vectormath.html#.vectormatrixmul">Numbas.vectormath.vectormatrixmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml"><a href="Numbas.xml.html">Numbas.xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.examXML"><a href="Numbas.xml.html#.examXML">Numbas.xml.examXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.getTextContent"><a href="Numbas.xml.html#.getTextContent">Numbas.xml.getTextContent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.isEmpty"><a href="Numbas.xml.html#.isEmpty">Numbas.xml.isEmpty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadFunctions"><a href="Numbas.xml.html#.loadFunctions">Numbas.xml.loadFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadVariables"><a href="Numbas.xml.html#.loadVariables">Numbas.xml.loadVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadXML"><a href="Numbas.xml.html#.loadXML">Numbas.xml.loadXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadXMLDocs"><a href="Numbas.xml.html#.loadXMLDocs">Numbas.xml.loadXMLDocs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.localise"><a href="Numbas.xml.html#.localise">Numbas.xml.localise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.serializeMessage"><a href="Numbas.xml.html#.serializeMessage">Numbas.xml.serializeMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.setTextContent"><a href="Numbas.xml.html#.setTextContent">Numbas.xml.setTextContent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.templates"><a href="Numbas.xml.html#.templates">Numbas.xml.templates</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.tryGetAttribute"><a href="Numbas.xml.html#.tryGetAttribute">Numbas.xml.tryGetAttribute</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.tryGetAttribute_options"><a href="Numbas.xml.html#.tryGetAttribute_options">Numbas.xml.tryGetAttribute_options</a></li>
-		
+
 			<li class="search-result" data-longname="package:undefined"><a href="global.html#package:">package:undefined</a></li>
-		
+
 			<li class="search-result" data-longname="range"><a href="global.html#range">range</a></li>
-		
+
 			<li class="search-result" data-longname="RequireScript"><a href="RequireScript.html">RequireScript</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/controls.js"><a href="global.html#runtime/scripts/controls.js">runtime/scripts/controls.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/exam.js"><a href="global.html#runtime/scripts/exam.js">runtime/scripts/exam.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme.js"><a href="global.html#runtime/scripts/jme.js">runtime/scripts/jme.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-builtins.js"><a href="global.html#runtime/scripts/jme-builtins.js">runtime/scripts/jme-builtins.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-display.js"><a href="global.html#runtime/scripts/jme-display.js">runtime/scripts/jme-display.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-rules.js"><a href="global.html#runtime/scripts/jme-rules.js">runtime/scripts/jme-rules.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-variables.js"><a href="global.html#runtime/scripts/jme-variables.js">runtime/scripts/jme-variables.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/json.js"><a href="global.html#runtime/scripts/json.js">runtime/scripts/json.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/math.js"><a href="global.html#runtime/scripts/math.js">runtime/scripts/math.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/numbas.js"><a href="global.html#runtime/scripts/numbas.js">runtime/scripts/numbas.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/part.js"><a href="global.html#runtime/scripts/part.js">runtime/scripts/part.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/custom_part_type.js"><a href="global.html#runtime/scripts/parts/custom_part_type.js">runtime/scripts/parts/custom_part_type.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/extension.js"><a href="global.html#runtime/scripts/parts/extension.js">runtime/scripts/parts/extension.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/gapfill.js"><a href="global.html#runtime/scripts/parts/gapfill.js">runtime/scripts/parts/gapfill.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/information.js"><a href="global.html#runtime/scripts/parts/information.js">runtime/scripts/parts/information.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/jme.js"><a href="global.html#runtime/scripts/parts/jme.js">runtime/scripts/parts/jme.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/matrixentry.js"><a href="global.html#runtime/scripts/parts/matrixentry.js">runtime/scripts/parts/matrixentry.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/multipleresponse.js"><a href="global.html#runtime/scripts/parts/multipleresponse.js">runtime/scripts/parts/multipleresponse.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/numberentry.js"><a href="global.html#runtime/scripts/parts/numberentry.js">runtime/scripts/parts/numberentry.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/patternmatch.js"><a href="global.html#runtime/scripts/parts/patternmatch.js">runtime/scripts/parts/patternmatch.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/question.js"><a href="global.html#runtime/scripts/question.js">runtime/scripts/question.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/schedule.js"><a href="global.html#runtime/scripts/schedule.js">runtime/scripts/schedule.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/scorm-storage.js"><a href="global.html#runtime/scripts/scorm-storage.js">runtime/scripts/scorm-storage.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/start-exam.js"><a href="global.html#runtime/scripts/start-exam.js">runtime/scripts/start-exam.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/timing.js"><a href="global.html#runtime/scripts/timing.js">runtime/scripts/timing.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/util.js"><a href="global.html#runtime/scripts/util.js">runtime/scripts/util.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/xml.js"><a href="global.html#runtime/scripts/xml.js">runtime/scripts/xml.js</a></li>
-		
+
 			<li class="search-result" data-longname="set"><a href="global.html#set">set</a></li>
-		
+
 			<li class="search-result" data-longname="TeX"><a href="global.html#TeX">TeX</a></li>
-		
+
 			<li class="search-result" data-longname="themes/default/files/scripts/display.js"><a href="global.html#themes/default/files/scripts/display.js">themes/default/files/scripts/display.js</a></li>
-		
+
 			<li class="search-result" data-longname="vector"><a href="global.html#vector">vector</a></li>
-		
+
 			<li class="search-result" data-longname="viewModel"><a href="viewModel.html">viewModel</a></li>
-		
+
 			<li class="search-result" data-longname="Number"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></li>
-		
+
 			<li class="search-result" data-longname="String"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></li>
-		
+
 			<li class="search-result" data-longname="RegExp"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a></li>
-		
+
 			<li class="search-result" data-longname="Date"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a></li>
-		
+
 			<li class="search-result" data-longname="Element"><a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a></li>
-		
+
 			<li class="search-result" data-longname="observable"><a href="http://knockoutjs.com/documentation/observables.html">observable</a></li>
-		
+
 			<li class="search-result" data-longname="jQuery"><a href="http://api.jquery.com/Types/#jQuery">jQuery</a></li>
-		
+
 			<li class="search-result" data-longname="Error"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a></li>
-		
+
 			<li class="search-result" data-longname="Boolean"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></li>
-		
+
 			<li class="search-result" data-longname="Array"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></li>
-		
+
 			<li class="search-result" data-longname="function"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></li>
-		
+
 			<li class="search-result" data-longname="XMLDocument"><a href="https://developer.mozilla.org/en/docs/Web/API/XMLDocument">XMLDocument</a></li>
-		
+
 			<li class="search-result" data-longname="Object"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></li>
-		
+
 	</ul>
 </div>
 <div class="main-nav-item"><h3>Namespaces</h3><ul><li><a href="Numbas.html">Numbas</a></li><li><a href="Numbas.controls.html">Numbas.controls</a></li><li><a href="Numbas.display.html">Numbas.display</a></li><li><a href="Numbas.jme.html">Numbas.jme</a></li><li><a href="Numbas.jme.display.html">Numbas.jme.display</a></li><li><a href="Numbas.jme.rules.html">Numbas.jme.rules</a></li><li><a href="Numbas.jme.types.html">Numbas.jme.types</a></li><li><a href="Numbas.jme.variables.html">Numbas.jme.variables</a></li><li><a href="Numbas.json.html">Numbas.json</a></li><li><a href="Numbas.marking.html">Numbas.marking</a></li><li><a href="Numbas.math.html">Numbas.math</a></li><li><a href="Numbas.matrixmath.html">Numbas.matrixmath</a></li><li><a href="Numbas.parts.html">Numbas.parts</a></li><li><a href="Numbas.schedule.html">Numbas.schedule</a></li><li><a href="Numbas.setmath.html">Numbas.setmath</a></li><li><a href="Numbas.storage.html">Numbas.storage</a></li><li><a href="Numbas.timing.html">Numbas.timing</a></li><li><a href="Numbas.util.html">Numbas.util</a></li><li><a href="Numbas.vectormath.html">Numbas.vectormath</a></li><li><a href="Numbas.xml.html">Numbas.xml</a></li></ul></div><div class="main-nav-item"><h3>Classes</h3><ul><li><a href="Numbas.storage.BlankStorage.html">BlankStorage</a></li><li><a href="Numbas.math.ComplexDecimal.html">ComplexDecimal</a></li><li><a href="Numbas.parts.CustomPart.html">CustomPart</a></li><li><a href="Numbas.jme.variables.DOMcontentsubber.html">DOMcontentsubber</a></li><li><a href="Numbas.Error.html">Error</a></li><li><a href="Numbas.Exam.html">Exam</a></li><li><a href="Numbas.display.ExamDisplay.html">ExamDisplay</a></li><li><a href="Numbas.ExamEvent.html">ExamEvent</a></li><li><a href="Numbas.parts.ExtensionPart.html">ExtensionPart</a></li><li><a href="Numbas.math.Fraction.html">Fraction</a></li><li><a href="Numbas.jme.funcObj.html">funcObj</a></li><li><a href="Numbas.parts.GapFillPart.html">GapFillPart</a></li><li><a href="Numbas.parts.InformationPart.html">InformationPart</a></li><li><a href="Numbas.parts.JMEPart.html">JMEPart</a></li><li><a href="Numbas.marking.MarkingNote.html">MarkingNote</a></li><li><a href="Numbas.marking.MarkingScript.html">MarkingScript</a></li><li><a href="Numbas.parts.MatrixEntryPart.html">MatrixEntryPart</a></li><li><a href="Numbas.parts.MultipleResponsePart.html">MultipleResponsePart</a></li><li><a href="Numbas.parts.NumberEntryPart.html">NumberEntryPart</a></li><li><a href="Numbas.jme.Parser.html">Parser</a></li><li><a href="Numbas.parts.Part_.html">Part</a></li><li><a href="Numbas.display.PartDisplay.html">PartDisplay</a></li><li><a href="Numbas.parts.PatternMatchPart.html">PatternMatchPart</a></li><li><a href="Numbas.Question.html">Question</a></li><li><a href="Numbas.display.QuestionDisplay.html">QuestionDisplay</a></li><li><a href="Numbas.QuestionGroup.html">QuestionGroup</a></li><li><a href="RequireScript.html">RequireScript</a></li><li><a href="Numbas.jme.rules.Rule.html">Rule</a></li><li><a href="Numbas.jme.rules.Ruleset.html">Ruleset</a></li><li><a href="Numbas.jme.Scope.html">Scope</a></li><li><a href="Numbas.storage.SCORMStorage.html">SCORMStorage</a></li><li><a href="Numbas.schedule.SignalBox.html">SignalBox</a></li><li><a href="Numbas.marking.StatefulScope.html">StatefulScope</a></li><li><a href="Numbas.jme.types.TBool.html">TBool</a></li><li><a href="Numbas.jme.types.TDict.html">TDict</a></li><li><a href="Numbas.jme.types.TExpression.html">TExpression</a></li><li><a href="Numbas.jme.types.TFunc.html">TFunc</a></li><li><a href="Numbas.jme.types.THTML.html">THTML</a></li><li><a href="Numbas.jme.types.TKeyPair.html">TKeyPair</a></li><li><a href="Numbas.jme.types.TList.html">TList</a></li><li><a href="Numbas.jme.types.TMatrix.html">TMatrix</a></li><li><a href="Numbas.jme.types.TName.html">TName</a></li><li><a href="Numbas.jme.types.TNothing.html">TNothing</a></li><li><a href="Numbas.jme.types.TNum.html">TNum</a></li><li><a href="Numbas.jme.types.TOp.html">TOp</a></li><li><a href="Numbas.jme.types.TPunc.html">TPunc</a></li><li><a href="Numbas.jme.types.TRange.html">TRange</a></li><li><a href="Numbas.jme.types.TSet.html">TSet</a></li><li><a href="Numbas.jme.types.TString.html">TString</a></li><li><a href="Numbas.jme.types.TVector.html">TVector</a></li></ul></div><div class="main-nav-item"><h3>Events</h3><ul><li><a href="Numbas.Question.html#event:functionsLoaded">functionsLoaded</a></li><li><a href="Numbas.Question.html#event:functionsMade">functionsMade</a></li><li><a href="Numbas.Question.html#event:generateVariables">generateVariables</a></li><li><a href="Numbas.Question.html#event:HTMLAttached">HTMLAttached</a></li><li><a href="Numbas.Question.html#event:partsGenerated">partsGenerated</a></li><li><a href="Numbas.Question.html#event:partsResumed">partsResumed</a></li><li><a href="Numbas.Question.html#event:preambleLoaded">preambleLoaded</a></li><li><a href="Numbas.Question.html#event:preambleRun">preambleRun</a></li><li><a href="Numbas.Exam.html#event:questionlistinitialised">question list initialised</a></li><li><a href="Numbas.Exam.html#event:ready">ready</a></li><li><a href="Numbas.Question.html#event:ready">ready</a></li><li><a href="Numbas.Question.html#event:rulesetsLoaded">rulesetsLoaded</a></li><li><a href="Numbas.Question.html#event:rulesetsMade">rulesetsMade</a></li><li><a href="Numbas.Question.html#event:variableDefinitionsLoaded">variableDefinitionsLoaded</a></li><li><a href="Numbas.Question.html#event:variablesGenerated">variablesGenerated</a></li><li><a href="Numbas.Question.html#event:variablesSet">variablesSet</a></li></ul></div><h3>Global variables</h3><ul><li><a href="global.html#get">get</a></li><li><a href="global.html#hasWarnings">hasWarnings</a></li></ul>

--- a/docs/Numbas.jme.rules.html
+++ b/docs/Numbas.jme.rules.html
@@ -5025,9 +5025,30 @@ Maps variable names to trees.</p>
 
 
 
-
-
             <td class="description last"><p>Always show the multiplication symbol between multiplicands?</p></td>
+        </tr>
+
+
+
+
+        <tr>
+
+                <td class="name"><code>flatfractions</code></td>
+
+
+            <td class="type">
+
+
+<span class="param-type"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></span>
+
+
+
+            </td>
+
+
+
+
+            <td class="description last"><p>Display fractions horizontally?</p></td>
         </tr>
 
     </tbody>

--- a/docs/runtime_scripts_jme-display.js.html
+++ b/docs/runtime_scripts_jme-display.js.html
@@ -23,11 +23,11 @@
 
 		<h1 class="page-title">Source: runtime/scripts/jme-display.js</h1>
 
-		
 
 
 
-    
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>/*
@@ -1257,7 +1257,7 @@ var jmeRealNumber = jme.display.jmeRealNumber = function(n,settings)
         im += im.match(/\d$/) ? 'i' : '*i';
         if(Math.abs(n.im)&lt;1e-15) {
             return re;
-        } 
+        }
         else if(n.re==0)
         {
             if(n.im==1)
@@ -1341,7 +1341,7 @@ var jmeDecimal = jme.display.jmeDecimal = function(n,settings)
         var re = jmeDecimal(n.re);
         if(n.isReal()) {
             return re;
-        } 
+        }
         var im = jmeDecimal(n.im)+'*i';
         if(n.re.isZero()) {
             if(n.im.eq(1))
@@ -1683,7 +1683,7 @@ var align_text_blocks = jme.display.align_text_blocks = function(header,items) {
         }
         return line;
     }
-    
+
     var item_lines = items.map(function(item){return item.split('\n')});
     var item_widths = item_lines.map(function(lines) {return lines.reduce(function(m,l){return Math.max(l.length,m)},0)});
     var num_lines = item_lines.reduce(function(t,ls){return Math.max(ls.length,t)},0);
@@ -1781,3397 +1781,3397 @@ var tree_diagram = Numbas.jme.display.tree_diagram = function(tree) {
 		<h2><a href="index.html">Home</a></h2><div class="search">
 	<input id="search-query" type="text" placeholder="Search"/>
 	<ul id="search-results">
-		
+
 			<li class="search-result" data-longname="global"><a href="global.html">global</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree"><a href="AnnotatedTree.html">AnnotatedTree</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#assign"><a href="AnnotatedTree.html#assign">AnnotatedTree#assign</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#assign_args"><a href="AnnotatedTree.html#assign_args">AnnotatedTree#assign_args</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#backtrack"><a href="AnnotatedTree.html#backtrack">AnnotatedTree#backtrack</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#next"><a href="AnnotatedTree.html#next">AnnotatedTree#next</a></li>
-		
+
 			<li class="search-result" data-longname="complex"><a href="global.html#complex">complex</a></li>
-		
+
 			<li class="search-result" data-longname="fraction"><a href="global.html#fraction">fraction</a></li>
-		
+
 			<li class="search-result" data-longname="get"><a href="global.html#get">get</a></li>
-		
+
 			<li class="search-result" data-longname="hasWarnings"><a href="global.html#hasWarnings">hasWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="JME"><a href="global.html#JME">JME</a></li>
-		
+
 			<li class="search-result" data-longname="matrix"><a href="global.html#matrix">matrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas"><a href="Numbas.html">Numbas</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.addExtension"><a href="Numbas.html#.addExtension">Numbas.addExtension</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.checkAllScriptsLoaded"><a href="Numbas.html#.checkAllScriptsLoaded">Numbas.checkAllScriptsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls"><a href="Numbas.controls.html">Numbas.controls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.backToResults"><a href="Numbas.controls.html#.backToResults">Numbas.controls.backToResults</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.beginExam"><a href="Numbas.controls.html#.beginExam">Numbas.controls.beginExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.endExam"><a href="Numbas.controls.html#.endExam">Numbas.controls.endExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.exitExam"><a href="Numbas.controls.html#.exitExam">Numbas.controls.exitExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.getAdvice"><a href="Numbas.controls.html#.getAdvice">Numbas.controls.getAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.hideSteps"><a href="Numbas.controls.html#.hideSteps">Numbas.controls.hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.jumpQuestion"><a href="Numbas.controls.html#.jumpQuestion">Numbas.controls.jumpQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.makeQuestionJumper"><a href="Numbas.controls.html#.makeQuestionJumper">Numbas.controls.makeQuestionJumper</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.nextQuestion"><a href="Numbas.controls.html#.nextQuestion">Numbas.controls.nextQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.pauseExam"><a href="Numbas.controls.html#.pauseExam">Numbas.controls.pauseExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.previousQuestion"><a href="Numbas.controls.html#.previousQuestion">Numbas.controls.previousQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.regenQuestion"><a href="Numbas.controls.html#.regenQuestion">Numbas.controls.regenQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.resumeExam"><a href="Numbas.controls.html#.resumeExam">Numbas.controls.resumeExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.revealAnswer"><a href="Numbas.controls.html#.revealAnswer">Numbas.controls.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.submitQuestion"><a href="Numbas.controls.html#.submitQuestion">Numbas.controls.submitQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPart"><a href="Numbas.html#.createPart">Numbas.createPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPartFromJSON"><a href="Numbas.html#.createPartFromJSON">Numbas.createPartFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPartFromXML"><a href="Numbas.html#.createPartFromXML">Numbas.createPartFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createQuestionFromJSON"><a href="Numbas.html#.createQuestionFromJSON">Numbas.createQuestionFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createQuestionFromXML"><a href="Numbas.html#.createQuestionFromXML">Numbas.createQuestionFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.custom_part_types"><a href="Numbas.html#.custom_part_types">Numbas.custom_part_types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.debug"><a href="Numbas.html#.debug">Numbas.debug</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display"><a href="Numbas.display.html">Numbas.display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.die"><a href="Numbas.display.html#.die">Numbas.display.die</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay"><a href="Numbas.display.ExamDisplay.html">Numbas.display.ExamDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay._endTime"><a href="Numbas.display.ExamDisplay.html#._endTime">Numbas.display.ExamDisplay._endTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay._startTime"><a href="Numbas.display.ExamDisplay.html#._startTime">Numbas.display.ExamDisplay._startTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.allowPause"><a href="Numbas.display.ExamDisplay.html#.allowPause">Numbas.display.ExamDisplay.allowPause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.applyQuestionBindings"><a href="Numbas.display.ExamDisplay.html#.applyQuestionBindings">Numbas.display.ExamDisplay.applyQuestionBindings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.beginExam"><a href="Numbas.display.ExamDisplay.html#.beginExam">Numbas.display.ExamDisplay.beginExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canAdvance"><a href="Numbas.display.ExamDisplay.html#.canAdvance">Numbas.display.ExamDisplay.canAdvance</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canBegin"><a href="Numbas.display.ExamDisplay.html#.canBegin">Numbas.display.ExamDisplay.canBegin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canReverse"><a href="Numbas.display.ExamDisplay.html#.canReverse">Numbas.display.ExamDisplay.canReverse</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.currentQuestion"><a href="Numbas.display.ExamDisplay.html#.currentQuestion">Numbas.display.ExamDisplay.currentQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.currentQuestionNumber"><a href="Numbas.display.ExamDisplay.html#.currentQuestionNumber">Numbas.display.ExamDisplay.currentQuestionNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.displayTime"><a href="Numbas.display.ExamDisplay.html#.displayTime">Numbas.display.ExamDisplay.displayTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.end"><a href="Numbas.display.ExamDisplay.html#.end">Numbas.display.ExamDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.endRegen"><a href="Numbas.display.ExamDisplay.html#.endRegen">Numbas.display.ExamDisplay.endRegen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.enteredPassword"><a href="Numbas.display.ExamDisplay.html#.enteredPassword">Numbas.display.ExamDisplay.enteredPassword</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.exam"><a href="Numbas.display.ExamDisplay.html#.exam">Numbas.display.ExamDisplay.exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.examScoreDisplay"><a href="Numbas.display.ExamDisplay.html#.examScoreDisplay">Numbas.display.ExamDisplay.examScoreDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.feedbackMessage"><a href="Numbas.display.ExamDisplay.html#.feedbackMessage">Numbas.display.ExamDisplay.feedbackMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.hideNavMenu"><a href="Numbas.display.ExamDisplay.html#.hideNavMenu">Numbas.display.ExamDisplay.hideNavMenu</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.hideTiming"><a href="Numbas.display.ExamDisplay.html#.hideTiming">Numbas.display.ExamDisplay.hideTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.infoPage"><a href="Numbas.display.ExamDisplay.html#.infoPage">Numbas.display.ExamDisplay.infoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.initQuestionList"><a href="Numbas.display.ExamDisplay.html#.initQuestionList">Numbas.display.ExamDisplay.initQuestionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.marks"><a href="Numbas.display.ExamDisplay.html#.marks">Numbas.display.ExamDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.mode"><a href="Numbas.display.ExamDisplay.html#.mode">Numbas.display.ExamDisplay.mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.passed"><a href="Numbas.display.ExamDisplay.html#.passed">Numbas.display.ExamDisplay.passed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.passwordFeedback."><a href="Numbas.display.ExamDisplay.html#.passwordFeedback.">Numbas.display.ExamDisplay.passwordFeedback.</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.percentPass"><a href="Numbas.display.ExamDisplay.html#.percentPass">Numbas.display.ExamDisplay.percentPass</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.percentScore"><a href="Numbas.display.ExamDisplay.html#.percentScore">Numbas.display.ExamDisplay.percentScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questions"><a href="Numbas.display.ExamDisplay.html#.questions">Numbas.display.ExamDisplay.questions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questionsAttempted"><a href="Numbas.display.ExamDisplay.html#.questionsAttempted">Numbas.display.ExamDisplay.questionsAttempted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questionsAttemptedDisplay"><a href="Numbas.display.ExamDisplay.html#.questionsAttemptedDisplay">Numbas.display.ExamDisplay.questionsAttemptedDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.result"><a href="Numbas.display.ExamDisplay.html#.result">Numbas.display.ExamDisplay.result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.saving"><a href="Numbas.display.ExamDisplay.html#.saving">Numbas.display.ExamDisplay.saving</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.score"><a href="Numbas.display.ExamDisplay.html#.score">Numbas.display.ExamDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showInfoPage"><a href="Numbas.display.ExamDisplay.html#.showInfoPage">Numbas.display.ExamDisplay.showInfoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showQuestion"><a href="Numbas.display.ExamDisplay.html#.showQuestion">Numbas.display.ExamDisplay.showQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showQuestionGroupNames"><a href="Numbas.display.ExamDisplay.html#.showQuestionGroupNames">Numbas.display.ExamDisplay.showQuestionGroupNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showScore"><a href="Numbas.display.ExamDisplay.html#.showScore">Numbas.display.ExamDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showTiming"><a href="Numbas.display.ExamDisplay.html#.showTiming">Numbas.display.ExamDisplay.showTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.startRegen"><a href="Numbas.display.ExamDisplay.html#.startRegen">Numbas.display.ExamDisplay.startRegen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.timeSpent"><a href="Numbas.display.ExamDisplay.html#.timeSpent">Numbas.display.ExamDisplay.timeSpent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.updateQuestionMenu"><a href="Numbas.display.ExamDisplay.html#.updateQuestionMenu">Numbas.display.ExamDisplay.updateQuestionMenu</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.viewType"><a href="Numbas.display.ExamDisplay.html#.viewType">Numbas.display.ExamDisplay.viewType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.feedback_state"><a href="Numbas.display.html#.feedback_state">Numbas.display.feedback_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.feedbackable"><a href="Numbas.display.html#.feedbackable">Numbas.display.feedbackable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.getLocalisedAttribute"><a href="Numbas.display.html#.getLocalisedAttribute">Numbas.display.getLocalisedAttribute</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.init"><a href="Numbas.display.html#.init">Numbas.display.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.localisePage"><a href="Numbas.display.html#.localisePage">Numbas.display.localisePage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.modal"><a href="Numbas.display.html#.modal">Numbas.display.modal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay"><a href="Numbas.display.PartDisplay.html">Numbas.display.PartDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.answered"><a href="Numbas.display.PartDisplay.html#.answered">Numbas.display.PartDisplay.answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.controls"><a href="Numbas.display.PartDisplay.html#.controls">Numbas.display.PartDisplay.controls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.credit"><a href="Numbas.display.PartDisplay.html#.credit">Numbas.display.PartDisplay.credit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.doesMarking"><a href="Numbas.display.PartDisplay.html#.doesMarking">Numbas.display.PartDisplay.doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.end"><a href="Numbas.display.PartDisplay.html#.end">Numbas.display.PartDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.feedbackMessages"><a href="Numbas.display.PartDisplay.html#.feedbackMessages">Numbas.display.PartDisplay.feedbackMessages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.feedbackShown"><a href="Numbas.display.PartDisplay.html#.feedbackShown">Numbas.display.PartDisplay.feedbackShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.hideSteps"><a href="Numbas.display.PartDisplay.html#.hideSteps">Numbas.display.PartDisplay.hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.hideWarnings"><a href="Numbas.display.PartDisplay.html#.hideWarnings">Numbas.display.PartDisplay.hideWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.init"><a href="Numbas.display.PartDisplay.html#.init">Numbas.display.PartDisplay.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.inputEvents"><a href="Numbas.display.PartDisplay.html#.inputEvents">Numbas.display.PartDisplay.inputEvents</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.isDirty"><a href="Numbas.display.PartDisplay.html#.isDirty">Numbas.display.PartDisplay.isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.isNotOnlyPart"><a href="Numbas.display.PartDisplay.html#.isNotOnlyPart">Numbas.display.PartDisplay.isNotOnlyPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.marks"><a href="Numbas.display.PartDisplay.html#.marks">Numbas.display.PartDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.part"><a href="Numbas.display.PartDisplay.html#.part">Numbas.display.PartDisplay.part</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.question"><a href="Numbas.display.PartDisplay.html#.question">Numbas.display.PartDisplay.question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.removeWarnings"><a href="Numbas.display.PartDisplay.html#.removeWarnings">Numbas.display.PartDisplay.removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.restoreAnswer"><a href="Numbas.display.PartDisplay.html#.restoreAnswer">Numbas.display.PartDisplay.restoreAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.revealAnswer"><a href="Numbas.display.PartDisplay.html#.revealAnswer">Numbas.display.PartDisplay.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.revealed"><a href="Numbas.display.PartDisplay.html#.revealed">Numbas.display.PartDisplay.revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.score"><a href="Numbas.display.PartDisplay.html#.score">Numbas.display.PartDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.scoreFeedback"><a href="Numbas.display.PartDisplay.html#.scoreFeedback">Numbas.display.PartDisplay.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.setWarnings"><a href="Numbas.display.PartDisplay.html#.setWarnings">Numbas.display.PartDisplay.setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.show"><a href="Numbas.display.PartDisplay.html#.show">Numbas.display.PartDisplay.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showCorrectAnswer"><a href="Numbas.display.PartDisplay.html#.showCorrectAnswer">Numbas.display.PartDisplay.showCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackBox"><a href="Numbas.display.PartDisplay.html#.showFeedbackBox">Numbas.display.PartDisplay.showFeedbackBox</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackIcon"><a href="Numbas.display.PartDisplay.html#.showFeedbackIcon">Numbas.display.PartDisplay.showFeedbackIcon</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackMessages"><a href="Numbas.display.PartDisplay.html#.showFeedbackMessages">Numbas.display.PartDisplay.showFeedbackMessages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showMarks"><a href="Numbas.display.PartDisplay.html#.showMarks">Numbas.display.PartDisplay.showMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showScore"><a href="Numbas.display.PartDisplay.html#.showScore">Numbas.display.PartDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showSteps"><a href="Numbas.display.PartDisplay.html#.showSteps">Numbas.display.PartDisplay.showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showSubmitPart"><a href="Numbas.display.PartDisplay.html#.showSubmitPart">Numbas.display.PartDisplay.showSubmitPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showWarnings"><a href="Numbas.display.PartDisplay.html#.showWarnings">Numbas.display.PartDisplay.showWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsOpen"><a href="Numbas.display.PartDisplay.html#.stepsOpen">Numbas.display.PartDisplay.stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsPenaltyMessage"><a href="Numbas.display.PartDisplay.html#.stepsPenaltyMessage">Numbas.display.PartDisplay.stepsPenaltyMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsShown"><a href="Numbas.display.PartDisplay.html#.stepsShown">Numbas.display.PartDisplay.stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.toggleFeedbackText"><a href="Numbas.display.PartDisplay.html#.toggleFeedbackText">Numbas.display.PartDisplay.toggleFeedbackText</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.updateCorrectAnswer"><a href="Numbas.display.PartDisplay.html#.updateCorrectAnswer">Numbas.display.PartDisplay.updateCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warning"><a href="Numbas.display.PartDisplay.html#.warning">Numbas.display.PartDisplay.warning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warnings"><a href="Numbas.display.PartDisplay.html#.warnings">Numbas.display.PartDisplay.warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warningsShown"><a href="Numbas.display.PartDisplay.html#.warningsShown">Numbas.display.PartDisplay.warningsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay#setName"><a href="Numbas.display.PartDisplay.html#setName">Numbas.display.PartDisplay#setName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay"><a href="Numbas.display.QuestionDisplay.html">Numbas.display.QuestionDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.adviceDisplayed"><a href="Numbas.display.QuestionDisplay.html#.adviceDisplayed">Numbas.display.QuestionDisplay.adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.answered"><a href="Numbas.display.QuestionDisplay.html#.answered">Numbas.display.QuestionDisplay.answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.anyAnswered"><a href="Numbas.display.QuestionDisplay.html#.anyAnswered">Numbas.display.QuestionDisplay.anyAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.canReveal"><a href="Numbas.display.QuestionDisplay.html#.canReveal">Numbas.display.QuestionDisplay.canReveal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.credit"><a href="Numbas.display.QuestionDisplay.html#.credit">Numbas.display.QuestionDisplay.credit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.displayName"><a href="Numbas.display.QuestionDisplay.html#.displayName">Numbas.display.QuestionDisplay.displayName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.doesMarking"><a href="Numbas.display.QuestionDisplay.html#.doesMarking">Numbas.display.QuestionDisplay.doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.end"><a href="Numbas.display.QuestionDisplay.html#.end">Numbas.display.QuestionDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.getPart"><a href="Numbas.display.QuestionDisplay.html#.getPart">Numbas.display.QuestionDisplay.getPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.html"><a href="Numbas.display.QuestionDisplay.html#.html">Numbas.display.QuestionDisplay.html</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.init"><a href="Numbas.display.QuestionDisplay.html#.init">Numbas.display.QuestionDisplay.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.isDirty"><a href="Numbas.display.QuestionDisplay.html#.isDirty">Numbas.display.QuestionDisplay.isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.leave"><a href="Numbas.display.QuestionDisplay.html#.leave">Numbas.display.QuestionDisplay.leave</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.makeHTML"><a href="Numbas.display.QuestionDisplay.html#.makeHTML">Numbas.display.QuestionDisplay.makeHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.marks"><a href="Numbas.display.QuestionDisplay.html#.marks">Numbas.display.QuestionDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.numParts"><a href="Numbas.display.QuestionDisplay.html#.numParts">Numbas.display.QuestionDisplay.numParts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.question"><a href="Numbas.display.QuestionDisplay.html#.question">Numbas.display.QuestionDisplay.question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.revealAnswer"><a href="Numbas.display.QuestionDisplay.html#.revealAnswer">Numbas.display.QuestionDisplay.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.revealed"><a href="Numbas.display.QuestionDisplay.html#.revealed">Numbas.display.QuestionDisplay.revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.review"><a href="Numbas.display.QuestionDisplay.html#.review">Numbas.display.QuestionDisplay.review</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.score"><a href="Numbas.display.QuestionDisplay.html#.score">Numbas.display.QuestionDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.scoreFeedback"><a href="Numbas.display.QuestionDisplay.html#.scoreFeedback">Numbas.display.QuestionDisplay.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.scrollToError"><a href="Numbas.display.QuestionDisplay.html#.scrollToError">Numbas.display.QuestionDisplay.scrollToError</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.show"><a href="Numbas.display.QuestionDisplay.html#.show">Numbas.display.QuestionDisplay.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.showAdvice"><a href="Numbas.display.QuestionDisplay.html#.showAdvice">Numbas.display.QuestionDisplay.showAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.showScore"><a href="Numbas.display.QuestionDisplay.html#.showScore">Numbas.display.QuestionDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.submitMessage"><a href="Numbas.display.QuestionDisplay.html#.submitMessage">Numbas.display.QuestionDisplay.submitMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.visible"><a href="Numbas.display.QuestionDisplay.html#.visible">Numbas.display.QuestionDisplay.visible</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.visited"><a href="Numbas.display.QuestionDisplay.html#.visited">Numbas.display.QuestionDisplay.visited</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.scoreFeedback"><a href="Numbas.display.html#.scoreFeedback">Numbas.display.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showAlert"><a href="Numbas.display.html#.showAlert">Numbas.display.showAlert</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showConfirm"><a href="Numbas.display.html#.showConfirm">Numbas.display.showConfirm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showLoadProgress"><a href="Numbas.display.html#.showLoadProgress">Numbas.display.showLoadProgress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showScoreFeedback"><a href="Numbas.display.html#.showScoreFeedback">Numbas.display.showScoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showScoreFeedback_settings"><a href="Numbas.display.html#.showScoreFeedback_settings">Numbas.display.showScoreFeedback_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.typeset"><a href="Numbas.display.html#.typeset">Numbas.display.typeset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Error"><a href="Numbas.Error.html">Numbas.Error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam"><a href="Numbas.Exam.html">Numbas.Exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.exam"><a href="Numbas.html#.exam">Numbas.exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#acceptPassword"><a href="Numbas.Exam.html#acceptPassword">Numbas.Exam#acceptPassword</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#begin"><a href="Numbas.Exam.html#begin">Numbas.Exam#begin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#calculateScore"><a href="Numbas.Exam.html#calculateScore">Numbas.Exam#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#changeQuestion"><a href="Numbas.Exam.html#changeQuestion">Numbas.Exam#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#chooseQuestionSubset"><a href="Numbas.Exam.html#chooseQuestionSubset">Numbas.Exam#chooseQuestionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#countDown"><a href="Numbas.Exam.html#countDown">Numbas.Exam#countDown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#currentQuestion"><a href="Numbas.Exam.html#currentQuestion">Numbas.Exam#currentQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#currentQuestionNumber"><a href="Numbas.Exam.html#currentQuestionNumber">Numbas.Exam#currentQuestionNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#displayDuration"><a href="Numbas.Exam.html#displayDuration">Numbas.Exam#displayDuration</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#end"><a href="Numbas.Exam.html#end">Numbas.Exam#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#endTime"><a href="Numbas.Exam.html#endTime">Numbas.Exam#endTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#endTiming"><a href="Numbas.Exam.html#endTiming">Numbas.Exam#endTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#event:question list initialised"><a href="Numbas.Exam.html#event:questionlistinitialised">Numbas.Exam#event:question list initialised</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#event:ready"><a href="Numbas.Exam.html#event:ready">Numbas.Exam#event:ready</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#exit"><a href="Numbas.Exam.html#exit">Numbas.Exam#exit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#init"><a href="Numbas.Exam.html#init">Numbas.Exam#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#inProgress"><a href="Numbas.Exam.html#inProgress">Numbas.Exam#inProgress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#load"><a href="Numbas.Exam.html#load">Numbas.Exam#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#makeQuestionList"><a href="Numbas.Exam.html#makeQuestionList">Numbas.Exam#makeQuestionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#mark"><a href="Numbas.Exam.html#mark">Numbas.Exam#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#mode"><a href="Numbas.Exam.html#mode">Numbas.Exam#mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#passed"><a href="Numbas.Exam.html#passed">Numbas.Exam#passed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#pause"><a href="Numbas.Exam.html#pause">Numbas.Exam#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#percentScore"><a href="Numbas.Exam.html#percentScore">Numbas.Exam#percentScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#question_groups"><a href="Numbas.Exam.html#question_groups">Numbas.Exam#question_groups</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#questionList"><a href="Numbas.Exam.html#questionList">Numbas.Exam#questionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#questionSubset"><a href="Numbas.Exam.html#questionSubset">Numbas.Exam#questionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#regenQuestion"><a href="Numbas.Exam.html#regenQuestion">Numbas.Exam#regenQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#resume"><a href="Numbas.Exam.html#resume">Numbas.Exam#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#reviewQuestion"><a href="Numbas.Exam.html#reviewQuestion">Numbas.Exam#reviewQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#scope"><a href="Numbas.Exam.html#scope">Numbas.Exam#scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#score"><a href="Numbas.Exam.html#score">Numbas.Exam#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#settings"><a href="Numbas.Exam.html#settings">Numbas.Exam#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#showInfoPage"><a href="Numbas.Exam.html#showInfoPage">Numbas.Exam#showInfoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#signals"><a href="Numbas.Exam.html#signals">Numbas.Exam#signals</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#start"><a href="Numbas.Exam.html#start">Numbas.Exam#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#startTiming"><a href="Numbas.Exam.html#startTiming">Numbas.Exam#startTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#stop"><a href="Numbas.Exam.html#stop">Numbas.Exam#stop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#stopwatch"><a href="Numbas.Exam.html#stopwatch">Numbas.Exam#stopwatch</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#store"><a href="Numbas.Exam.html#store">Numbas.Exam#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#student_id"><a href="Numbas.Exam.html#student_id">Numbas.Exam#student_id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#student_name"><a href="Numbas.Exam.html#student_name">Numbas.Exam#student_name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#timeRemaining"><a href="Numbas.Exam.html#timeRemaining">Numbas.Exam#timeRemaining</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#timeSpent"><a href="Numbas.Exam.html#timeSpent">Numbas.Exam#timeSpent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#tryChangeQuestion"><a href="Numbas.Exam.html#tryChangeQuestion">Numbas.Exam#tryChangeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#tryEnd"><a href="Numbas.Exam.html#tryEnd">Numbas.Exam#tryEnd</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#updateScore"><a href="Numbas.Exam.html#updateScore">Numbas.Exam#updateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#xml"><a href="Numbas.Exam.html#xml">Numbas.Exam#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent"><a href="Numbas.ExamEvent.html">Numbas.ExamEvent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#action"><a href="Numbas.ExamEvent.html#action">Numbas.ExamEvent#action</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#message"><a href="Numbas.ExamEvent.html#message">Numbas.ExamEvent#message</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#type"><a href="Numbas.ExamEvent.html#type">Numbas.ExamEvent#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.extensions"><a href="Numbas.html#.extensions">Numbas.extensions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.init"><a href="Numbas.html#.init">Numbas.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme"><a href="Numbas.jme.html">Numbas.jme</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addBinaryOperator"><a href="Numbas.jme.html#.addBinaryOperator">Numbas.jme.addBinaryOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addPostfixOperator"><a href="Numbas.jme.html#.addPostfixOperator">Numbas.jme.addPostfixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addPrefixOperator"><a href="Numbas.jme.html#.addPrefixOperator">Numbas.jme.addPrefixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.arity"><a href="Numbas.jme.html#.arity">Numbas.jme.arity</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.associative"><a href="Numbas.jme.html#.associative">Numbas.jme.associative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.builtinScope"><a href="Numbas.jme.html#.builtinScope">Numbas.jme.builtinScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.castToType"><a href="Numbas.jme.html#.castToType">Numbas.jme.castToType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.checkingFunction"><a href="Numbas.jme.html#.checkingFunction">Numbas.jme.checkingFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.checkingFunctions"><a href="Numbas.jme.html#.checkingFunctions">Numbas.jme.checkingFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.commutative"><a href="Numbas.jme.html#.commutative">Numbas.jme.commutative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compare"><a href="Numbas.jme.html#.compare">Numbas.jme.compare</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compare_settings"><a href="Numbas.jme.html#.compare_settings">Numbas.jme.compare_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTokens"><a href="Numbas.jme.html#.compareTokens">Numbas.jme.compareTokens</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTokensByValue"><a href="Numbas.jme.html#.compareTokensByValue">Numbas.jme.compareTokensByValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTrees"><a href="Numbas.jme.html#.compareTrees">Numbas.jme.compareTrees</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compile"><a href="Numbas.jme.html#.compile">Numbas.jme.compile</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compileList"><a href="Numbas.jme.html#.compileList">Numbas.jme.compileList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.constants"><a href="Numbas.jme.html#.constants">Numbas.jme.constants</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.contentsubvars"><a href="Numbas.jme.html#.contentsubvars">Numbas.jme.contentsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.converseOps"><a href="Numbas.jme.html#.converseOps">Numbas.jme.converseOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display"><a href="Numbas.jme.display.html">Numbas.jme.display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.exprToLaTeX"><a href="Numbas.jme.display.html#.exprToLaTeX">Numbas.jme.display.exprToLaTeX</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jme.display.specialNumbers"><a href="Numbas.jme.display.html#.jme.display.specialNumbers">Numbas.jme.display.jme.display.specialNumbers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jme_display_settings"><a href="Numbas.jme.display.html#.jme_display_settings">Numbas.jme.display.jme_display_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jmeFunctions"><a href="Numbas.jme.display.html#.jmeFunctions">Numbas.jme.display.jmeFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets"><a href="Numbas.jme.display.opBrackets.html">Numbas.jme.display.opBrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."*""><a href="Numbas.jme.display.opBrackets.html#.%22*%22">Numbas.jme.display.opBrackets."*"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."+""><a href="Numbas.jme.display.opBrackets.html#.%22+%22">Numbas.jme.display.opBrackets."+"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."+u""><a href="Numbas.jme.display.opBrackets.html#.%22+u%22">Numbas.jme.display.opBrackets."+u"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."-""><a href="Numbas.jme.display.opBrackets.html#.%22-%22">Numbas.jme.display.opBrackets."-"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."-u""><a href="Numbas.jme.display.opBrackets.html#.%22-u%22">Numbas.jme.display.opBrackets."-u"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."/""><a href="Numbas.jme.display.opBrackets.html#.%22/%22">Numbas.jme.display.opBrackets."/"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."=""><a href="Numbas.jme.display.opBrackets.html#.%22=%22">Numbas.jme.display.opBrackets."="</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."^""><a href="Numbas.jme.display.opBrackets.html#.%22%5E%22">Numbas.jme.display.opBrackets."^"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.and"><a href="Numbas.jme.display.opBrackets.html#.and">Numbas.jme.display.opBrackets.and</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.fact"><a href="Numbas.jme.display.opBrackets.html#.fact">Numbas.jme.display.opBrackets.fact</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.or"><a href="Numbas.jme.display.opBrackets.html#.or">Numbas.jme.display.opBrackets.or</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.xor"><a href="Numbas.jme.display.opBrackets.html#.xor">Numbas.jme.display.opBrackets.xor</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplify"><a href="Numbas.jme.display.html#.simplify">Numbas.jme.display.simplify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplifyExpression"><a href="Numbas.jme.display.html#.simplifyExpression">Numbas.jme.display.simplifyExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplifyTree"><a href="Numbas.jme.display.html#.simplifyTree">Numbas.jme.display.simplifyTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.special_number_definition"><a href="Numbas.jme.display.html#.special_number_definition">Numbas.jme.display.special_number_definition</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.specialNames"><a href="Numbas.jme.display.html#.specialNames">Numbas.jme.display.specialNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texify"><a href="Numbas.jme.display.html#.texify">Numbas.jme.display.texify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texify_settings"><a href="Numbas.jme.display.html#.texify_settings">Numbas.jme.display.texify_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texName"><a href="Numbas.jme.display.html#.texName">Numbas.jme.display.texName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texNameAnnotations"><a href="Numbas.jme.display.html#.texNameAnnotations">Numbas.jme.display.texNameAnnotations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texOps"><a href="Numbas.jme.display.html#.texOps">Numbas.jme.display.texOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.treeToJME"><a href="Numbas.jme.display.html#.treeToJME">Numbas.jme.display.treeToJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME"><a href="Numbas.jme.display.html#.typeToJME">Numbas.jme.display.typeToJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.boolean"><a href="Numbas.jme.display.html#.typeToJME#.boolean">Numbas.jme.display.typeToJME.boolean</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.decimal"><a href="Numbas.jme.display.html#.typeToJME#.decimal">Numbas.jme.display.typeToJME.decimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.dict"><a href="Numbas.jme.display.html#.typeToJME#.dict">Numbas.jme.display.typeToJME.dict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.expression"><a href="Numbas.jme.display.html#.typeToJME#.expression">Numbas.jme.display.typeToJME.expression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.function"><a href="Numbas.jme.display.html#.typeToJME#.function">Numbas.jme.display.typeToJME.function</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.html"><a href="Numbas.jme.display.html#.typeToJME#.html">Numbas.jme.display.typeToJME.html</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.integer"><a href="Numbas.jme.display.html#.typeToJME#.integer">Numbas.jme.display.typeToJME.integer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.keypair"><a href="Numbas.jme.display.html#.typeToJME#.keypair">Numbas.jme.display.typeToJME.keypair</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.list"><a href="Numbas.jme.display.html#.typeToJME#.list">Numbas.jme.display.typeToJME.list</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.matrix"><a href="Numbas.jme.display.html#.typeToJME#.matrix">Numbas.jme.display.typeToJME.matrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.name"><a href="Numbas.jme.display.html#.typeToJME#.name">Numbas.jme.display.typeToJME.name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.nothing"><a href="Numbas.jme.display.html#.typeToJME#.nothing">Numbas.jme.display.typeToJME.nothing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.number"><a href="Numbas.jme.display.html#.typeToJME#.number">Numbas.jme.display.typeToJME.number</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.op"><a href="Numbas.jme.display.html#.typeToJME#.op">Numbas.jme.display.typeToJME.op</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.range"><a href="Numbas.jme.display.html#.typeToJME#.range">Numbas.jme.display.typeToJME.range</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.rational"><a href="Numbas.jme.display.html#.typeToJME#.rational">Numbas.jme.display.typeToJME.rational</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.set"><a href="Numbas.jme.display.html#.typeToJME#.set">Numbas.jme.display.typeToJME.set</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.string"><a href="Numbas.jme.display.html#.typeToJME#.string">Numbas.jme.display.typeToJME.string</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.vector"><a href="Numbas.jme.display.html#.typeToJME#.vector">Numbas.jme.display.typeToJME.vector</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToTeX"><a href="Numbas.jme.display.html#.typeToTeX">Numbas.jme.display.typeToTeX</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.escape"><a href="Numbas.jme.html#.escape">Numbas.jme.escape</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.evaluate"><a href="Numbas.jme.html#.evaluate">Numbas.jme.evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.evaluate_fn"><a href="Numbas.jme.html#.evaluate_fn">Numbas.jme.evaluate_fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findCompatibleType"><a href="Numbas.jme.html#.findCompatibleType">Numbas.jme.findCompatibleType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findvars"><a href="Numbas.jme.html#.findvars">Numbas.jme.findvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findvarsOps"><a href="Numbas.jme.html#.findvarsOps">Numbas.jme.findvarsOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj"><a href="Numbas.jme.funcObj.html">Numbas.jme.funcObj</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.description"><a href="Numbas.jme.funcObj.html#.description">Numbas.jme.funcObj.description</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.evaluate"><a href="Numbas.jme.funcObj.html#.evaluate">Numbas.jme.funcObj.evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.fn"><a href="Numbas.jme.funcObj.html#.fn">Numbas.jme.funcObj.fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.id"><a href="Numbas.jme.funcObj.html#.id">Numbas.jme.funcObj.id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.intype"><a href="Numbas.jme.funcObj.html#.intype">Numbas.jme.funcObj.intype</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.name"><a href="Numbas.jme.funcObj.html#.name">Numbas.jme.funcObj.name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.outtype"><a href="Numbas.jme.funcObj.html#.outtype">Numbas.jme.funcObj.outtype</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.random"><a href="Numbas.jme.funcObj.html#.random">Numbas.jme.funcObj.random</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.typecheck"><a href="Numbas.jme.funcObj.html#.typecheck">Numbas.jme.funcObj.typecheck</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj_options"><a href="Numbas.jme.html#.funcObj_options">Numbas.jme.funcObj_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcSynonyms"><a href="Numbas.jme.html#.funcSynonyms">Numbas.jme.funcSynonyms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isFunction"><a href="Numbas.jme.html#.isFunction">Numbas.jme.isFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isMonomial"><a href="Numbas.jme.html#.isMonomial">Numbas.jme.isMonomial</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isName"><a href="Numbas.jme.html#.isName">Numbas.jme.isName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isOp"><a href="Numbas.jme.html#.isOp">Numbas.jme.isOp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isRandom"><a href="Numbas.jme.html#.isRandom">Numbas.jme.isRandom</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isType"><a href="Numbas.jme.html#.isType">Numbas.jme.isType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.jme.sortTokensBy"><a href="Numbas.jme.html#.jme.sortTokensBy">Numbas.jme.jme.sortTokensBy</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.lazyOps"><a href="Numbas.jme.html#.lazyOps">Numbas.jme.lazyOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.makeSafe"><a href="Numbas.jme.html#.makeSafe">Numbas.jme.makeSafe</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.mapFunctions"><a href="Numbas.jme.html#.mapFunctions">Numbas.jme.mapFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.operatorOptions"><a href="Numbas.jme.html#.operatorOptions">Numbas.jme.operatorOptions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.opSynonyms"><a href="Numbas.jme.html#.opSynonyms">Numbas.jme.opSynonyms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser"><a href="Numbas.jme.Parser.html">Numbas.jme.Parser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addBinaryOperator"><a href="Numbas.jme.Parser.html#addBinaryOperator">Numbas.jme.Parser#addBinaryOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addOperator"><a href="Numbas.jme.Parser.html#addOperator">Numbas.jme.Parser#addOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addPostfixOperator"><a href="Numbas.jme.Parser.html#addPostfixOperator">Numbas.jme.Parser#addPostfixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addPrefixOperator"><a href="Numbas.jme.Parser.html#addPrefixOperator">Numbas.jme.Parser#addPrefixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#compile"><a href="Numbas.jme.Parser.html#compile">Numbas.jme.Parser#compile</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#funcSynonym"><a href="Numbas.jme.Parser.html#funcSynonym">Numbas.jme.Parser#funcSynonym</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getArity"><a href="Numbas.jme.Parser.html#getArity">Numbas.jme.Parser#getArity</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getConstant"><a href="Numbas.jme.Parser.html#getConstant">Numbas.jme.Parser#getConstant</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPostfixForm"><a href="Numbas.jme.Parser.html#getPostfixForm">Numbas.jme.Parser#getPostfixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPrecedence"><a href="Numbas.jme.Parser.html#getPrecedence">Numbas.jme.Parser#getPrecedence</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPrefixForm"><a href="Numbas.jme.Parser.html#getPrefixForm">Numbas.jme.Parser#getPrefixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getSetting"><a href="Numbas.jme.Parser.html#getSetting">Numbas.jme.Parser#getSetting</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isAssociative"><a href="Numbas.jme.Parser.html#isAssociative">Numbas.jme.Parser#isAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isCommutative"><a href="Numbas.jme.Parser.html#isCommutative">Numbas.jme.Parser#isCommutative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isRightAssociative"><a href="Numbas.jme.Parser.html#isRightAssociative">Numbas.jme.Parser#isRightAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#ops"><a href="Numbas.jme.Parser.html#ops">Numbas.jme.Parser#ops</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#opSynonym"><a href="Numbas.jme.Parser.html#opSynonym">Numbas.jme.Parser#opSynonym</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#option_defaults"><a href="Numbas.jme.Parser.html#option_defaults">Numbas.jme.Parser#option_defaults</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#re"><a href="Numbas.jme.Parser.html#re">Numbas.jme.Parser#re</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#setOperatorProperties"><a href="Numbas.jme.Parser.html#setOperatorProperties">Numbas.jme.Parser#setOperatorProperties</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#shunt"><a href="Numbas.jme.Parser.html#shunt">Numbas.jme.Parser#shunt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#shunt_type_actions.op"><a href="Numbas.jme.Parser_shunt_type_actions.op.html">Numbas.jme.Parser#shunt_type_actions.op</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#tokenise"><a href="Numbas.jme.Parser.html#tokenise">Numbas.jme.Parser#tokenise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#tokeniser_types"><a href="Numbas.jme.Parser.html#tokeniser_types">Numbas.jme.Parser#tokeniser_types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.parser_options"><a href="Numbas.jme.html#.parser_options">Numbas.jme.parser_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.postfixForm"><a href="Numbas.jme.html#.postfixForm">Numbas.jme.postfixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.precedence"><a href="Numbas.jme.html#.precedence">Numbas.jme.precedence</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.prefixForm"><a href="Numbas.jme.html#.prefixForm">Numbas.jme.prefixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.resultsEqual"><a href="Numbas.jme.html#.resultsEqual">Numbas.jme.resultsEqual</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rightAssociative"><a href="Numbas.jme.html#.rightAssociative">Numbas.jme.rightAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules"><a href="Numbas.jme.rules.html">Numbas.jme.rules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.applyPostReplacement"><a href="Numbas.jme.rules.html#.applyPostReplacement">Numbas.jme.rules.applyPostReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.collectRuleset"><a href="Numbas.jme.rules.html#.collectRuleset">Numbas.jme.rules.collectRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.compileRules"><a href="Numbas.jme.rules.html#.compileRules">Numbas.jme.rules.compileRules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.displayFlags"><a href="Numbas.jme.rules.html#.displayFlags">Numbas.jme.rules.displayFlags</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.extend_options"><a href="Numbas.jme.rules.html#.extend_options">Numbas.jme.rules.extend_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.findSequenceMatch"><a href="Numbas.jme.rules.html#.findSequenceMatch">Numbas.jme.rules.findSequenceMatch</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.findSequenceMatch_options"><a href="Numbas.jme.rules.html#.findSequenceMatch_options">Numbas.jme.rules.findSequenceMatch_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.getTerms"><a href="Numbas.jme.rules.html#.getTerms">Numbas.jme.rules.getTerms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.getTerms_options"><a href="Numbas.jme.rules.html#.getTerms_options">Numbas.jme.rules.getTerms_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.jme_pattern_match"><a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchAllTree"><a href="Numbas.jme.rules.html#.matchAllTree">Numbas.jme.rules.matchAllTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchExpression"><a href="Numbas.jme.rules.html#.matchExpression">Numbas.jme.rules.matchExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchTree"><a href="Numbas.jme.rules.html#.matchTree">Numbas.jme.rules.matchTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchTree_options"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.number_conditions"><a href="Numbas.jme.rules.html#.number_conditions">Numbas.jme.rules.number_conditions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.patternParser"><a href="Numbas.jme.rules.html#.patternParser">Numbas.jme.rules.patternParser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule"><a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#get_options"><a href="Numbas.jme.rules.Rule.html#get_options">Numbas.jme.rules.Rule#get_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#match"><a href="Numbas.jme.rules.Rule.html#match">Numbas.jme.rules.Rule#match</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#matchAll"><a href="Numbas.jme.rules.Rule.html#matchAll">Numbas.jme.rules.Rule#matchAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#replace"><a href="Numbas.jme.rules.Rule.html#replace">Numbas.jme.rules.Rule#replace</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#replaceAll"><a href="Numbas.jme.rules.Rule.html#replaceAll">Numbas.jme.rules.Rule#replaceAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset"><a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset#flagSet"><a href="Numbas.jme.rules.Ruleset.html#flagSet">Numbas.jme.rules.Ruleset#flagSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset#simplify"><a href="Numbas.jme.rules.Ruleset.html#simplify">Numbas.jme.rules.Ruleset#simplify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.ruleset_flags"><a href="Numbas.jme.rules.html#.ruleset_flags">Numbas.jme.rules.ruleset_flags</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.simplificationRules"><a href="Numbas.jme.rules.html#.simplificationRules">Numbas.jme.rules.simplificationRules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchFunctions"><a href="Numbas.jme.rules.html#.specialMatchFunctions">Numbas.jme.rules.specialMatchFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchNames"><a href="Numbas.jme.rules.html#.specialMatchNames">Numbas.jme.rules.specialMatchNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchOps"><a href="Numbas.jme.rules.html#.specialMatchOps">Numbas.jme.rules.specialMatchOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.term"><a href="Numbas.jme.rules.html#.term">Numbas.jme.rules.term</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Term"><a href="Numbas.jme.rules.Term.html">Numbas.jme.rules.Term</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transform"><a href="Numbas.jme.rules.html#.transform">Numbas.jme.rules.transform</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transform_result"><a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transformAll"><a href="Numbas.jme.rules.html#.transformAll">Numbas.jme.rules.transformAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope"><a href="Numbas.jme.Scope.html">Numbas.jme.Scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#addFunction"><a href="Numbas.jme.Scope.html#addFunction">Numbas.jme.Scope#addFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#addRuleset"><a href="Numbas.jme.Scope.html#addRuleset">Numbas.jme.Scope#addRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allFunctions"><a href="Numbas.jme.Scope.html#allFunctions">Numbas.jme.Scope#allFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allRulesets"><a href="Numbas.jme.Scope.html#allRulesets">Numbas.jme.Scope#allRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allVariables"><a href="Numbas.jme.Scope.html#allVariables">Numbas.jme.Scope#allVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#collect"><a href="Numbas.jme.Scope.html#collect">Numbas.jme.Scope#collect</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteFunction"><a href="Numbas.jme.Scope.html#deleteFunction">Numbas.jme.Scope#deleteFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteRuleset"><a href="Numbas.jme.Scope.html#deleteRuleset">Numbas.jme.Scope#deleteRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteVariable"><a href="Numbas.jme.Scope.html#deleteVariable">Numbas.jme.Scope#deleteVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#evaluate"><a href="Numbas.jme.Scope.html#evaluate">Numbas.jme.Scope#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#flatten"><a href="Numbas.jme.Scope.html#flatten">Numbas.jme.Scope#flatten</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getFunction"><a href="Numbas.jme.Scope.html#getFunction">Numbas.jme.Scope#getFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getRuleset"><a href="Numbas.jme.Scope.html#getRuleset">Numbas.jme.Scope#getRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getVariable"><a href="Numbas.jme.Scope.html#getVariable">Numbas.jme.Scope#getVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#matchFunctionToArguments"><a href="Numbas.jme.Scope.html#matchFunctionToArguments">Numbas.jme.Scope#matchFunctionToArguments</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#resolve"><a href="Numbas.jme.Scope.html#resolve">Numbas.jme.Scope#resolve</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#setRuleset"><a href="Numbas.jme.Scope.html#setRuleset">Numbas.jme.Scope#setRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#setVariable"><a href="Numbas.jme.Scope.html#setVariable">Numbas.jme.Scope#setVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#unset"><a href="Numbas.jme.Scope.html#unset">Numbas.jme.Scope#unset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.scope_deletions"><a href="Numbas.jme.html#.scope_deletions">Numbas.jme.scope_deletions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.shunt"><a href="Numbas.jme.html#.shunt">Numbas.jme.shunt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature"><a href="Numbas.jme.html#.signature">Numbas.jme.signature</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature_result"><a href="Numbas.jme.html#.signature_result">Numbas.jme.signature_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature_result_argument"><a href="Numbas.jme.html#.signature_result_argument">Numbas.jme.signature_result_argument</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.standardParser"><a href="Numbas.jme.html#.standardParser">Numbas.jme.standardParser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.substituteTree"><a href="Numbas.jme.html#.substituteTree">Numbas.jme.substituteTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.substituteTreeOps"><a href="Numbas.jme.html#.substituteTreeOps">Numbas.jme.substituteTreeOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.subvars"><a href="Numbas.jme.html#.subvars">Numbas.jme.subvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.texsplit"><a href="Numbas.jme.html#.texsplit">Numbas.jme.texsplit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.token"><a href="Numbas.jme.html#.token">Numbas.jme.token</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenComparisons"><a href="Numbas.jme.html#.tokenComparisons">Numbas.jme.tokenComparisons</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenise"><a href="Numbas.jme.html#.tokenise">Numbas.jme.tokenise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenToDisplayString"><a href="Numbas.jme.html#.tokenToDisplayString">Numbas.jme.tokenToDisplayString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tree"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.treesSame"><a href="Numbas.jme.html#.treesSame">Numbas.jme.treesSame</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.typecheck_fn"><a href="Numbas.jme.html#.typecheck_fn">Numbas.jme.typecheck_fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types"><a href="Numbas.jme.types.html">Numbas.jme.types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TBool"><a href="Numbas.jme.types.TBool.html">Numbas.jme.types.TBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TDict"><a href="Numbas.jme.types.TDict.html">Numbas.jme.types.TDict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TExpression"><a href="Numbas.jme.types.TExpression.html">Numbas.jme.types.TExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TFunc"><a href="Numbas.jme.types.TFunc.html">Numbas.jme.types.TFunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.THTML"><a href="Numbas.jme.types.THTML.html">Numbas.jme.types.THTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TKeyPair"><a href="Numbas.jme.types.TKeyPair.html">Numbas.jme.types.TKeyPair</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TList"><a href="Numbas.jme.types.TList.html">Numbas.jme.types.TList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TMatrix"><a href="Numbas.jme.types.TMatrix.html">Numbas.jme.types.TMatrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TName"><a href="Numbas.jme.types.TName.html">Numbas.jme.types.TName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TNothing"><a href="Numbas.jme.types.TNothing.html">Numbas.jme.types.TNothing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TNum"><a href="Numbas.jme.types.TNum.html">Numbas.jme.types.TNum</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TOp"><a href="Numbas.jme.types.TOp.html">Numbas.jme.types.TOp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TPunc"><a href="Numbas.jme.types.TPunc.html">Numbas.jme.types.TPunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TRange"><a href="Numbas.jme.types.TRange.html">Numbas.jme.types.TRange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TSet"><a href="Numbas.jme.types.TSet.html">Numbas.jme.types.TSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TString"><a href="Numbas.jme.types.TString.html">Numbas.jme.types.TString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TVector"><a href="Numbas.jme.types.TVector.html">Numbas.jme.types.TVector</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.typeToDisplayString"><a href="Numbas.jme.html#.typeToDisplayString">Numbas.jme.typeToDisplayString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.unescape"><a href="Numbas.jme.html#.unescape">Numbas.jme.unescape</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.unwrapValue"><a href="Numbas.jme.html#.unwrapValue">Numbas.jme.unwrapValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables"><a href="Numbas.jme.variables.html">Numbas.jme.variables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.computeRuleset"><a href="Numbas.jme.variables.html#.computeRuleset">Numbas.jme.variables.computeRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.computeVariable"><a href="Numbas.jme.variables.html#.computeVariable">Numbas.jme.variables.computeVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubber"><a href="Numbas.jme.variables.DOMcontentsubber.html">Numbas.jme.variables.DOMcontentsubber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubber#sub_element"><a href="Numbas.jme.variables.DOMcontentsubber_sub_element.html">Numbas.jme.variables.DOMcontentsubber#sub_element</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubvars"><a href="Numbas.jme.variables.html#.DOMcontentsubvars">Numbas.jme.variables.DOMcontentsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMsubvars"><a href="Numbas.jme.variables.html#.DOMsubvars">Numbas.jme.variables.DOMsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.func_data"><a href="Numbas.jme.variables.html#.func_data">Numbas.jme.variables.func_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeFunction"><a href="Numbas.jme.variables.html#.makeFunction">Numbas.jme.variables.makeFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeFunctions"><a href="Numbas.jme.variables.html#.makeFunctions">Numbas.jme.variables.makeFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeJavascriptFunction"><a href="Numbas.jme.variables.html#.makeJavascriptFunction">Numbas.jme.variables.makeJavascriptFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeJMEFunction"><a href="Numbas.jme.variables.html#.makeJMEFunction">Numbas.jme.variables.makeJMEFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeRulesets"><a href="Numbas.jme.variables.html#.makeRulesets">Numbas.jme.variables.makeRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeVariables"><a href="Numbas.jme.variables.html#.makeVariables">Numbas.jme.variables.makeVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.variable_data_dict"><a href="Numbas.jme.variables.html#.variable_data_dict">Numbas.jme.variables.variable_data_dict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.variableDependants"><a href="Numbas.jme.variables.html#.variableDependants">Numbas.jme.variables.variableDependants</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.varsUsed"><a href="Numbas.jme.html#.varsUsed">Numbas.jme.varsUsed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.wrapValue"><a href="Numbas.jme.html#.wrapValue">Numbas.jme.wrapValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart"><a href="Numbas.JMEPart.html">Numbas.JMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#addValueGenerator"><a href="Numbas.JMEPart.html#addValueGenerator">Numbas.JMEPart#addValueGenerator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#baseMarkingScript"><a href="Numbas.JMEPart.html#baseMarkingScript">Numbas.JMEPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#getCorrectAnswer"><a href="Numbas.JMEPart.html#getCorrectAnswer">Numbas.JMEPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#input_options"><a href="Numbas.JMEPart.html#input_options">Numbas.JMEPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#input_widget"><a href="Numbas.JMEPart.html#input_widget">Numbas.JMEPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#rawStudentAnswerAsJME"><a href="Numbas.JMEPart.html#rawStudentAnswerAsJME">Numbas.JMEPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#setStudentAnswer"><a href="Numbas.JMEPart.html#setStudentAnswer">Numbas.JMEPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#settings"><a href="Numbas.JMEPart.html#settings">Numbas.JMEPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#studentAnswer"><a href="Numbas.JMEPart.html#studentAnswer">Numbas.JMEPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json"><a href="Numbas.json.html">Numbas.json</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json.tryGet"><a href="Numbas.json.html#.tryGet">Numbas.json.tryGet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json.tryLoad"><a href="Numbas.json.html#.tryLoad">Numbas.json.tryLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.loadScript"><a href="Numbas.html#.loadScript">Numbas.loadScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.locale"><a href="Numbas.html#.locale">Numbas.locale</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking"><a href="Numbas.marking.html">Numbas.marking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.compute_note"><a href="Numbas.marking.html#.compute_note">Numbas.marking.compute_note</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.feedback"><a href="Numbas.marking.html#.feedback">Numbas.marking.feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.feedback_item"><a href="Numbas.marking.html#.feedback_item">Numbas.marking.feedback_item</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps"><a href="Numbas.marking.html#.FeedbackOps">Numbas.marking.FeedbackOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.ADD_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.ADD_CREDIT">Numbas.marking.FeedbackOps.ADD_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.CONCAT"><a href="Numbas.marking.html#.FeedbackOps#.CONCAT">Numbas.marking.FeedbackOps.CONCAT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.END"><a href="Numbas.marking.html#.FeedbackOps#.END">Numbas.marking.FeedbackOps.END</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.FEEDBACK"><a href="Numbas.marking.html#.FeedbackOps#.FEEDBACK">Numbas.marking.FeedbackOps.FEEDBACK</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.MULTIPLY_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.MULTIPLY_CREDIT">Numbas.marking.FeedbackOps.MULTIPLY_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.SET_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.SET_CREDIT">Numbas.marking.FeedbackOps.SET_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.SUB_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.SUB_CREDIT">Numbas.marking.FeedbackOps.SUB_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.WARNING"><a href="Numbas.marking.html#.FeedbackOps#.WARNING">Numbas.marking.FeedbackOps.WARNING</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.finalise_state"><a href="Numbas.marking.html#.finalise_state">Numbas.marking.finalise_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.finalised_state"><a href="Numbas.marking.html#.finalised_state">Numbas.marking.finalised_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.marking_script_result"><a href="Numbas.marking.html#.marking_script_result">Numbas.marking.marking_script_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingNote"><a href="Numbas.marking.MarkingNote.html">Numbas.marking.MarkingNote</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript"><a href="Numbas.marking.MarkingScript.html">Numbas.marking.MarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript#evaluate"><a href="Numbas.marking.MarkingScript.html#evaluate">Numbas.marking.MarkingScript#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript#source"><a href="Numbas.marking.MarkingScript.html#source">Numbas.marking.MarkingScript#source</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.note_definition"><a href="Numbas.marking.html#.note_definition">Numbas.marking.note_definition</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope"><a href="Numbas.marking.StatefulScope.html">Numbas.marking.StatefulScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#addFunction"><a href="Numbas.marking.StatefulScope.html#addFunction">Numbas.marking.StatefulScope#addFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#addRuleset"><a href="Numbas.marking.StatefulScope.html#addRuleset">Numbas.marking.StatefulScope#addRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allFunctions"><a href="Numbas.marking.StatefulScope.html#allFunctions">Numbas.marking.StatefulScope#allFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allRulesets"><a href="Numbas.marking.StatefulScope.html#allRulesets">Numbas.marking.StatefulScope#allRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allVariables"><a href="Numbas.marking.StatefulScope.html#allVariables">Numbas.marking.StatefulScope#allVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#collect"><a href="Numbas.marking.StatefulScope.html#collect">Numbas.marking.StatefulScope#collect</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteFunction"><a href="Numbas.marking.StatefulScope.html#deleteFunction">Numbas.marking.StatefulScope#deleteFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteRuleset"><a href="Numbas.marking.StatefulScope.html#deleteRuleset">Numbas.marking.StatefulScope#deleteRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteVariable"><a href="Numbas.marking.StatefulScope.html#deleteVariable">Numbas.marking.StatefulScope#deleteVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#evaluate"><a href="Numbas.marking.StatefulScope.html#evaluate">Numbas.marking.StatefulScope#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#flatten"><a href="Numbas.marking.StatefulScope.html#flatten">Numbas.marking.StatefulScope#flatten</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getFunction"><a href="Numbas.marking.StatefulScope.html#getFunction">Numbas.marking.StatefulScope#getFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getRuleset"><a href="Numbas.marking.StatefulScope.html#getRuleset">Numbas.marking.StatefulScope#getRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getVariable"><a href="Numbas.marking.StatefulScope.html#getVariable">Numbas.marking.StatefulScope#getVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#matchFunctionToArguments"><a href="Numbas.marking.StatefulScope.html#matchFunctionToArguments">Numbas.marking.StatefulScope#matchFunctionToArguments</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#resolve"><a href="Numbas.marking.StatefulScope.html#resolve">Numbas.marking.StatefulScope#resolve</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#setRuleset"><a href="Numbas.marking.StatefulScope.html#setRuleset">Numbas.marking.StatefulScope#setRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#setVariable"><a href="Numbas.marking.StatefulScope.html#setVariable">Numbas.marking.StatefulScope#setVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#unset"><a href="Numbas.marking.StatefulScope.html#unset">Numbas.marking.StatefulScope#unset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking_scripts"><a href="Numbas.html#.marking_scripts">Numbas.marking_scripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math"><a href="Numbas.math.html">Numbas.math</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.abs"><a href="Numbas.math.html#.abs">Numbas.math.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.add"><a href="Numbas.math.html#.add">Numbas.math.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.addDigits"><a href="Numbas.math.html#.addDigits">Numbas.math.addDigits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arccos"><a href="Numbas.math.html#.arccos">Numbas.math.arccos</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arccosh"><a href="Numbas.math.html#.arccosh">Numbas.math.arccosh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arcsin"><a href="Numbas.math.html#.arcsin">Numbas.math.arcsin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arcsinh"><a href="Numbas.math.html#.arcsinh">Numbas.math.arcsinh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arctan"><a href="Numbas.math.html#.arctan">Numbas.math.arctan</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arctanh"><a href="Numbas.math.html#.arctanh">Numbas.math.arctanh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arg"><a href="Numbas.math.html#.arg">Numbas.math.arg</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.binomialCoefficients"><a href="Numbas.math.html#.binomialCoefficients">Numbas.math.binomialCoefficients</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.ceil"><a href="Numbas.math.html#.ceil">Numbas.math.ceil</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.choose"><a href="Numbas.math.html#.choose">Numbas.math.choose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.combinations"><a href="Numbas.math.html#.combinations">Numbas.math.combinations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.complex"><a href="Numbas.math.html#.complex">Numbas.math.complex</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.ComplexDecimal"><a href="Numbas.math.ComplexDecimal.html">Numbas.math.ComplexDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.complexToString"><a href="Numbas.math.html#.complexToString">Numbas.math.complexToString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.conjugate"><a href="Numbas.math.html#.conjugate">Numbas.math.conjugate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.coprime"><a href="Numbas.math.html#.coprime">Numbas.math.coprime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cos"><a href="Numbas.math.html#.cos">Numbas.math.cos</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosec"><a href="Numbas.math.html#.cosec">Numbas.math.cosec</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosech"><a href="Numbas.math.html#.cosech">Numbas.math.cosech</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosh"><a href="Numbas.math.html#.cosh">Numbas.math.cosh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cot"><a href="Numbas.math.html#.cot">Numbas.math.cot</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.coth"><a href="Numbas.math.html#.coth">Numbas.math.coth</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.countDP"><a href="Numbas.math.html#.countDP">Numbas.math.countDP</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.countSigFigs"><a href="Numbas.math.html#.countSigFigs">Numbas.math.countSigFigs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.deal"><a href="Numbas.math.html#.deal">Numbas.math.deal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.defineRange"><a href="Numbas.math.html#.defineRange">Numbas.math.defineRange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.degrees"><a href="Numbas.math.html#.degrees">Numbas.math.degrees</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.div"><a href="Numbas.math.html#.div">Numbas.math.div</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.divides"><a href="Numbas.math.html#.divides">Numbas.math.divides</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.eq"><a href="Numbas.math.html#.eq">Numbas.math.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.except"><a href="Numbas.math.html#.except">Numbas.math.except</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.exp"><a href="Numbas.math.html#.exp">Numbas.math.exp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.factorial"><a href="Numbas.math.html#.factorial">Numbas.math.factorial</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.factorise"><a href="Numbas.math.html#.factorise">Numbas.math.factorise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.floor"><a href="Numbas.math.html#.floor">Numbas.math.floor</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.fract"><a href="Numbas.math.html#.fract">Numbas.math.fract</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.Fraction"><a href="Numbas.math.Fraction.html">Numbas.math.Fraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gamma"><a href="Numbas.math.html#.gamma">Numbas.math.gamma</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gcd"><a href="Numbas.math.html#.gcd">Numbas.math.gcd</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.geq"><a href="Numbas.math.html#.geq">Numbas.math.geq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gt"><a href="Numbas.math.html#.gt">Numbas.math.gt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.im"><a href="Numbas.math.html#.im">Numbas.math.im</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.inverse"><a href="Numbas.math.html#.inverse">Numbas.math.inverse</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.isclose"><a href="Numbas.math.html#.isclose">Numbas.math.isclose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.lcm"><a href="Numbas.math.html#.lcm">Numbas.math.lcm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.leq"><a href="Numbas.math.html#.leq">Numbas.math.leq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.listmax"><a href="Numbas.math.html#.listmax">Numbas.math.listmax</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.listmin"><a href="Numbas.math.html#.listmin">Numbas.math.listmin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log"><a href="Numbas.math.html#.log">Numbas.math.log</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log10"><a href="Numbas.math.html#.log10">Numbas.math.log10</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log_base"><a href="Numbas.math.html#.log_base">Numbas.math.log_base</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.lt"><a href="Numbas.math.html#.lt">Numbas.math.lt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.max"><a href="Numbas.math.html#.max">Numbas.math.max</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.min"><a href="Numbas.math.html#.min">Numbas.math.min</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.mod"><a href="Numbas.math.html#.mod">Numbas.math.mod</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.mul"><a href="Numbas.math.html#.mul">Numbas.math.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.negate"><a href="Numbas.math.html#.negate">Numbas.math.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.negative"><a href="Numbas.math.html#.negative">Numbas.math.negative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.neq"><a href="Numbas.math.html#.neq">Numbas.math.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceComplexDecimal"><a href="Numbas.math.html#.niceComplexDecimal">Numbas.math.niceComplexDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceDecimal"><a href="Numbas.math.html#.niceDecimal">Numbas.math.niceDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceNumber"><a href="Numbas.math.html#.niceNumber">Numbas.math.niceNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceNumber_settings"><a href="Numbas.math.html#.niceNumber_settings">Numbas.math.niceNumber_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.nonnegative"><a href="Numbas.math.html#.nonnegative">Numbas.math.nonnegative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.parseScientific"><a href="Numbas.math.html#.parseScientific">Numbas.math.parseScientific</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.permutations"><a href="Numbas.math.html#.permutations">Numbas.math.permutations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.piDegree"><a href="Numbas.math.html#.piDegree">Numbas.math.piDegree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.positive"><a href="Numbas.math.html#.positive">Numbas.math.positive</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.pow"><a href="Numbas.math.html#.pow">Numbas.math.pow</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.precround"><a href="Numbas.math.html#.precround">Numbas.math.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.primes"><a href="Numbas.math.html#.primes">Numbas.math.primes</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.radians"><a href="Numbas.math.html#.radians">Numbas.math.radians</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.random"><a href="Numbas.math.html#.random">Numbas.math.random</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.randomint"><a href="Numbas.math.html#.randomint">Numbas.math.randomint</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.randomrange"><a href="Numbas.math.html#.randomrange">Numbas.math.randomrange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeSize"><a href="Numbas.math.html#.rangeSize">Numbas.math.rangeSize</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeSteps"><a href="Numbas.math.html#.rangeSteps">Numbas.math.rangeSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeToList"><a href="Numbas.math.html#.rangeToList">Numbas.math.rangeToList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rationalApproximation"><a href="Numbas.math.html#.rationalApproximation">Numbas.math.rationalApproximation</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.re"><a href="Numbas.math.html#.re">Numbas.math.re</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.re_scientificNumber"><a href="Numbas.math.html#.re_scientificNumber">Numbas.math.re_scientificNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.root"><a href="Numbas.math.html#.root">Numbas.math.root</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.round"><a href="Numbas.math.html#.round">Numbas.math.round</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sec"><a href="Numbas.math.html#.sec">Numbas.math.sec</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sech"><a href="Numbas.math.html#.sech">Numbas.math.sech</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.shuffle"><a href="Numbas.math.html#.shuffle">Numbas.math.shuffle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sign"><a href="Numbas.math.html#.sign">Numbas.math.sign</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.siground"><a href="Numbas.math.html#.siground">Numbas.math.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sin"><a href="Numbas.math.html#.sin">Numbas.math.sin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sinh"><a href="Numbas.math.html#.sinh">Numbas.math.sinh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sqrt"><a href="Numbas.math.html#.sqrt">Numbas.math.sqrt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sub"><a href="Numbas.math.html#.sub">Numbas.math.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sum"><a href="Numbas.math.html#.sum">Numbas.math.sum</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.tan"><a href="Numbas.math.html#.tan">Numbas.math.tan</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.tanh"><a href="Numbas.math.html#.tanh">Numbas.math.tanh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.toGivenPrecision"><a href="Numbas.math.html#.toGivenPrecision">Numbas.math.toGivenPrecision</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.toNearest"><a href="Numbas.math.html#.toNearest">Numbas.math.toNearest</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.trunc"><a href="Numbas.math.html#.trunc">Numbas.math.trunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.unscientific"><a href="Numbas.math.html#.unscientific">Numbas.math.unscientific</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.withinTolerance"><a href="Numbas.math.html#.withinTolerance">Numbas.math.withinTolerance</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath"><a href="Numbas.matrixmath.html">Numbas.matrixmath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.abs"><a href="Numbas.matrixmath.html#.abs">Numbas.matrixmath.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.add"><a href="Numbas.matrixmath.html#.add">Numbas.matrixmath.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.eq"><a href="Numbas.matrixmath.html#.eq">Numbas.matrixmath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.id"><a href="Numbas.matrixmath.html#.id">Numbas.matrixmath.id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.map"><a href="Numbas.matrixmath.html#.map">Numbas.matrixmath.map</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.mul"><a href="Numbas.matrixmath.html#.mul">Numbas.matrixmath.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.negate"><a href="Numbas.matrixmath.html#.negate">Numbas.matrixmath.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.neq"><a href="Numbas.matrixmath.html#.neq">Numbas.matrixmath.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.precround"><a href="Numbas.matrixmath.html#.precround">Numbas.matrixmath.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.scalardiv"><a href="Numbas.matrixmath.html#.scalardiv">Numbas.matrixmath.scalardiv</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.scalarmul"><a href="Numbas.matrixmath.html#.scalarmul">Numbas.matrixmath.scalarmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.siground"><a href="Numbas.matrixmath.html#.siground">Numbas.matrixmath.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.sub"><a href="Numbas.matrixmath.html#.sub">Numbas.matrixmath.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.sum_cells"><a href="Numbas.matrixmath.html#.sum_cells">Numbas.matrixmath.sum_cells</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.transpose"><a href="Numbas.matrixmath.html#.transpose">Numbas.matrixmath.transpose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.partConstructors"><a href="Numbas.html#.partConstructors">Numbas.partConstructors</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts"><a href="Numbas.parts.html">Numbas.parts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart"><a href="Numbas.parts.CustomPart.html">Numbas.parts.CustomPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addCredit"><a href="Numbas.parts.CustomPart.html#addCredit">Numbas.parts.CustomPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addStep"><a href="Numbas.parts.CustomPart.html#addStep">Numbas.parts.CustomPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addVariableReplacement"><a href="Numbas.parts.CustomPart.html#addVariableReplacement">Numbas.parts.CustomPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#answered"><a href="Numbas.parts.CustomPart.html#answered">Numbas.parts.CustomPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#apply_feedback"><a href="Numbas.parts.CustomPart.html#apply_feedback">Numbas.parts.CustomPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#applyScoreLimits"><a href="Numbas.parts.CustomPart.html#applyScoreLimits">Numbas.parts.CustomPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#assignName"><a href="Numbas.parts.CustomPart.html#assignName">Numbas.parts.CustomPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#baseMarkingScript"><a href="Numbas.parts.CustomPart.html#baseMarkingScript">Numbas.parts.CustomPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#calculateScore"><a href="Numbas.parts.CustomPart.html#calculateScore">Numbas.parts.CustomPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#creditFraction"><a href="Numbas.parts.CustomPart.html#creditFraction">Numbas.parts.CustomPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#customName"><a href="Numbas.parts.CustomPart.html#customName">Numbas.parts.CustomPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#display"><a href="Numbas.parts.CustomPart.html#display">Numbas.parts.CustomPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#doesMarking"><a href="Numbas.parts.CustomPart.html#doesMarking">Numbas.parts.CustomPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#error"><a href="Numbas.parts.CustomPart.html#error">Numbas.parts.CustomPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#errorCarriedForwardScope"><a href="Numbas.parts.CustomPart.html#errorCarriedForwardScope">Numbas.parts.CustomPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#finalised_result"><a href="Numbas.parts.CustomPart.html#finalised_result">Numbas.parts.CustomPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#finaliseLoad"><a href="Numbas.parts.CustomPart.html#finaliseLoad">Numbas.parts.CustomPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#gaps"><a href="Numbas.parts.CustomPart.html#gaps">Numbas.parts.CustomPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#getCorrectAnswer"><a href="Numbas.parts.CustomPart.html#getCorrectAnswer">Numbas.parts.CustomPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#getScope"><a href="Numbas.parts.CustomPart.html#getScope">Numbas.parts.CustomPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#giveWarning"><a href="Numbas.parts.CustomPart.html#giveWarning">Numbas.parts.CustomPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#hasStagedAnswer"><a href="Numbas.parts.CustomPart.html#hasStagedAnswer">Numbas.parts.CustomPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#hideSteps"><a href="Numbas.parts.CustomPart.html#hideSteps">Numbas.parts.CustomPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#input_options"><a href="Numbas.parts.CustomPart.html#input_options">Numbas.parts.CustomPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#input_widget"><a href="Numbas.parts.CustomPart.html#input_widget">Numbas.parts.CustomPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#isDirty"><a href="Numbas.parts.CustomPart.html#isDirty">Numbas.parts.CustomPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#loadFromJSON"><a href="Numbas.parts.CustomPart.html#loadFromJSON">Numbas.parts.CustomPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#loadFromXML"><a href="Numbas.parts.CustomPart.html#loadFromXML">Numbas.parts.CustomPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#mark"><a href="Numbas.parts.CustomPart.html#mark">Numbas.parts.CustomPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#mark_answer"><a href="Numbas.parts.CustomPart.html#mark_answer">Numbas.parts.CustomPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markAgainstScope"><a href="Numbas.parts.CustomPart.html#markAgainstScope">Numbas.parts.CustomPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingComment"><a href="Numbas.parts.CustomPart.html#markingComment">Numbas.parts.CustomPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingFeedback"><a href="Numbas.parts.CustomPart.html#markingFeedback">Numbas.parts.CustomPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingScript"><a href="Numbas.parts.CustomPart.html#markingScript">Numbas.parts.CustomPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#marks"><a href="Numbas.parts.CustomPart.html#marks">Numbas.parts.CustomPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#multCredit"><a href="Numbas.parts.CustomPart.html#multCredit">Numbas.parts.CustomPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#name"><a href="Numbas.parts.CustomPart.html#name">Numbas.parts.CustomPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#openSteps"><a href="Numbas.parts.CustomPart.html#openSteps">Numbas.parts.CustomPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#parentPart"><a href="Numbas.parts.CustomPart.html#parentPart">Numbas.parts.CustomPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#path"><a href="Numbas.parts.CustomPart.html#path">Numbas.parts.CustomPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#pleaseResubmit"><a href="Numbas.parts.CustomPart.html#pleaseResubmit">Numbas.parts.CustomPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#question"><a href="Numbas.parts.CustomPart.html#question">Numbas.parts.CustomPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#rawStudentAnswerAsJME"><a href="Numbas.parts.CustomPart.html#rawStudentAnswerAsJME">Numbas.parts.CustomPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#removeWarnings"><a href="Numbas.parts.CustomPart.html#removeWarnings">Numbas.parts.CustomPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#resume"><a href="Numbas.parts.CustomPart.html#resume">Numbas.parts.CustomPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#revealAnswer"><a href="Numbas.parts.CustomPart.html#revealAnswer">Numbas.parts.CustomPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#score"><a href="Numbas.parts.CustomPart.html#score">Numbas.parts.CustomPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setCredit"><a href="Numbas.parts.CustomPart.html#setCredit">Numbas.parts.CustomPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setDirty"><a href="Numbas.parts.CustomPart.html#setDirty">Numbas.parts.CustomPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setMarkingScript"><a href="Numbas.parts.CustomPart.html#setMarkingScript">Numbas.parts.CustomPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setScript"><a href="Numbas.parts.CustomPart.html#setScript">Numbas.parts.CustomPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setStudentAnswer"><a href="Numbas.parts.CustomPart.html#setStudentAnswer">Numbas.parts.CustomPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#settings"><a href="Numbas.parts.CustomPart.html#settings">Numbas.parts.CustomPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setWarnings"><a href="Numbas.parts.CustomPart.html#setWarnings">Numbas.parts.CustomPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#shouldResubmit"><a href="Numbas.parts.CustomPart.html#shouldResubmit">Numbas.parts.CustomPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#showSteps"><a href="Numbas.parts.CustomPart.html#showSteps">Numbas.parts.CustomPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stagedAnswer"><a href="Numbas.parts.CustomPart.html#stagedAnswer">Numbas.parts.CustomPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#steps"><a href="Numbas.parts.CustomPart.html#steps">Numbas.parts.CustomPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsMarks"><a href="Numbas.parts.CustomPart.html#stepsMarks">Numbas.parts.CustomPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsOpen"><a href="Numbas.parts.CustomPart.html#stepsOpen">Numbas.parts.CustomPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsShown"><a href="Numbas.parts.CustomPart.html#stepsShown">Numbas.parts.CustomPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#store"><a href="Numbas.parts.CustomPart.html#store">Numbas.parts.CustomPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#storeAnswer"><a href="Numbas.parts.CustomPart.html#storeAnswer">Numbas.parts.CustomPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#studentAnswerAsJME"><a href="Numbas.parts.CustomPart.html#studentAnswerAsJME">Numbas.parts.CustomPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#subCredit"><a href="Numbas.parts.CustomPart.html#subCredit">Numbas.parts.CustomPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#submit"><a href="Numbas.parts.CustomPart.html#submit">Numbas.parts.CustomPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#type"><a href="Numbas.parts.CustomPart.html#type">Numbas.parts.CustomPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#useCustomName"><a href="Numbas.parts.CustomPart.html#useCustomName">Numbas.parts.CustomPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#warnings"><a href="Numbas.parts.CustomPart.html#warnings">Numbas.parts.CustomPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#xml"><a href="Numbas.parts.CustomPart.html#xml">Numbas.parts.CustomPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart"><a href="Numbas.parts.ExtensionPart.html">Numbas.parts.ExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addCredit"><a href="Numbas.parts.ExtensionPart.html#addCredit">Numbas.parts.ExtensionPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addStep"><a href="Numbas.parts.ExtensionPart.html#addStep">Numbas.parts.ExtensionPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addVariableReplacement"><a href="Numbas.parts.ExtensionPart.html#addVariableReplacement">Numbas.parts.ExtensionPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#answered"><a href="Numbas.parts.ExtensionPart.html#answered">Numbas.parts.ExtensionPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#apply_feedback"><a href="Numbas.parts.ExtensionPart.html#apply_feedback">Numbas.parts.ExtensionPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#applyScoreLimits"><a href="Numbas.parts.ExtensionPart.html#applyScoreLimits">Numbas.parts.ExtensionPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#assignName"><a href="Numbas.parts.ExtensionPart.html#assignName">Numbas.parts.ExtensionPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#baseMarkingScript"><a href="Numbas.parts.ExtensionPart.html#baseMarkingScript">Numbas.parts.ExtensionPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#calculateScore"><a href="Numbas.parts.ExtensionPart.html#calculateScore">Numbas.parts.ExtensionPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#createSuspendData"><a href="Numbas.parts.ExtensionPart.html#createSuspendData">Numbas.parts.ExtensionPart#createSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#creditFraction"><a href="Numbas.parts.ExtensionPart.html#creditFraction">Numbas.parts.ExtensionPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#customName"><a href="Numbas.parts.ExtensionPart.html#customName">Numbas.parts.ExtensionPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#display"><a href="Numbas.parts.ExtensionPart.html#display">Numbas.parts.ExtensionPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#doesMarking"><a href="Numbas.parts.ExtensionPart.html#doesMarking">Numbas.parts.ExtensionPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#error"><a href="Numbas.parts.ExtensionPart.html#error">Numbas.parts.ExtensionPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#errorCarriedForwardScope"><a href="Numbas.parts.ExtensionPart.html#errorCarriedForwardScope">Numbas.parts.ExtensionPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#finalised_result"><a href="Numbas.parts.ExtensionPart.html#finalised_result">Numbas.parts.ExtensionPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#finaliseLoad"><a href="Numbas.parts.ExtensionPart.html#finaliseLoad">Numbas.parts.ExtensionPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#gaps"><a href="Numbas.parts.ExtensionPart.html#gaps">Numbas.parts.ExtensionPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#getCorrectAnswer"><a href="Numbas.parts.ExtensionPart.html#getCorrectAnswer">Numbas.parts.ExtensionPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#getScope"><a href="Numbas.parts.ExtensionPart.html#getScope">Numbas.parts.ExtensionPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#giveWarning"><a href="Numbas.parts.ExtensionPart.html#giveWarning">Numbas.parts.ExtensionPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#hasStagedAnswer"><a href="Numbas.parts.ExtensionPart.html#hasStagedAnswer">Numbas.parts.ExtensionPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#hideSteps"><a href="Numbas.parts.ExtensionPart.html#hideSteps">Numbas.parts.ExtensionPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#input_options"><a href="Numbas.parts.ExtensionPart.html#input_options">Numbas.parts.ExtensionPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#input_widget"><a href="Numbas.parts.ExtensionPart.html#input_widget">Numbas.parts.ExtensionPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#isDirty"><a href="Numbas.parts.ExtensionPart.html#isDirty">Numbas.parts.ExtensionPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadFromJSON"><a href="Numbas.parts.ExtensionPart.html#loadFromJSON">Numbas.parts.ExtensionPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadFromXML"><a href="Numbas.parts.ExtensionPart.html#loadFromXML">Numbas.parts.ExtensionPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadSuspendData"><a href="Numbas.parts.ExtensionPart.html#loadSuspendData">Numbas.parts.ExtensionPart#loadSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#mark"><a href="Numbas.parts.ExtensionPart.html#mark">Numbas.parts.ExtensionPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#mark_answer"><a href="Numbas.parts.ExtensionPart.html#mark_answer">Numbas.parts.ExtensionPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markAgainstScope"><a href="Numbas.parts.ExtensionPart.html#markAgainstScope">Numbas.parts.ExtensionPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingComment"><a href="Numbas.parts.ExtensionPart.html#markingComment">Numbas.parts.ExtensionPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingFeedback"><a href="Numbas.parts.ExtensionPart.html#markingFeedback">Numbas.parts.ExtensionPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingScript"><a href="Numbas.parts.ExtensionPart.html#markingScript">Numbas.parts.ExtensionPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#marks"><a href="Numbas.parts.ExtensionPart.html#marks">Numbas.parts.ExtensionPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#multCredit"><a href="Numbas.parts.ExtensionPart.html#multCredit">Numbas.parts.ExtensionPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#name"><a href="Numbas.parts.ExtensionPart.html#name">Numbas.parts.ExtensionPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#openSteps"><a href="Numbas.parts.ExtensionPart.html#openSteps">Numbas.parts.ExtensionPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#parentPart"><a href="Numbas.parts.ExtensionPart.html#parentPart">Numbas.parts.ExtensionPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#path"><a href="Numbas.parts.ExtensionPart.html#path">Numbas.parts.ExtensionPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#pleaseResubmit"><a href="Numbas.parts.ExtensionPart.html#pleaseResubmit">Numbas.parts.ExtensionPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#question"><a href="Numbas.parts.ExtensionPart.html#question">Numbas.parts.ExtensionPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#rawStudentAnswerAsJME"><a href="Numbas.parts.ExtensionPart.html#rawStudentAnswerAsJME">Numbas.parts.ExtensionPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#removeWarnings"><a href="Numbas.parts.ExtensionPart.html#removeWarnings">Numbas.parts.ExtensionPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#resume"><a href="Numbas.parts.ExtensionPart.html#resume">Numbas.parts.ExtensionPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#revealAnswer"><a href="Numbas.parts.ExtensionPart.html#revealAnswer">Numbas.parts.ExtensionPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#score"><a href="Numbas.parts.ExtensionPart.html#score">Numbas.parts.ExtensionPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setCredit"><a href="Numbas.parts.ExtensionPart.html#setCredit">Numbas.parts.ExtensionPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setDirty"><a href="Numbas.parts.ExtensionPart.html#setDirty">Numbas.parts.ExtensionPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setMarkingScript"><a href="Numbas.parts.ExtensionPart.html#setMarkingScript">Numbas.parts.ExtensionPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setScript"><a href="Numbas.parts.ExtensionPart.html#setScript">Numbas.parts.ExtensionPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setStudentAnswer"><a href="Numbas.parts.ExtensionPart.html#setStudentAnswer">Numbas.parts.ExtensionPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#settings"><a href="Numbas.parts.ExtensionPart.html#settings">Numbas.parts.ExtensionPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setWarnings"><a href="Numbas.parts.ExtensionPart.html#setWarnings">Numbas.parts.ExtensionPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#shouldResubmit"><a href="Numbas.parts.ExtensionPart.html#shouldResubmit">Numbas.parts.ExtensionPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#showSteps"><a href="Numbas.parts.ExtensionPart.html#showSteps">Numbas.parts.ExtensionPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stagedAnswer"><a href="Numbas.parts.ExtensionPart.html#stagedAnswer">Numbas.parts.ExtensionPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#steps"><a href="Numbas.parts.ExtensionPart.html#steps">Numbas.parts.ExtensionPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsMarks"><a href="Numbas.parts.ExtensionPart.html#stepsMarks">Numbas.parts.ExtensionPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsOpen"><a href="Numbas.parts.ExtensionPart.html#stepsOpen">Numbas.parts.ExtensionPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsShown"><a href="Numbas.parts.ExtensionPart.html#stepsShown">Numbas.parts.ExtensionPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#store"><a href="Numbas.parts.ExtensionPart.html#store">Numbas.parts.ExtensionPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#storeAnswer"><a href="Numbas.parts.ExtensionPart.html#storeAnswer">Numbas.parts.ExtensionPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#studentAnswerAsJME"><a href="Numbas.parts.ExtensionPart.html#studentAnswerAsJME">Numbas.parts.ExtensionPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#subCredit"><a href="Numbas.parts.ExtensionPart.html#subCredit">Numbas.parts.ExtensionPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#submit"><a href="Numbas.parts.ExtensionPart.html#submit">Numbas.parts.ExtensionPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#type"><a href="Numbas.parts.ExtensionPart.html#type">Numbas.parts.ExtensionPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#useCustomName"><a href="Numbas.parts.ExtensionPart.html#useCustomName">Numbas.parts.ExtensionPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#warnings"><a href="Numbas.parts.ExtensionPart.html#warnings">Numbas.parts.ExtensionPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#xml"><a href="Numbas.parts.ExtensionPart.html#xml">Numbas.parts.ExtensionPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.feedbackmessage"><a href="Numbas.parts.html#.feedbackmessage">Numbas.parts.feedbackmessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart"><a href="Numbas.parts.GapFillPart.html">Numbas.parts.GapFillPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addCredit"><a href="Numbas.parts.GapFillPart.html#addCredit">Numbas.parts.GapFillPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addGap"><a href="Numbas.parts.GapFillPart.html#addGap">Numbas.parts.GapFillPart#addGap</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addStep"><a href="Numbas.parts.GapFillPart.html#addStep">Numbas.parts.GapFillPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addVariableReplacement"><a href="Numbas.parts.GapFillPart.html#addVariableReplacement">Numbas.parts.GapFillPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#answered"><a href="Numbas.parts.GapFillPart.html#answered">Numbas.parts.GapFillPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#apply_feedback"><a href="Numbas.parts.GapFillPart.html#apply_feedback">Numbas.parts.GapFillPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#applyScoreLimits"><a href="Numbas.parts.GapFillPart.html#applyScoreLimits">Numbas.parts.GapFillPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#assignName"><a href="Numbas.parts.GapFillPart.html#assignName">Numbas.parts.GapFillPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#baseMarkingScript"><a href="Numbas.parts.GapFillPart.html#baseMarkingScript">Numbas.parts.GapFillPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#calculateScore"><a href="Numbas.parts.GapFillPart.html#calculateScore">Numbas.parts.GapFillPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#creditFraction"><a href="Numbas.parts.GapFillPart.html#creditFraction">Numbas.parts.GapFillPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#customName"><a href="Numbas.parts.GapFillPart.html#customName">Numbas.parts.GapFillPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#display"><a href="Numbas.parts.GapFillPart.html#display">Numbas.parts.GapFillPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#doesMarking"><a href="Numbas.parts.GapFillPart.html#doesMarking">Numbas.parts.GapFillPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#error"><a href="Numbas.parts.GapFillPart.html#error">Numbas.parts.GapFillPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#errorCarriedForwardScope"><a href="Numbas.parts.GapFillPart.html#errorCarriedForwardScope">Numbas.parts.GapFillPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#finalised_result"><a href="Numbas.parts.GapFillPart.html#finalised_result">Numbas.parts.GapFillPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#finaliseLoad"><a href="Numbas.parts.GapFillPart.html#finaliseLoad">Numbas.parts.GapFillPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#gaps"><a href="Numbas.parts.GapFillPart.html#gaps">Numbas.parts.GapFillPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#getCorrectAnswer"><a href="Numbas.parts.GapFillPart.html#getCorrectAnswer">Numbas.parts.GapFillPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#getScope"><a href="Numbas.parts.GapFillPart.html#getScope">Numbas.parts.GapFillPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#giveWarning"><a href="Numbas.parts.GapFillPart.html#giveWarning">Numbas.parts.GapFillPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#hasStagedAnswer"><a href="Numbas.parts.GapFillPart.html#hasStagedAnswer">Numbas.parts.GapFillPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#hideSteps"><a href="Numbas.parts.GapFillPart.html#hideSteps">Numbas.parts.GapFillPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#input_options"><a href="Numbas.parts.GapFillPart.html#input_options">Numbas.parts.GapFillPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#input_widget"><a href="Numbas.parts.GapFillPart.html#input_widget">Numbas.parts.GapFillPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#isDirty"><a href="Numbas.parts.GapFillPart.html#isDirty">Numbas.parts.GapFillPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#loadFromJSON"><a href="Numbas.parts.GapFillPart.html#loadFromJSON">Numbas.parts.GapFillPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#loadFromXML"><a href="Numbas.parts.GapFillPart.html#loadFromXML">Numbas.parts.GapFillPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#mark"><a href="Numbas.parts.GapFillPart.html#mark">Numbas.parts.GapFillPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#mark_answer"><a href="Numbas.parts.GapFillPart.html#mark_answer">Numbas.parts.GapFillPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markAgainstScope"><a href="Numbas.parts.GapFillPart.html#markAgainstScope">Numbas.parts.GapFillPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingComment"><a href="Numbas.parts.GapFillPart.html#markingComment">Numbas.parts.GapFillPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingFeedback"><a href="Numbas.parts.GapFillPart.html#markingFeedback">Numbas.parts.GapFillPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingScript"><a href="Numbas.parts.GapFillPart.html#markingScript">Numbas.parts.GapFillPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#marks"><a href="Numbas.parts.GapFillPart.html#marks">Numbas.parts.GapFillPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#multCredit"><a href="Numbas.parts.GapFillPart.html#multCredit">Numbas.parts.GapFillPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#name"><a href="Numbas.parts.GapFillPart.html#name">Numbas.parts.GapFillPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#openSteps"><a href="Numbas.parts.GapFillPart.html#openSteps">Numbas.parts.GapFillPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#parentPart"><a href="Numbas.parts.GapFillPart.html#parentPart">Numbas.parts.GapFillPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#path"><a href="Numbas.parts.GapFillPart.html#path">Numbas.parts.GapFillPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#pleaseResubmit"><a href="Numbas.parts.GapFillPart.html#pleaseResubmit">Numbas.parts.GapFillPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#question"><a href="Numbas.parts.GapFillPart.html#question">Numbas.parts.GapFillPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#rawStudentAnswerAsJME"><a href="Numbas.parts.GapFillPart.html#rawStudentAnswerAsJME">Numbas.parts.GapFillPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#removeWarnings"><a href="Numbas.parts.GapFillPart.html#removeWarnings">Numbas.parts.GapFillPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#resume"><a href="Numbas.parts.GapFillPart.html#resume">Numbas.parts.GapFillPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#revealAnswer"><a href="Numbas.parts.GapFillPart.html#revealAnswer">Numbas.parts.GapFillPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#score"><a href="Numbas.parts.GapFillPart.html#score">Numbas.parts.GapFillPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setCredit"><a href="Numbas.parts.GapFillPart.html#setCredit">Numbas.parts.GapFillPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setDirty"><a href="Numbas.parts.GapFillPart.html#setDirty">Numbas.parts.GapFillPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setMarkingScript"><a href="Numbas.parts.GapFillPart.html#setMarkingScript">Numbas.parts.GapFillPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setScript"><a href="Numbas.parts.GapFillPart.html#setScript">Numbas.parts.GapFillPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setStudentAnswer"><a href="Numbas.parts.GapFillPart.html#setStudentAnswer">Numbas.parts.GapFillPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#settings"><a href="Numbas.parts.GapFillPart.html#settings">Numbas.parts.GapFillPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setWarnings"><a href="Numbas.parts.GapFillPart.html#setWarnings">Numbas.parts.GapFillPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#shouldResubmit"><a href="Numbas.parts.GapFillPart.html#shouldResubmit">Numbas.parts.GapFillPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#showSteps"><a href="Numbas.parts.GapFillPart.html#showSteps">Numbas.parts.GapFillPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stagedAnswer"><a href="Numbas.parts.GapFillPart.html#stagedAnswer">Numbas.parts.GapFillPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#steps"><a href="Numbas.parts.GapFillPart.html#steps">Numbas.parts.GapFillPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsMarks"><a href="Numbas.parts.GapFillPart.html#stepsMarks">Numbas.parts.GapFillPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsOpen"><a href="Numbas.parts.GapFillPart.html#stepsOpen">Numbas.parts.GapFillPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsShown"><a href="Numbas.parts.GapFillPart.html#stepsShown">Numbas.parts.GapFillPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#store"><a href="Numbas.parts.GapFillPart.html#store">Numbas.parts.GapFillPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#storeAnswer"><a href="Numbas.parts.GapFillPart.html#storeAnswer">Numbas.parts.GapFillPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#studentAnswerAsJME"><a href="Numbas.parts.GapFillPart.html#studentAnswerAsJME">Numbas.parts.GapFillPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#subCredit"><a href="Numbas.parts.GapFillPart.html#subCredit">Numbas.parts.GapFillPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#submit"><a href="Numbas.parts.GapFillPart.html#submit">Numbas.parts.GapFillPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#type"><a href="Numbas.parts.GapFillPart.html#type">Numbas.parts.GapFillPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#useCustomName"><a href="Numbas.parts.GapFillPart.html#useCustomName">Numbas.parts.GapFillPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#warnings"><a href="Numbas.parts.GapFillPart.html#warnings">Numbas.parts.GapFillPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#xml"><a href="Numbas.parts.GapFillPart.html#xml">Numbas.parts.GapFillPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart"><a href="Numbas.parts.InformationOnlyPart.html">Numbas.parts.InformationOnlyPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart#setDirty"><a href="Numbas.parts.InformationOnlyPart.html#setDirty">Numbas.parts.InformationOnlyPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart#validate"><a href="Numbas.parts.InformationOnlyPart.html#validate">Numbas.parts.InformationOnlyPart#validate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart"><a href="Numbas.parts.InformationPart.html">Numbas.parts.InformationPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addCredit"><a href="Numbas.parts.InformationPart.html#addCredit">Numbas.parts.InformationPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addStep"><a href="Numbas.parts.InformationPart.html#addStep">Numbas.parts.InformationPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addVariableReplacement"><a href="Numbas.parts.InformationPart.html#addVariableReplacement">Numbas.parts.InformationPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#answered"><a href="Numbas.parts.InformationPart.html#answered">Numbas.parts.InformationPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#apply_feedback"><a href="Numbas.parts.InformationPart.html#apply_feedback">Numbas.parts.InformationPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#applyScoreLimits"><a href="Numbas.parts.InformationPart.html#applyScoreLimits">Numbas.parts.InformationPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#assignName"><a href="Numbas.parts.InformationPart.html#assignName">Numbas.parts.InformationPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#baseMarkingScript"><a href="Numbas.parts.InformationPart.html#baseMarkingScript">Numbas.parts.InformationPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#calculateScore"><a href="Numbas.parts.InformationPart.html#calculateScore">Numbas.parts.InformationPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#creditFraction"><a href="Numbas.parts.InformationPart.html#creditFraction">Numbas.parts.InformationPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#customName"><a href="Numbas.parts.InformationPart.html#customName">Numbas.parts.InformationPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#display"><a href="Numbas.parts.InformationPart.html#display">Numbas.parts.InformationPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#doesMarking"><a href="Numbas.parts.InformationPart.html#doesMarking">Numbas.parts.InformationPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#error"><a href="Numbas.parts.InformationPart.html#error">Numbas.parts.InformationPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#errorCarriedForwardScope"><a href="Numbas.parts.InformationPart.html#errorCarriedForwardScope">Numbas.parts.InformationPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#finalised_result"><a href="Numbas.parts.InformationPart.html#finalised_result">Numbas.parts.InformationPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#finaliseLoad"><a href="Numbas.parts.InformationPart.html#finaliseLoad">Numbas.parts.InformationPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#gaps"><a href="Numbas.parts.InformationPart.html#gaps">Numbas.parts.InformationPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#getCorrectAnswer"><a href="Numbas.parts.InformationPart.html#getCorrectAnswer">Numbas.parts.InformationPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#getScope"><a href="Numbas.parts.InformationPart.html#getScope">Numbas.parts.InformationPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#giveWarning"><a href="Numbas.parts.InformationPart.html#giveWarning">Numbas.parts.InformationPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#hasStagedAnswer"><a href="Numbas.parts.InformationPart.html#hasStagedAnswer">Numbas.parts.InformationPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#hideSteps"><a href="Numbas.parts.InformationPart.html#hideSteps">Numbas.parts.InformationPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#input_options"><a href="Numbas.parts.InformationPart.html#input_options">Numbas.parts.InformationPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#input_widget"><a href="Numbas.parts.InformationPart.html#input_widget">Numbas.parts.InformationPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#isDirty"><a href="Numbas.parts.InformationPart.html#isDirty">Numbas.parts.InformationPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#loadFromJSON"><a href="Numbas.parts.InformationPart.html#loadFromJSON">Numbas.parts.InformationPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#loadFromXML"><a href="Numbas.parts.InformationPart.html#loadFromXML">Numbas.parts.InformationPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#mark"><a href="Numbas.parts.InformationPart.html#mark">Numbas.parts.InformationPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#mark_answer"><a href="Numbas.parts.InformationPart.html#mark_answer">Numbas.parts.InformationPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markAgainstScope"><a href="Numbas.parts.InformationPart.html#markAgainstScope">Numbas.parts.InformationPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingComment"><a href="Numbas.parts.InformationPart.html#markingComment">Numbas.parts.InformationPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingFeedback"><a href="Numbas.parts.InformationPart.html#markingFeedback">Numbas.parts.InformationPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingScript"><a href="Numbas.parts.InformationPart.html#markingScript">Numbas.parts.InformationPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#marks"><a href="Numbas.parts.InformationPart.html#marks">Numbas.parts.InformationPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#multCredit"><a href="Numbas.parts.InformationPart.html#multCredit">Numbas.parts.InformationPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#name"><a href="Numbas.parts.InformationPart.html#name">Numbas.parts.InformationPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#openSteps"><a href="Numbas.parts.InformationPart.html#openSteps">Numbas.parts.InformationPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#parentPart"><a href="Numbas.parts.InformationPart.html#parentPart">Numbas.parts.InformationPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#path"><a href="Numbas.parts.InformationPart.html#path">Numbas.parts.InformationPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#pleaseResubmit"><a href="Numbas.parts.InformationPart.html#pleaseResubmit">Numbas.parts.InformationPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#question"><a href="Numbas.parts.InformationPart.html#question">Numbas.parts.InformationPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#rawStudentAnswerAsJME"><a href="Numbas.parts.InformationPart.html#rawStudentAnswerAsJME">Numbas.parts.InformationPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#removeWarnings"><a href="Numbas.parts.InformationPart.html#removeWarnings">Numbas.parts.InformationPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#resume"><a href="Numbas.parts.InformationPart.html#resume">Numbas.parts.InformationPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#revealAnswer"><a href="Numbas.parts.InformationPart.html#revealAnswer">Numbas.parts.InformationPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#score"><a href="Numbas.parts.InformationPart.html#score">Numbas.parts.InformationPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setCredit"><a href="Numbas.parts.InformationPart.html#setCredit">Numbas.parts.InformationPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setDirty"><a href="Numbas.parts.InformationPart.html#setDirty">Numbas.parts.InformationPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setMarkingScript"><a href="Numbas.parts.InformationPart.html#setMarkingScript">Numbas.parts.InformationPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setScript"><a href="Numbas.parts.InformationPart.html#setScript">Numbas.parts.InformationPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setStudentAnswer"><a href="Numbas.parts.InformationPart.html#setStudentAnswer">Numbas.parts.InformationPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#settings"><a href="Numbas.parts.InformationPart.html#settings">Numbas.parts.InformationPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setWarnings"><a href="Numbas.parts.InformationPart.html#setWarnings">Numbas.parts.InformationPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#shouldResubmit"><a href="Numbas.parts.InformationPart.html#shouldResubmit">Numbas.parts.InformationPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#showSteps"><a href="Numbas.parts.InformationPart.html#showSteps">Numbas.parts.InformationPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stagedAnswer"><a href="Numbas.parts.InformationPart.html#stagedAnswer">Numbas.parts.InformationPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#steps"><a href="Numbas.parts.InformationPart.html#steps">Numbas.parts.InformationPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsMarks"><a href="Numbas.parts.InformationPart.html#stepsMarks">Numbas.parts.InformationPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsOpen"><a href="Numbas.parts.InformationPart.html#stepsOpen">Numbas.parts.InformationPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsShown"><a href="Numbas.parts.InformationPart.html#stepsShown">Numbas.parts.InformationPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#store"><a href="Numbas.parts.InformationPart.html#store">Numbas.parts.InformationPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#storeAnswer"><a href="Numbas.parts.InformationPart.html#storeAnswer">Numbas.parts.InformationPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#studentAnswerAsJME"><a href="Numbas.parts.InformationPart.html#studentAnswerAsJME">Numbas.parts.InformationPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#subCredit"><a href="Numbas.parts.InformationPart.html#subCredit">Numbas.parts.InformationPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#submit"><a href="Numbas.parts.InformationPart.html#submit">Numbas.parts.InformationPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#type"><a href="Numbas.parts.InformationPart.html#type">Numbas.parts.InformationPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#useCustomName"><a href="Numbas.parts.InformationPart.html#useCustomName">Numbas.parts.InformationPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#warnings"><a href="Numbas.parts.InformationPart.html#warnings">Numbas.parts.InformationPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#xml"><a href="Numbas.parts.InformationPart.html#xml">Numbas.parts.InformationPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart"><a href="Numbas.parts.JMEPart.html">Numbas.parts.JMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addCredit"><a href="Numbas.parts.JMEPart.html#addCredit">Numbas.parts.JMEPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addStep"><a href="Numbas.parts.JMEPart.html#addStep">Numbas.parts.JMEPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addVariableReplacement"><a href="Numbas.parts.JMEPart.html#addVariableReplacement">Numbas.parts.JMEPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#answered"><a href="Numbas.parts.JMEPart.html#answered">Numbas.parts.JMEPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#apply_feedback"><a href="Numbas.parts.JMEPart.html#apply_feedback">Numbas.parts.JMEPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#applyScoreLimits"><a href="Numbas.parts.JMEPart.html#applyScoreLimits">Numbas.parts.JMEPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#assignName"><a href="Numbas.parts.JMEPart.html#assignName">Numbas.parts.JMEPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#baseMarkingScript"><a href="Numbas.parts.JMEPart.html#baseMarkingScript">Numbas.parts.JMEPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#calculateScore"><a href="Numbas.parts.JMEPart.html#calculateScore">Numbas.parts.JMEPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#creditFraction"><a href="Numbas.parts.JMEPart.html#creditFraction">Numbas.parts.JMEPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#customName"><a href="Numbas.parts.JMEPart.html#customName">Numbas.parts.JMEPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#display"><a href="Numbas.parts.JMEPart.html#display">Numbas.parts.JMEPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#doesMarking"><a href="Numbas.parts.JMEPart.html#doesMarking">Numbas.parts.JMEPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#error"><a href="Numbas.parts.JMEPart.html#error">Numbas.parts.JMEPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#errorCarriedForwardScope"><a href="Numbas.parts.JMEPart.html#errorCarriedForwardScope">Numbas.parts.JMEPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#finalised_result"><a href="Numbas.parts.JMEPart.html#finalised_result">Numbas.parts.JMEPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#finaliseLoad"><a href="Numbas.parts.JMEPart.html#finaliseLoad">Numbas.parts.JMEPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#gaps"><a href="Numbas.parts.JMEPart.html#gaps">Numbas.parts.JMEPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#getCorrectAnswer"><a href="Numbas.parts.JMEPart.html#getCorrectAnswer">Numbas.parts.JMEPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#getScope"><a href="Numbas.parts.JMEPart.html#getScope">Numbas.parts.JMEPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#giveWarning"><a href="Numbas.parts.JMEPart.html#giveWarning">Numbas.parts.JMEPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#hasStagedAnswer"><a href="Numbas.parts.JMEPart.html#hasStagedAnswer">Numbas.parts.JMEPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#hideSteps"><a href="Numbas.parts.JMEPart.html#hideSteps">Numbas.parts.JMEPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#input_options"><a href="Numbas.parts.JMEPart.html#input_options">Numbas.parts.JMEPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#input_widget"><a href="Numbas.parts.JMEPart.html#input_widget">Numbas.parts.JMEPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#isDirty"><a href="Numbas.parts.JMEPart.html#isDirty">Numbas.parts.JMEPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#loadFromJSON"><a href="Numbas.parts.JMEPart.html#loadFromJSON">Numbas.parts.JMEPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#loadFromXML"><a href="Numbas.parts.JMEPart.html#loadFromXML">Numbas.parts.JMEPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#mark"><a href="Numbas.parts.JMEPart.html#mark">Numbas.parts.JMEPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#mark_answer"><a href="Numbas.parts.JMEPart.html#mark_answer">Numbas.parts.JMEPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markAgainstScope"><a href="Numbas.parts.JMEPart.html#markAgainstScope">Numbas.parts.JMEPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingComment"><a href="Numbas.parts.JMEPart.html#markingComment">Numbas.parts.JMEPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingFeedback"><a href="Numbas.parts.JMEPart.html#markingFeedback">Numbas.parts.JMEPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingScript"><a href="Numbas.parts.JMEPart.html#markingScript">Numbas.parts.JMEPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#marks"><a href="Numbas.parts.JMEPart.html#marks">Numbas.parts.JMEPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#multCredit"><a href="Numbas.parts.JMEPart.html#multCredit">Numbas.parts.JMEPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#name"><a href="Numbas.parts.JMEPart.html#name">Numbas.parts.JMEPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#openSteps"><a href="Numbas.parts.JMEPart.html#openSteps">Numbas.parts.JMEPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#parentPart"><a href="Numbas.parts.JMEPart.html#parentPart">Numbas.parts.JMEPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#path"><a href="Numbas.parts.JMEPart.html#path">Numbas.parts.JMEPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#pleaseResubmit"><a href="Numbas.parts.JMEPart.html#pleaseResubmit">Numbas.parts.JMEPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#question"><a href="Numbas.parts.JMEPart.html#question">Numbas.parts.JMEPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#rawStudentAnswerAsJME"><a href="Numbas.parts.JMEPart.html#rawStudentAnswerAsJME">Numbas.parts.JMEPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#removeWarnings"><a href="Numbas.parts.JMEPart.html#removeWarnings">Numbas.parts.JMEPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#resume"><a href="Numbas.parts.JMEPart.html#resume">Numbas.parts.JMEPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#revealAnswer"><a href="Numbas.parts.JMEPart.html#revealAnswer">Numbas.parts.JMEPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#score"><a href="Numbas.parts.JMEPart.html#score">Numbas.parts.JMEPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setCredit"><a href="Numbas.parts.JMEPart.html#setCredit">Numbas.parts.JMEPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setDirty"><a href="Numbas.parts.JMEPart.html#setDirty">Numbas.parts.JMEPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setMarkingScript"><a href="Numbas.parts.JMEPart.html#setMarkingScript">Numbas.parts.JMEPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setScript"><a href="Numbas.parts.JMEPart.html#setScript">Numbas.parts.JMEPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setStudentAnswer"><a href="Numbas.parts.JMEPart.html#setStudentAnswer">Numbas.parts.JMEPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#settings"><a href="Numbas.parts.JMEPart.html#settings">Numbas.parts.JMEPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setWarnings"><a href="Numbas.parts.JMEPart.html#setWarnings">Numbas.parts.JMEPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#shouldResubmit"><a href="Numbas.parts.JMEPart.html#shouldResubmit">Numbas.parts.JMEPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#showSteps"><a href="Numbas.parts.JMEPart.html#showSteps">Numbas.parts.JMEPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stagedAnswer"><a href="Numbas.parts.JMEPart.html#stagedAnswer">Numbas.parts.JMEPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#steps"><a href="Numbas.parts.JMEPart.html#steps">Numbas.parts.JMEPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsMarks"><a href="Numbas.parts.JMEPart.html#stepsMarks">Numbas.parts.JMEPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsOpen"><a href="Numbas.parts.JMEPart.html#stepsOpen">Numbas.parts.JMEPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsShown"><a href="Numbas.parts.JMEPart.html#stepsShown">Numbas.parts.JMEPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#store"><a href="Numbas.parts.JMEPart.html#store">Numbas.parts.JMEPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#storeAnswer"><a href="Numbas.parts.JMEPart.html#storeAnswer">Numbas.parts.JMEPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#studentAnswerAsJME"><a href="Numbas.parts.JMEPart.html#studentAnswerAsJME">Numbas.parts.JMEPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#subCredit"><a href="Numbas.parts.JMEPart.html#subCredit">Numbas.parts.JMEPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#submit"><a href="Numbas.parts.JMEPart.html#submit">Numbas.parts.JMEPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#type"><a href="Numbas.parts.JMEPart.html#type">Numbas.parts.JMEPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#useCustomName"><a href="Numbas.parts.JMEPart.html#useCustomName">Numbas.parts.JMEPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#warnings"><a href="Numbas.parts.JMEPart.html#warnings">Numbas.parts.JMEPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#xml"><a href="Numbas.parts.JMEPart.html#xml">Numbas.parts.JMEPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.marking_results"><a href="Numbas.parts.html#.marking_results">Numbas.parts.marking_results</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart"><a href="Numbas.parts.MatrixEntryPart.html">Numbas.parts.MatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addCredit"><a href="Numbas.parts.MatrixEntryPart.html#addCredit">Numbas.parts.MatrixEntryPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addStep"><a href="Numbas.parts.MatrixEntryPart.html#addStep">Numbas.parts.MatrixEntryPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addVariableReplacement"><a href="Numbas.parts.MatrixEntryPart.html#addVariableReplacement">Numbas.parts.MatrixEntryPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#answered"><a href="Numbas.parts.MatrixEntryPart.html#answered">Numbas.parts.MatrixEntryPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#apply_feedback"><a href="Numbas.parts.MatrixEntryPart.html#apply_feedback">Numbas.parts.MatrixEntryPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#applyScoreLimits"><a href="Numbas.parts.MatrixEntryPart.html#applyScoreLimits">Numbas.parts.MatrixEntryPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#assignName"><a href="Numbas.parts.MatrixEntryPart.html#assignName">Numbas.parts.MatrixEntryPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#baseMarkingScript"><a href="Numbas.parts.MatrixEntryPart.html#baseMarkingScript">Numbas.parts.MatrixEntryPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#calculateScore"><a href="Numbas.parts.MatrixEntryPart.html#calculateScore">Numbas.parts.MatrixEntryPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#creditFraction"><a href="Numbas.parts.MatrixEntryPart.html#creditFraction">Numbas.parts.MatrixEntryPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#customName"><a href="Numbas.parts.MatrixEntryPart.html#customName">Numbas.parts.MatrixEntryPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#display"><a href="Numbas.parts.MatrixEntryPart.html#display">Numbas.parts.MatrixEntryPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#doesMarking"><a href="Numbas.parts.MatrixEntryPart.html#doesMarking">Numbas.parts.MatrixEntryPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#error"><a href="Numbas.parts.MatrixEntryPart.html#error">Numbas.parts.MatrixEntryPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#errorCarriedForwardScope"><a href="Numbas.parts.MatrixEntryPart.html#errorCarriedForwardScope">Numbas.parts.MatrixEntryPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#finalised_result"><a href="Numbas.parts.MatrixEntryPart.html#finalised_result">Numbas.parts.MatrixEntryPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#finaliseLoad"><a href="Numbas.parts.MatrixEntryPart.html#finaliseLoad">Numbas.parts.MatrixEntryPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#gaps"><a href="Numbas.parts.MatrixEntryPart.html#gaps">Numbas.parts.MatrixEntryPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#getCorrectAnswer"><a href="Numbas.parts.MatrixEntryPart.html#getCorrectAnswer">Numbas.parts.MatrixEntryPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#getScope"><a href="Numbas.parts.MatrixEntryPart.html#getScope">Numbas.parts.MatrixEntryPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#giveWarning"><a href="Numbas.parts.MatrixEntryPart.html#giveWarning">Numbas.parts.MatrixEntryPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#hasStagedAnswer"><a href="Numbas.parts.MatrixEntryPart.html#hasStagedAnswer">Numbas.parts.MatrixEntryPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#hideSteps"><a href="Numbas.parts.MatrixEntryPart.html#hideSteps">Numbas.parts.MatrixEntryPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#input_options"><a href="Numbas.parts.MatrixEntryPart.html#input_options">Numbas.parts.MatrixEntryPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#input_widget"><a href="Numbas.parts.MatrixEntryPart.html#input_widget">Numbas.parts.MatrixEntryPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#isDirty"><a href="Numbas.parts.MatrixEntryPart.html#isDirty">Numbas.parts.MatrixEntryPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#loadFromJSON"><a href="Numbas.parts.MatrixEntryPart.html#loadFromJSON">Numbas.parts.MatrixEntryPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#loadFromXML"><a href="Numbas.parts.MatrixEntryPart.html#loadFromXML">Numbas.parts.MatrixEntryPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#mark"><a href="Numbas.parts.MatrixEntryPart.html#mark">Numbas.parts.MatrixEntryPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#mark_answer"><a href="Numbas.parts.MatrixEntryPart.html#mark_answer">Numbas.parts.MatrixEntryPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markAgainstScope"><a href="Numbas.parts.MatrixEntryPart.html#markAgainstScope">Numbas.parts.MatrixEntryPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingComment"><a href="Numbas.parts.MatrixEntryPart.html#markingComment">Numbas.parts.MatrixEntryPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingFeedback"><a href="Numbas.parts.MatrixEntryPart.html#markingFeedback">Numbas.parts.MatrixEntryPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingScript"><a href="Numbas.parts.MatrixEntryPart.html#markingScript">Numbas.parts.MatrixEntryPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#marks"><a href="Numbas.parts.MatrixEntryPart.html#marks">Numbas.parts.MatrixEntryPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#multCredit"><a href="Numbas.parts.MatrixEntryPart.html#multCredit">Numbas.parts.MatrixEntryPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#name"><a href="Numbas.parts.MatrixEntryPart.html#name">Numbas.parts.MatrixEntryPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#openSteps"><a href="Numbas.parts.MatrixEntryPart.html#openSteps">Numbas.parts.MatrixEntryPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#parentPart"><a href="Numbas.parts.MatrixEntryPart.html#parentPart">Numbas.parts.MatrixEntryPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#path"><a href="Numbas.parts.MatrixEntryPart.html#path">Numbas.parts.MatrixEntryPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#pleaseResubmit"><a href="Numbas.parts.MatrixEntryPart.html#pleaseResubmit">Numbas.parts.MatrixEntryPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#question"><a href="Numbas.parts.MatrixEntryPart.html#question">Numbas.parts.MatrixEntryPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#rawStudentAnswerAsJME"><a href="Numbas.parts.MatrixEntryPart.html#rawStudentAnswerAsJME">Numbas.parts.MatrixEntryPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#removeWarnings"><a href="Numbas.parts.MatrixEntryPart.html#removeWarnings">Numbas.parts.MatrixEntryPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#resume"><a href="Numbas.parts.MatrixEntryPart.html#resume">Numbas.parts.MatrixEntryPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#revealAnswer"><a href="Numbas.parts.MatrixEntryPart.html#revealAnswer">Numbas.parts.MatrixEntryPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#score"><a href="Numbas.parts.MatrixEntryPart.html#score">Numbas.parts.MatrixEntryPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setCredit"><a href="Numbas.parts.MatrixEntryPart.html#setCredit">Numbas.parts.MatrixEntryPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setDirty"><a href="Numbas.parts.MatrixEntryPart.html#setDirty">Numbas.parts.MatrixEntryPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setMarkingScript"><a href="Numbas.parts.MatrixEntryPart.html#setMarkingScript">Numbas.parts.MatrixEntryPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setScript"><a href="Numbas.parts.MatrixEntryPart.html#setScript">Numbas.parts.MatrixEntryPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setStudentAnswer"><a href="Numbas.parts.MatrixEntryPart.html#setStudentAnswer">Numbas.parts.MatrixEntryPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#settings"><a href="Numbas.parts.MatrixEntryPart.html#settings">Numbas.parts.MatrixEntryPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setWarnings"><a href="Numbas.parts.MatrixEntryPart.html#setWarnings">Numbas.parts.MatrixEntryPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#shouldResubmit"><a href="Numbas.parts.MatrixEntryPart.html#shouldResubmit">Numbas.parts.MatrixEntryPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#showSteps"><a href="Numbas.parts.MatrixEntryPart.html#showSteps">Numbas.parts.MatrixEntryPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stagedAnswer"><a href="Numbas.parts.MatrixEntryPart.html#stagedAnswer">Numbas.parts.MatrixEntryPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#steps"><a href="Numbas.parts.MatrixEntryPart.html#steps">Numbas.parts.MatrixEntryPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsMarks"><a href="Numbas.parts.MatrixEntryPart.html#stepsMarks">Numbas.parts.MatrixEntryPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsOpen"><a href="Numbas.parts.MatrixEntryPart.html#stepsOpen">Numbas.parts.MatrixEntryPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsShown"><a href="Numbas.parts.MatrixEntryPart.html#stepsShown">Numbas.parts.MatrixEntryPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#store"><a href="Numbas.parts.MatrixEntryPart.html#store">Numbas.parts.MatrixEntryPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#storeAnswer"><a href="Numbas.parts.MatrixEntryPart.html#storeAnswer">Numbas.parts.MatrixEntryPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#studentAnswer"><a href="Numbas.parts.MatrixEntryPart.html#studentAnswer">Numbas.parts.MatrixEntryPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#studentAnswerAsJME"><a href="Numbas.parts.MatrixEntryPart.html#studentAnswerAsJME">Numbas.parts.MatrixEntryPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#subCredit"><a href="Numbas.parts.MatrixEntryPart.html#subCredit">Numbas.parts.MatrixEntryPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#submit"><a href="Numbas.parts.MatrixEntryPart.html#submit">Numbas.parts.MatrixEntryPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#type"><a href="Numbas.parts.MatrixEntryPart.html#type">Numbas.parts.MatrixEntryPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#useCustomName"><a href="Numbas.parts.MatrixEntryPart.html#useCustomName">Numbas.parts.MatrixEntryPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#warnings"><a href="Numbas.parts.MatrixEntryPart.html#warnings">Numbas.parts.MatrixEntryPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#xml"><a href="Numbas.parts.MatrixEntryPart.html#xml">Numbas.parts.MatrixEntryPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart"><a href="Numbas.parts.MultipleResponsePart.html">Numbas.parts.MultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart.layoutTypes"><a href="Numbas.parts.MultipleResponsePart.html#.layoutTypes">Numbas.parts.MultipleResponsePart.layoutTypes</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addCredit"><a href="Numbas.parts.MultipleResponsePart.html#addCredit">Numbas.parts.MultipleResponsePart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addStep"><a href="Numbas.parts.MultipleResponsePart.html#addStep">Numbas.parts.MultipleResponsePart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addVariableReplacement"><a href="Numbas.parts.MultipleResponsePart.html#addVariableReplacement">Numbas.parts.MultipleResponsePart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#answered"><a href="Numbas.parts.MultipleResponsePart.html#answered">Numbas.parts.MultipleResponsePart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#apply_feedback"><a href="Numbas.parts.MultipleResponsePart.html#apply_feedback">Numbas.parts.MultipleResponsePart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#applyScoreLimits"><a href="Numbas.parts.MultipleResponsePart.html#applyScoreLimits">Numbas.parts.MultipleResponsePart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#assignName"><a href="Numbas.parts.MultipleResponsePart.html#assignName">Numbas.parts.MultipleResponsePart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#baseMarkingScript"><a href="Numbas.parts.MultipleResponsePart.html#baseMarkingScript">Numbas.parts.MultipleResponsePart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#calculateScore"><a href="Numbas.parts.MultipleResponsePart.html#calculateScore">Numbas.parts.MultipleResponsePart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#creditFraction"><a href="Numbas.parts.MultipleResponsePart.html#creditFraction">Numbas.parts.MultipleResponsePart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#customName"><a href="Numbas.parts.MultipleResponsePart.html#customName">Numbas.parts.MultipleResponsePart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#display"><a href="Numbas.parts.MultipleResponsePart.html#display">Numbas.parts.MultipleResponsePart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#doesMarking"><a href="Numbas.parts.MultipleResponsePart.html#doesMarking">Numbas.parts.MultipleResponsePart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#error"><a href="Numbas.parts.MultipleResponsePart.html#error">Numbas.parts.MultipleResponsePart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#errorCarriedForwardScope"><a href="Numbas.parts.MultipleResponsePart.html#errorCarriedForwardScope">Numbas.parts.MultipleResponsePart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#finalised_result"><a href="Numbas.parts.MultipleResponsePart.html#finalised_result">Numbas.parts.MultipleResponsePart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#finaliseLoad"><a href="Numbas.parts.MultipleResponsePart.html#finaliseLoad">Numbas.parts.MultipleResponsePart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#flipped"><a href="Numbas.parts.MultipleResponsePart.html#flipped">Numbas.parts.MultipleResponsePart#flipped</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#gaps"><a href="Numbas.parts.MultipleResponsePart.html#gaps">Numbas.parts.MultipleResponsePart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#getCorrectAnswer"><a href="Numbas.parts.MultipleResponsePart.html#getCorrectAnswer">Numbas.parts.MultipleResponsePart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#getScope"><a href="Numbas.parts.MultipleResponsePart.html#getScope">Numbas.parts.MultipleResponsePart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#giveWarning"><a href="Numbas.parts.MultipleResponsePart.html#giveWarning">Numbas.parts.MultipleResponsePart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#hasStagedAnswer"><a href="Numbas.parts.MultipleResponsePart.html#hasStagedAnswer">Numbas.parts.MultipleResponsePart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#hideSteps"><a href="Numbas.parts.MultipleResponsePart.html#hideSteps">Numbas.parts.MultipleResponsePart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#input_options"><a href="Numbas.parts.MultipleResponsePart.html#input_options">Numbas.parts.MultipleResponsePart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#input_widget"><a href="Numbas.parts.MultipleResponsePart.html#input_widget">Numbas.parts.MultipleResponsePart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#isDirty"><a href="Numbas.parts.MultipleResponsePart.html#isDirty">Numbas.parts.MultipleResponsePart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#loadFromJSON"><a href="Numbas.parts.MultipleResponsePart.html#loadFromJSON">Numbas.parts.MultipleResponsePart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#loadFromXML"><a href="Numbas.parts.MultipleResponsePart.html#loadFromXML">Numbas.parts.MultipleResponsePart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#mark"><a href="Numbas.parts.MultipleResponsePart.html#mark">Numbas.parts.MultipleResponsePart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#mark_answer"><a href="Numbas.parts.MultipleResponsePart.html#mark_answer">Numbas.parts.MultipleResponsePart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markAgainstScope"><a href="Numbas.parts.MultipleResponsePart.html#markAgainstScope">Numbas.parts.MultipleResponsePart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingComment"><a href="Numbas.parts.MultipleResponsePart.html#markingComment">Numbas.parts.MultipleResponsePart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingFeedback"><a href="Numbas.parts.MultipleResponsePart.html#markingFeedback">Numbas.parts.MultipleResponsePart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingScript"><a href="Numbas.parts.MultipleResponsePart.html#markingScript">Numbas.parts.MultipleResponsePart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#marks"><a href="Numbas.parts.MultipleResponsePart.html#marks">Numbas.parts.MultipleResponsePart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#multCredit"><a href="Numbas.parts.MultipleResponsePart.html#multCredit">Numbas.parts.MultipleResponsePart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#name"><a href="Numbas.parts.MultipleResponsePart.html#name">Numbas.parts.MultipleResponsePart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#numAnswers"><a href="Numbas.parts.MultipleResponsePart.html#numAnswers">Numbas.parts.MultipleResponsePart#numAnswers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#numChoices"><a href="Numbas.parts.MultipleResponsePart.html#numChoices">Numbas.parts.MultipleResponsePart#numChoices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#openSteps"><a href="Numbas.parts.MultipleResponsePart.html#openSteps">Numbas.parts.MultipleResponsePart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#parentPart"><a href="Numbas.parts.MultipleResponsePart.html#parentPart">Numbas.parts.MultipleResponsePart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#path"><a href="Numbas.parts.MultipleResponsePart.html#path">Numbas.parts.MultipleResponsePart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#pleaseResubmit"><a href="Numbas.parts.MultipleResponsePart.html#pleaseResubmit">Numbas.parts.MultipleResponsePart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#question"><a href="Numbas.parts.MultipleResponsePart.html#question">Numbas.parts.MultipleResponsePart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#rawStudentAnswerAsJME"><a href="Numbas.parts.MultipleResponsePart.html#rawStudentAnswerAsJME">Numbas.parts.MultipleResponsePart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#removeWarnings"><a href="Numbas.parts.MultipleResponsePart.html#removeWarnings">Numbas.parts.MultipleResponsePart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#resume"><a href="Numbas.parts.MultipleResponsePart.html#resume">Numbas.parts.MultipleResponsePart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#revealAnswer"><a href="Numbas.parts.MultipleResponsePart.html#revealAnswer">Numbas.parts.MultipleResponsePart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#score"><a href="Numbas.parts.MultipleResponsePart.html#score">Numbas.parts.MultipleResponsePart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setCredit"><a href="Numbas.parts.MultipleResponsePart.html#setCredit">Numbas.parts.MultipleResponsePart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setDirty"><a href="Numbas.parts.MultipleResponsePart.html#setDirty">Numbas.parts.MultipleResponsePart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setMarkingScript"><a href="Numbas.parts.MultipleResponsePart.html#setMarkingScript">Numbas.parts.MultipleResponsePart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setScript"><a href="Numbas.parts.MultipleResponsePart.html#setScript">Numbas.parts.MultipleResponsePart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setStudentAnswer"><a href="Numbas.parts.MultipleResponsePart.html#setStudentAnswer">Numbas.parts.MultipleResponsePart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#settings"><a href="Numbas.parts.MultipleResponsePart.html#settings">Numbas.parts.MultipleResponsePart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setWarnings"><a href="Numbas.parts.MultipleResponsePart.html#setWarnings">Numbas.parts.MultipleResponsePart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#shouldResubmit"><a href="Numbas.parts.MultipleResponsePart.html#shouldResubmit">Numbas.parts.MultipleResponsePart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#showSteps"><a href="Numbas.parts.MultipleResponsePart.html#showSteps">Numbas.parts.MultipleResponsePart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stagedAnswer"><a href="Numbas.parts.MultipleResponsePart.html#stagedAnswer">Numbas.parts.MultipleResponsePart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#steps"><a href="Numbas.parts.MultipleResponsePart.html#steps">Numbas.parts.MultipleResponsePart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsMarks"><a href="Numbas.parts.MultipleResponsePart.html#stepsMarks">Numbas.parts.MultipleResponsePart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsOpen"><a href="Numbas.parts.MultipleResponsePart.html#stepsOpen">Numbas.parts.MultipleResponsePart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsShown"><a href="Numbas.parts.MultipleResponsePart.html#stepsShown">Numbas.parts.MultipleResponsePart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#store"><a href="Numbas.parts.MultipleResponsePart.html#store">Numbas.parts.MultipleResponsePart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#storeAnswer"><a href="Numbas.parts.MultipleResponsePart.html#storeAnswer">Numbas.parts.MultipleResponsePart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#storeTick"><a href="Numbas.parts.MultipleResponsePart.html#storeTick">Numbas.parts.MultipleResponsePart#storeTick</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#studentAnswerAsJME"><a href="Numbas.parts.MultipleResponsePart.html#studentAnswerAsJME">Numbas.parts.MultipleResponsePart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#subCredit"><a href="Numbas.parts.MultipleResponsePart.html#subCredit">Numbas.parts.MultipleResponsePart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#submit"><a href="Numbas.parts.MultipleResponsePart.html#submit">Numbas.parts.MultipleResponsePart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#ticks"><a href="Numbas.parts.MultipleResponsePart.html#ticks">Numbas.parts.MultipleResponsePart#ticks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#type"><a href="Numbas.parts.MultipleResponsePart.html#type">Numbas.parts.MultipleResponsePart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#useCustomName"><a href="Numbas.parts.MultipleResponsePart.html#useCustomName">Numbas.parts.MultipleResponsePart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#warnings"><a href="Numbas.parts.MultipleResponsePart.html#warnings">Numbas.parts.MultipleResponsePart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#xml"><a href="Numbas.parts.MultipleResponsePart.html#xml">Numbas.parts.MultipleResponsePart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart"><a href="Numbas.parts.NumberEntryPart.html">Numbas.parts.NumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addCredit"><a href="Numbas.parts.NumberEntryPart.html#addCredit">Numbas.parts.NumberEntryPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addStep"><a href="Numbas.parts.NumberEntryPart.html#addStep">Numbas.parts.NumberEntryPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addVariableReplacement"><a href="Numbas.parts.NumberEntryPart.html#addVariableReplacement">Numbas.parts.NumberEntryPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#answered"><a href="Numbas.parts.NumberEntryPart.html#answered">Numbas.parts.NumberEntryPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#apply_feedback"><a href="Numbas.parts.NumberEntryPart.html#apply_feedback">Numbas.parts.NumberEntryPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#applyScoreLimits"><a href="Numbas.parts.NumberEntryPart.html#applyScoreLimits">Numbas.parts.NumberEntryPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#assignName"><a href="Numbas.parts.NumberEntryPart.html#assignName">Numbas.parts.NumberEntryPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#baseMarkingScript"><a href="Numbas.parts.NumberEntryPart.html#baseMarkingScript">Numbas.parts.NumberEntryPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#calculateScore"><a href="Numbas.parts.NumberEntryPart.html#calculateScore">Numbas.parts.NumberEntryPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#cleanAnswer"><a href="Numbas.parts.NumberEntryPart.html#cleanAnswer">Numbas.parts.NumberEntryPart#cleanAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#creditFraction"><a href="Numbas.parts.NumberEntryPart.html#creditFraction">Numbas.parts.NumberEntryPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#customName"><a href="Numbas.parts.NumberEntryPart.html#customName">Numbas.parts.NumberEntryPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#display"><a href="Numbas.parts.NumberEntryPart.html#display">Numbas.parts.NumberEntryPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#doesMarking"><a href="Numbas.parts.NumberEntryPart.html#doesMarking">Numbas.parts.NumberEntryPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#error"><a href="Numbas.parts.NumberEntryPart.html#error">Numbas.parts.NumberEntryPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#errorCarriedForwardScope"><a href="Numbas.parts.NumberEntryPart.html#errorCarriedForwardScope">Numbas.parts.NumberEntryPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#finalised_result"><a href="Numbas.parts.NumberEntryPart.html#finalised_result">Numbas.parts.NumberEntryPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#finaliseLoad"><a href="Numbas.parts.NumberEntryPart.html#finaliseLoad">Numbas.parts.NumberEntryPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#gaps"><a href="Numbas.parts.NumberEntryPart.html#gaps">Numbas.parts.NumberEntryPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#getCorrectAnswer"><a href="Numbas.parts.NumberEntryPart.html#getCorrectAnswer">Numbas.parts.NumberEntryPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#getScope"><a href="Numbas.parts.NumberEntryPart.html#getScope">Numbas.parts.NumberEntryPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#giveWarning"><a href="Numbas.parts.NumberEntryPart.html#giveWarning">Numbas.parts.NumberEntryPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#hasStagedAnswer"><a href="Numbas.parts.NumberEntryPart.html#hasStagedAnswer">Numbas.parts.NumberEntryPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#hideSteps"><a href="Numbas.parts.NumberEntryPart.html#hideSteps">Numbas.parts.NumberEntryPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#input_options"><a href="Numbas.parts.NumberEntryPart.html#input_options">Numbas.parts.NumberEntryPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#input_widget"><a href="Numbas.parts.NumberEntryPart.html#input_widget">Numbas.parts.NumberEntryPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#isDirty"><a href="Numbas.parts.NumberEntryPart.html#isDirty">Numbas.parts.NumberEntryPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#loadFromJSON"><a href="Numbas.parts.NumberEntryPart.html#loadFromJSON">Numbas.parts.NumberEntryPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#loadFromXML"><a href="Numbas.parts.NumberEntryPart.html#loadFromXML">Numbas.parts.NumberEntryPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#mark"><a href="Numbas.parts.NumberEntryPart.html#mark">Numbas.parts.NumberEntryPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#mark_answer"><a href="Numbas.parts.NumberEntryPart.html#mark_answer">Numbas.parts.NumberEntryPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markAgainstScope"><a href="Numbas.parts.NumberEntryPart.html#markAgainstScope">Numbas.parts.NumberEntryPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingComment"><a href="Numbas.parts.NumberEntryPart.html#markingComment">Numbas.parts.NumberEntryPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingFeedback"><a href="Numbas.parts.NumberEntryPart.html#markingFeedback">Numbas.parts.NumberEntryPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingScript"><a href="Numbas.parts.NumberEntryPart.html#markingScript">Numbas.parts.NumberEntryPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#marks"><a href="Numbas.parts.NumberEntryPart.html#marks">Numbas.parts.NumberEntryPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#multCredit"><a href="Numbas.parts.NumberEntryPart.html#multCredit">Numbas.parts.NumberEntryPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#name"><a href="Numbas.parts.NumberEntryPart.html#name">Numbas.parts.NumberEntryPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#openSteps"><a href="Numbas.parts.NumberEntryPart.html#openSteps">Numbas.parts.NumberEntryPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#parentPart"><a href="Numbas.parts.NumberEntryPart.html#parentPart">Numbas.parts.NumberEntryPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#path"><a href="Numbas.parts.NumberEntryPart.html#path">Numbas.parts.NumberEntryPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#pleaseResubmit"><a href="Numbas.parts.NumberEntryPart.html#pleaseResubmit">Numbas.parts.NumberEntryPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#question"><a href="Numbas.parts.NumberEntryPart.html#question">Numbas.parts.NumberEntryPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#rawStudentAnswerAsJME"><a href="Numbas.parts.NumberEntryPart.html#rawStudentAnswerAsJME">Numbas.parts.NumberEntryPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#removeWarnings"><a href="Numbas.parts.NumberEntryPart.html#removeWarnings">Numbas.parts.NumberEntryPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#resume"><a href="Numbas.parts.NumberEntryPart.html#resume">Numbas.parts.NumberEntryPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#revealAnswer"><a href="Numbas.parts.NumberEntryPart.html#revealAnswer">Numbas.parts.NumberEntryPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#score"><a href="Numbas.parts.NumberEntryPart.html#score">Numbas.parts.NumberEntryPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setCredit"><a href="Numbas.parts.NumberEntryPart.html#setCredit">Numbas.parts.NumberEntryPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setDirty"><a href="Numbas.parts.NumberEntryPart.html#setDirty">Numbas.parts.NumberEntryPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setMarkingScript"><a href="Numbas.parts.NumberEntryPart.html#setMarkingScript">Numbas.parts.NumberEntryPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setScript"><a href="Numbas.parts.NumberEntryPart.html#setScript">Numbas.parts.NumberEntryPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setStudentAnswer"><a href="Numbas.parts.NumberEntryPart.html#setStudentAnswer">Numbas.parts.NumberEntryPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#settings"><a href="Numbas.parts.NumberEntryPart.html#settings">Numbas.parts.NumberEntryPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setWarnings"><a href="Numbas.parts.NumberEntryPart.html#setWarnings">Numbas.parts.NumberEntryPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#shouldResubmit"><a href="Numbas.parts.NumberEntryPart.html#shouldResubmit">Numbas.parts.NumberEntryPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#showSteps"><a href="Numbas.parts.NumberEntryPart.html#showSteps">Numbas.parts.NumberEntryPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stagedAnswer"><a href="Numbas.parts.NumberEntryPart.html#stagedAnswer">Numbas.parts.NumberEntryPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#steps"><a href="Numbas.parts.NumberEntryPart.html#steps">Numbas.parts.NumberEntryPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsMarks"><a href="Numbas.parts.NumberEntryPart.html#stepsMarks">Numbas.parts.NumberEntryPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsOpen"><a href="Numbas.parts.NumberEntryPart.html#stepsOpen">Numbas.parts.NumberEntryPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsShown"><a href="Numbas.parts.NumberEntryPart.html#stepsShown">Numbas.parts.NumberEntryPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#store"><a href="Numbas.parts.NumberEntryPart.html#store">Numbas.parts.NumberEntryPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#storeAnswer"><a href="Numbas.parts.NumberEntryPart.html#storeAnswer">Numbas.parts.NumberEntryPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#studentAnswer"><a href="Numbas.parts.NumberEntryPart.html#studentAnswer">Numbas.parts.NumberEntryPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#studentAnswerAsJME"><a href="Numbas.parts.NumberEntryPart.html#studentAnswerAsJME">Numbas.parts.NumberEntryPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#subCredit"><a href="Numbas.parts.NumberEntryPart.html#subCredit">Numbas.parts.NumberEntryPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#submit"><a href="Numbas.parts.NumberEntryPart.html#submit">Numbas.parts.NumberEntryPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#type"><a href="Numbas.parts.NumberEntryPart.html#type">Numbas.parts.NumberEntryPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#useCustomName"><a href="Numbas.parts.NumberEntryPart.html#useCustomName">Numbas.parts.NumberEntryPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#warnings"><a href="Numbas.parts.NumberEntryPart.html#warnings">Numbas.parts.NumberEntryPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#xml"><a href="Numbas.parts.NumberEntryPart.html#xml">Numbas.parts.NumberEntryPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part"><a href="Numbas.parts.Part_.html">Numbas.parts.Part</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addCredit"><a href="Numbas.parts.Part.html#addCredit">Numbas.parts.Part#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addStep"><a href="Numbas.parts.Part.html#addStep">Numbas.parts.Part#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addVariableReplacement"><a href="Numbas.parts.Part.html#addVariableReplacement">Numbas.parts.Part#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#answered"><a href="Numbas.parts.Part.html#answered">Numbas.parts.Part#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#apply_feedback"><a href="Numbas.parts.Part.html#apply_feedback">Numbas.parts.Part#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#applyScoreLimits"><a href="Numbas.parts.Part.html#applyScoreLimits">Numbas.parts.Part#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#applyScripts"><a href="Numbas.parts.Part_applyScripts.html">Numbas.parts.Part#applyScripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#assignName"><a href="Numbas.parts.Part.html#assignName">Numbas.parts.Part#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#baseMarkingScript"><a href="Numbas.parts.Part.html#baseMarkingScript">Numbas.parts.Part#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#calculateScore"><a href="Numbas.parts.Part.html#calculateScore">Numbas.parts.Part#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#creditFraction"><a href="Numbas.parts.Part.html#creditFraction">Numbas.parts.Part#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#customName"><a href="Numbas.parts.Part.html#customName">Numbas.parts.Part#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#display"><a href="Numbas.parts.Part.html#display">Numbas.parts.Part#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#doesMarking"><a href="Numbas.parts.Part.html#doesMarking">Numbas.parts.Part#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#error"><a href="Numbas.parts.Part.html#error">Numbas.parts.Part#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#errorCarriedForwardScope"><a href="Numbas.parts.Part.html#errorCarriedForwardScope">Numbas.parts.Part#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#finalised_result"><a href="Numbas.parts.Part.html#finalised_result">Numbas.parts.Part#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#finaliseLoad"><a href="Numbas.parts.Part.html#finaliseLoad">Numbas.parts.Part#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#gaps"><a href="Numbas.parts.Part.html#gaps">Numbas.parts.Part#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#getCorrectAnswer"><a href="Numbas.parts.Part.html#getCorrectAnswer">Numbas.parts.Part#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#getScope"><a href="Numbas.parts.Part.html#getScope">Numbas.parts.Part#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#giveWarning"><a href="Numbas.parts.Part.html#giveWarning">Numbas.parts.Part#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#hasStagedAnswer"><a href="Numbas.parts.Part.html#hasStagedAnswer">Numbas.parts.Part#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#hideSteps"><a href="Numbas.parts.Part.html#hideSteps">Numbas.parts.Part#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#input_options"><a href="Numbas.parts.Part.html#input_options">Numbas.parts.Part#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#input_widget"><a href="Numbas.parts.Part.html#input_widget">Numbas.parts.Part#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#isDirty"><a href="Numbas.parts.Part.html#isDirty">Numbas.parts.Part#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#loadFromJSON"><a href="Numbas.parts.Part.html#loadFromJSON">Numbas.parts.Part#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#loadFromXML"><a href="Numbas.parts.Part.html#loadFromXML">Numbas.parts.Part#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#mark"><a href="Numbas.parts.Part.html#mark">Numbas.parts.Part#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#mark_answer"><a href="Numbas.parts.Part.html#mark_answer">Numbas.parts.Part#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markAgainstScope"><a href="Numbas.parts.Part.html#markAgainstScope">Numbas.parts.Part#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingComment"><a href="Numbas.parts.Part.html#markingComment">Numbas.parts.Part#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingFeedback"><a href="Numbas.parts.Part.html#markingFeedback">Numbas.parts.Part#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingScript"><a href="Numbas.parts.Part.html#markingScript">Numbas.parts.Part#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#marks"><a href="Numbas.parts.Part.html#marks">Numbas.parts.Part#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#multCredit"><a href="Numbas.parts.Part.html#multCredit">Numbas.parts.Part#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#name"><a href="Numbas.parts.Part.html#name">Numbas.parts.Part#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#openSteps"><a href="Numbas.parts.Part.html#openSteps">Numbas.parts.Part#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#parentPart"><a href="Numbas.parts.Part.html#parentPart">Numbas.parts.Part#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#path"><a href="Numbas.parts.Part.html#path">Numbas.parts.Part#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#pleaseResubmit"><a href="Numbas.parts.Part.html#pleaseResubmit">Numbas.parts.Part#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#question"><a href="Numbas.parts.Part_.html#question">Numbas.parts.Part#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#rawStudentAnswerAsJME"><a href="Numbas.parts.Part_.html#rawStudentAnswerAsJME">Numbas.parts.Part#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#removeWarnings"><a href="Numbas.parts.Part_.html#removeWarnings">Numbas.parts.Part#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#resume"><a href="Numbas.parts.Part_.html#resume">Numbas.parts.Part#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#revealAnswer"><a href="Numbas.parts.Part_.html#revealAnswer">Numbas.parts.Part#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#score"><a href="Numbas.parts.Part_.html#score">Numbas.parts.Part#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setCredit"><a href="Numbas.parts.Part_.html#setCredit">Numbas.parts.Part#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setDirty"><a href="Numbas.parts.Part_.html#setDirty">Numbas.parts.Part#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setMarkingScript"><a href="Numbas.parts.Part_.html#setMarkingScript">Numbas.parts.Part#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setScript"><a href="Numbas.parts.Part_.html#setScript">Numbas.parts.Part#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setStudentAnswer"><a href="Numbas.parts.Part_.html#setStudentAnswer">Numbas.parts.Part#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#settings"><a href="Numbas.parts.Part_.html#settings">Numbas.parts.Part#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setWarnings"><a href="Numbas.parts.Part_.html#setWarnings">Numbas.parts.Part#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#shouldResubmit"><a href="Numbas.parts.Part_.html#shouldResubmit">Numbas.parts.Part#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#showSteps"><a href="Numbas.parts.Part_.html#showSteps">Numbas.parts.Part#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stagedAnswer"><a href="Numbas.parts.Part_.html#stagedAnswer">Numbas.parts.Part#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#steps"><a href="Numbas.parts.Part_.html#steps">Numbas.parts.Part#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsMarks"><a href="Numbas.parts.Part_.html#stepsMarks">Numbas.parts.Part#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsOpen"><a href="Numbas.parts.Part_.html#stepsOpen">Numbas.parts.Part#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsShown"><a href="Numbas.parts.Part_.html#stepsShown">Numbas.parts.Part#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#store"><a href="Numbas.parts.Part_.html#store">Numbas.parts.Part#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#storeAnswer"><a href="Numbas.parts.Part_.html#storeAnswer">Numbas.parts.Part#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#studentAnswerAsJME"><a href="Numbas.parts.Part_.html#studentAnswerAsJME">Numbas.parts.Part#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#subCredit"><a href="Numbas.parts.Part_.html#subCredit">Numbas.parts.Part#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#submit"><a href="Numbas.parts.Part_.html#submit">Numbas.parts.Part#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#type"><a href="Numbas.parts.Part_.html#type">Numbas.parts.Part#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#useCustomName"><a href="Numbas.parts.Part_.html#useCustomName">Numbas.parts.Part#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#warnings"><a href="Numbas.parts.Part_.html#warnings">Numbas.parts.Part#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#xml"><a href="Numbas.parts.Part_.html#xml">Numbas.parts.Part#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.partpath"><a href="Numbas.parts.html#.partpath">Numbas.parts.partpath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart"><a href="Numbas.parts.PatternMatchPart.html">Numbas.parts.PatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addCredit"><a href="Numbas.parts.PatternMatchPart.html#addCredit">Numbas.parts.PatternMatchPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addStep"><a href="Numbas.parts.PatternMatchPart.html#addStep">Numbas.parts.PatternMatchPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addVariableReplacement"><a href="Numbas.parts.PatternMatchPart.html#addVariableReplacement">Numbas.parts.PatternMatchPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#answered"><a href="Numbas.parts.PatternMatchPart.html#answered">Numbas.parts.PatternMatchPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#apply_feedback"><a href="Numbas.parts.PatternMatchPart.html#apply_feedback">Numbas.parts.PatternMatchPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#applyScoreLimits"><a href="Numbas.parts.PatternMatchPart.html#applyScoreLimits">Numbas.parts.PatternMatchPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#assignName"><a href="Numbas.parts.PatternMatchPart.html#assignName">Numbas.parts.PatternMatchPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#baseMarkingScript"><a href="Numbas.parts.PatternMatchPart.html#baseMarkingScript">Numbas.parts.PatternMatchPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#calculateScore"><a href="Numbas.parts.PatternMatchPart.html#calculateScore">Numbas.parts.PatternMatchPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#creditFraction"><a href="Numbas.parts.PatternMatchPart.html#creditFraction">Numbas.parts.PatternMatchPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#customName"><a href="Numbas.parts.PatternMatchPart.html#customName">Numbas.parts.PatternMatchPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#display"><a href="Numbas.parts.PatternMatchPart.html#display">Numbas.parts.PatternMatchPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#doesMarking"><a href="Numbas.parts.PatternMatchPart.html#doesMarking">Numbas.parts.PatternMatchPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#error"><a href="Numbas.parts.PatternMatchPart.html#error">Numbas.parts.PatternMatchPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#errorCarriedForwardScope"><a href="Numbas.parts.PatternMatchPart.html#errorCarriedForwardScope">Numbas.parts.PatternMatchPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#finalised_result"><a href="Numbas.parts.PatternMatchPart.html#finalised_result">Numbas.parts.PatternMatchPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#finaliseLoad"><a href="Numbas.parts.PatternMatchPart.html#finaliseLoad">Numbas.parts.PatternMatchPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#gaps"><a href="Numbas.parts.PatternMatchPart.html#gaps">Numbas.parts.PatternMatchPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#getCorrectAnswer"><a href="Numbas.parts.PatternMatchPart.html#getCorrectAnswer">Numbas.parts.PatternMatchPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#getScope"><a href="Numbas.parts.PatternMatchPart.html#getScope">Numbas.parts.PatternMatchPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#giveWarning"><a href="Numbas.parts.PatternMatchPart.html#giveWarning">Numbas.parts.PatternMatchPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#hasStagedAnswer"><a href="Numbas.parts.PatternMatchPart.html#hasStagedAnswer">Numbas.parts.PatternMatchPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#hideSteps"><a href="Numbas.parts.PatternMatchPart.html#hideSteps">Numbas.parts.PatternMatchPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#input_options"><a href="Numbas.parts.PatternMatchPart.html#input_options">Numbas.parts.PatternMatchPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#input_widget"><a href="Numbas.parts.PatternMatchPart.html#input_widget">Numbas.parts.PatternMatchPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#isDirty"><a href="Numbas.parts.PatternMatchPart.html#isDirty">Numbas.parts.PatternMatchPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#loadFromJSON"><a href="Numbas.parts.PatternMatchPart.html#loadFromJSON">Numbas.parts.PatternMatchPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#loadFromXML"><a href="Numbas.parts.PatternMatchPart.html#loadFromXML">Numbas.parts.PatternMatchPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#mark"><a href="Numbas.parts.PatternMatchPart.html#mark">Numbas.parts.PatternMatchPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#mark_answer"><a href="Numbas.parts.PatternMatchPart.html#mark_answer">Numbas.parts.PatternMatchPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markAgainstScope"><a href="Numbas.parts.PatternMatchPart.html#markAgainstScope">Numbas.parts.PatternMatchPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingComment"><a href="Numbas.parts.PatternMatchPart.html#markingComment">Numbas.parts.PatternMatchPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingFeedback"><a href="Numbas.parts.PatternMatchPart.html#markingFeedback">Numbas.parts.PatternMatchPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingScript"><a href="Numbas.parts.PatternMatchPart.html#markingScript">Numbas.parts.PatternMatchPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#marks"><a href="Numbas.parts.PatternMatchPart.html#marks">Numbas.parts.PatternMatchPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#multCredit"><a href="Numbas.parts.PatternMatchPart.html#multCredit">Numbas.parts.PatternMatchPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#name"><a href="Numbas.parts.PatternMatchPart.html#name">Numbas.parts.PatternMatchPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#openSteps"><a href="Numbas.parts.PatternMatchPart.html#openSteps">Numbas.parts.PatternMatchPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#parentPart"><a href="Numbas.parts.PatternMatchPart.html#parentPart">Numbas.parts.PatternMatchPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#path"><a href="Numbas.parts.PatternMatchPart.html#path">Numbas.parts.PatternMatchPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#pleaseResubmit"><a href="Numbas.parts.PatternMatchPart.html#pleaseResubmit">Numbas.parts.PatternMatchPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#question"><a href="Numbas.parts.PatternMatchPart.html#question">Numbas.parts.PatternMatchPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#rawStudentAnswerAsJME"><a href="Numbas.parts.PatternMatchPart.html#rawStudentAnswerAsJME">Numbas.parts.PatternMatchPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#removeWarnings"><a href="Numbas.parts.PatternMatchPart.html#removeWarnings">Numbas.parts.PatternMatchPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#resume"><a href="Numbas.parts.PatternMatchPart.html#resume">Numbas.parts.PatternMatchPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#revealAnswer"><a href="Numbas.parts.PatternMatchPart.html#revealAnswer">Numbas.parts.PatternMatchPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#score"><a href="Numbas.parts.PatternMatchPart.html#score">Numbas.parts.PatternMatchPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setCredit"><a href="Numbas.parts.PatternMatchPart.html#setCredit">Numbas.parts.PatternMatchPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setDirty"><a href="Numbas.parts.PatternMatchPart.html#setDirty">Numbas.parts.PatternMatchPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setMarkingScript"><a href="Numbas.parts.PatternMatchPart.html#setMarkingScript">Numbas.parts.PatternMatchPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setScript"><a href="Numbas.parts.PatternMatchPart.html#setScript">Numbas.parts.PatternMatchPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setStudentAnswer"><a href="Numbas.parts.PatternMatchPart.html#setStudentAnswer">Numbas.parts.PatternMatchPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#settings"><a href="Numbas.parts.PatternMatchPart.html#settings">Numbas.parts.PatternMatchPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setWarnings"><a href="Numbas.parts.PatternMatchPart.html#setWarnings">Numbas.parts.PatternMatchPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#shouldResubmit"><a href="Numbas.parts.PatternMatchPart.html#shouldResubmit">Numbas.parts.PatternMatchPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#showSteps"><a href="Numbas.parts.PatternMatchPart.html#showSteps">Numbas.parts.PatternMatchPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stagedAnswer"><a href="Numbas.parts.PatternMatchPart.html#stagedAnswer">Numbas.parts.PatternMatchPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#steps"><a href="Numbas.parts.PatternMatchPart.html#steps">Numbas.parts.PatternMatchPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsMarks"><a href="Numbas.parts.PatternMatchPart.html#stepsMarks">Numbas.parts.PatternMatchPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsOpen"><a href="Numbas.parts.PatternMatchPart.html#stepsOpen">Numbas.parts.PatternMatchPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsShown"><a href="Numbas.parts.PatternMatchPart.html#stepsShown">Numbas.parts.PatternMatchPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#store"><a href="Numbas.parts.PatternMatchPart.html#store">Numbas.parts.PatternMatchPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#storeAnswer"><a href="Numbas.parts.PatternMatchPart.html#storeAnswer">Numbas.parts.PatternMatchPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#studentAnswerAsJME"><a href="Numbas.parts.PatternMatchPart.html#studentAnswerAsJME">Numbas.parts.PatternMatchPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#subCredit"><a href="Numbas.parts.PatternMatchPart.html#subCredit">Numbas.parts.PatternMatchPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#submit"><a href="Numbas.parts.PatternMatchPart.html#submit">Numbas.parts.PatternMatchPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#type"><a href="Numbas.parts.PatternMatchPart.html#type">Numbas.parts.PatternMatchPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#useCustomName"><a href="Numbas.parts.PatternMatchPart.html#useCustomName">Numbas.parts.PatternMatchPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#warnings"><a href="Numbas.parts.PatternMatchPart.html#warnings">Numbas.parts.PatternMatchPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#xml"><a href="Numbas.parts.PatternMatchPart.html#xml">Numbas.parts.PatternMatchPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart"><a href="Numbas.PatternMatchPart.html">Numbas.PatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#baseMarkingScript"><a href="Numbas.PatternMatchPart.html#baseMarkingScript">Numbas.PatternMatchPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#getCorrectAnswer"><a href="Numbas.PatternMatchPart.html#getCorrectAnswer">Numbas.PatternMatchPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#input_options"><a href="Numbas.PatternMatchPart.html#input_options">Numbas.PatternMatchPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#input_widget"><a href="Numbas.PatternMatchPart.html#input_widget">Numbas.PatternMatchPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#rawStudentAnswerAsJME"><a href="Numbas.PatternMatchPart.html#rawStudentAnswerAsJME">Numbas.PatternMatchPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#setStudentAnswer"><a href="Numbas.PatternMatchPart.html#setStudentAnswer">Numbas.PatternMatchPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#settings"><a href="Numbas.PatternMatchPart.html#settings">Numbas.PatternMatchPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#studentAnswer"><a href="Numbas.PatternMatchPart.html#studentAnswer">Numbas.PatternMatchPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question"><a href="Numbas.Question.html">Numbas.Question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#addPart"><a href="Numbas.Question.html#addPart">Numbas.Question#addPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#adviceDisplayed"><a href="Numbas.Question.html#adviceDisplayed">Numbas.Question#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#answered"><a href="Numbas.Question.html#answered">Numbas.Question#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#calculateScore"><a href="Numbas.Question.html#calculateScore">Numbas.Question#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#callbacks"><a href="Numbas.Question.html#callbacks">Numbas.Question#callbacks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#display"><a href="Numbas.Question.html#display">Numbas.Question#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:functionsLoaded"><a href="Numbas.Question.html#event:functionsLoaded">Numbas.Question#event:functionsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:functionsMade"><a href="Numbas.Question.html#event:functionsMade">Numbas.Question#event:functionsMade</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:generateVariables"><a href="Numbas.Question.html#event:generateVariables">Numbas.Question#event:generateVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:HTMLAttached"><a href="Numbas.Question.html#event:HTMLAttached">Numbas.Question#event:HTMLAttached</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:partsGenerated"><a href="Numbas.Question.html#event:partsGenerated">Numbas.Question#event:partsGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:partsResumed"><a href="Numbas.Question.html#event:partsResumed">Numbas.Question#event:partsResumed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:preambleLoaded"><a href="Numbas.Question.html#event:preambleLoaded">Numbas.Question#event:preambleLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:preambleRun"><a href="Numbas.Question.html#event:preambleRun">Numbas.Question#event:preambleRun</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:ready"><a href="Numbas.Question.html#event:ready">Numbas.Question#event:ready</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:rulesetsLoaded"><a href="Numbas.Question.html#event:rulesetsLoaded">Numbas.Question#event:rulesetsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:rulesetsMade"><a href="Numbas.Question.html#event:rulesetsMade">Numbas.Question#event:rulesetsMade</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variableDefinitionsLoaded"><a href="Numbas.Question.html#event:variableDefinitionsLoaded">Numbas.Question#event:variableDefinitionsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variablesGenerated"><a href="Numbas.Question.html#event:variablesGenerated">Numbas.Question#event:variablesGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variablesSet"><a href="Numbas.Question.html#event:variablesSet">Numbas.Question#event:variablesSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#finaliseLoad"><a href="Numbas.Question.html#finaliseLoad">Numbas.Question#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#getAdvice"><a href="Numbas.Question.html#getAdvice">Numbas.Question#getAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#getPart"><a href="Numbas.Question.html#getPart">Numbas.Question#getPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#isDirty"><a href="Numbas.Question.html#isDirty">Numbas.Question#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#leave"><a href="Numbas.Question.html#leave">Numbas.Question#leave</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#leavingDirtyQuestion"><a href="Numbas.Question.html#leavingDirtyQuestion">Numbas.Question#leavingDirtyQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#loadFromJSON"><a href="Numbas.Question.html#loadFromJSON">Numbas.Question#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#loadFromXML"><a href="Numbas.Question.html#loadFromXML">Numbas.Question#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#marks"><a href="Numbas.Question.html#marks">Numbas.Question#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#name"><a href="Numbas.Question.html#name">Numbas.Question#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#number"><a href="Numbas.Question.html#number">Numbas.Question#number</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#onHTMLAttached"><a href="Numbas.Question.html#onHTMLAttached">Numbas.Question#onHTMLAttached</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#onVariablesGenerated"><a href="Numbas.Question.html#onVariablesGenerated">Numbas.Question#onVariablesGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#partDictionary"><a href="Numbas.Question.html#partDictionary">Numbas.Question#partDictionary</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#parts"><a href="Numbas.Question.html#parts">Numbas.Question#parts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#resume"><a href="Numbas.Question.html#resume">Numbas.Question#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#revealAnswer"><a href="Numbas.Question.html#revealAnswer">Numbas.Question#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#revealed"><a href="Numbas.Question.html#revealed">Numbas.Question#revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#runPreamble"><a href="Numbas.Question.html#runPreamble">Numbas.Question#runPreamble</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#scope"><a href="Numbas.Question.html#scope">Numbas.Question#scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#score"><a href="Numbas.Question.html#score">Numbas.Question#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#signals"><a href="Numbas.Question.html#signals">Numbas.Question#signals</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#store"><a href="Numbas.Question.html#store">Numbas.Question#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#submit"><a href="Numbas.Question.html#submit">Numbas.Question#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#submitted"><a href="Numbas.Question.html#submitted">Numbas.Question#submitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#updateScore"><a href="Numbas.Question.html#updateScore">Numbas.Question#updateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#validate"><a href="Numbas.Question.html#validate">Numbas.Question#validate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#visited"><a href="Numbas.Question.html#visited">Numbas.Question#visited</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#xml"><a href="Numbas.Question.html#xml">Numbas.Question#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup"><a href="Numbas.QuestionGroup.html">Numbas.QuestionGroup</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup#chooseQuestionSubset"><a href="Numbas.QuestionGroup.html#chooseQuestionSubset">Numbas.QuestionGroup#chooseQuestionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup#settings"><a href="Numbas.QuestionGroup.html#settings">Numbas.QuestionGroup#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.queueScript"><a href="Numbas.html#.queueScript">Numbas.queueScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.raw_marking_scripts"><a href="Numbas.html#.raw_marking_scripts">Numbas.raw_marking_scripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.rawxml"><a href="Numbas.html#.rawxml">Numbas.rawxml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule"><a href="Numbas.schedule.html">Numbas.schedule</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.add"><a href="Numbas.schedule.html#.add">Numbas.schedule.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.callback"><a href="Numbas.schedule.html#.callback">Numbas.schedule.callback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.calls"><a href="Numbas.schedule.html#.calls">Numbas.schedule.calls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.completed"><a href="Numbas.schedule.html#.completed">Numbas.schedule.completed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.drop"><a href="Numbas.schedule.html#.drop">Numbas.schedule.drop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halt"><a href="Numbas.schedule.html#.halt">Numbas.schedule.halt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halt_error"><a href="Numbas.schedule.html#.halt_error">Numbas.schedule.halt_error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halted"><a href="Numbas.schedule.html#.halted">Numbas.schedule.halted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.lift"><a href="Numbas.schedule.html#.lift">Numbas.schedule.lift</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.lifts"><a href="Numbas.schedule.html#.lifts">Numbas.schedule.lifts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.pop"><a href="Numbas.schedule.html#.pop">Numbas.schedule.pop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox"><a href="Numbas.schedule.SignalBox.html">Numbas.schedule.SignalBox</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#getCallback"><a href="Numbas.schedule.SignalBox.html#getCallback">Numbas.schedule.SignalBox#getCallback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#on"><a href="Numbas.schedule.SignalBox.html#on">Numbas.schedule.SignalBox#on</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#trigger"><a href="Numbas.schedule.SignalBox.html#trigger">Numbas.schedule.SignalBox#trigger</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.task_object"><a href="Numbas.schedule.html#.task_object">Numbas.schedule.task_object</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.total"><a href="Numbas.schedule.html#.total">Numbas.schedule.total</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath"><a href="Numbas.setmath.html">Numbas.setmath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.contains"><a href="Numbas.setmath.html#.contains">Numbas.setmath.contains</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.eq"><a href="Numbas.setmath.html#.eq">Numbas.setmath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.intersection"><a href="Numbas.setmath.html#.intersection">Numbas.setmath.intersection</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.minus"><a href="Numbas.setmath.html#.minus">Numbas.setmath.minus</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.size"><a href="Numbas.setmath.html#.size">Numbas.setmath.size</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.union"><a href="Numbas.setmath.html#.union">Numbas.setmath.union</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.showError"><a href="Numbas.html#.showError">Numbas.showError</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage"><a href="Numbas.storage.html">Numbas.storage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage"><a href="Numbas.storage.BlankStorage.html">Numbas.storage.BlankStorage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#adviceDisplayed"><a href="Numbas.storage.BlankStorage.html#adviceDisplayed">Numbas.storage.BlankStorage#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#answerRevealed"><a href="Numbas.storage.BlankStorage.html#answerRevealed">Numbas.storage.BlankStorage#answerRevealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#changeQuestion"><a href="Numbas.storage.BlankStorage.html#changeQuestion">Numbas.storage.BlankStorage#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#end"><a href="Numbas.storage.BlankStorage.html#end">Numbas.storage.BlankStorage#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getEntry"><a href="Numbas.storage.BlankStorage.html#getEntry">Numbas.storage.BlankStorage#getEntry</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getMode"><a href="Numbas.storage.BlankStorage.html#getMode">Numbas.storage.BlankStorage#getMode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getStudentID"><a href="Numbas.storage.BlankStorage.html#getStudentID">Numbas.storage.BlankStorage#getStudentID</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#init"><a href="Numbas.storage.BlankStorage.html#init">Numbas.storage.BlankStorage#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#load"><a href="Numbas.storage.BlankStorage.html#load">Numbas.storage.BlankStorage#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadExtensionPart"><a href="Numbas.storage.BlankStorage.html#loadExtensionPart">Numbas.storage.BlankStorage#loadExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadJMEPart"><a href="Numbas.storage.BlankStorage.html#loadJMEPart">Numbas.storage.BlankStorage#loadJMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadMatrixEntryPart"><a href="Numbas.storage.BlankStorage.html#loadMatrixEntryPart">Numbas.storage.BlankStorage#loadMatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadMultipleResponsePart"><a href="Numbas.storage.BlankStorage.html#loadMultipleResponsePart">Numbas.storage.BlankStorage#loadMultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadNumberEntryPart"><a href="Numbas.storage.BlankStorage.html#loadNumberEntryPart">Numbas.storage.BlankStorage#loadNumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadPart"><a href="Numbas.storage.BlankStorage.html#loadPart">Numbas.storage.BlankStorage#loadPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadPatternMatchPart"><a href="Numbas.storage.BlankStorage.html#loadPatternMatchPart">Numbas.storage.BlankStorage#loadPatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadQuestion"><a href="Numbas.storage.BlankStorage.html#loadQuestion">Numbas.storage.BlankStorage#loadQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#partAnswered"><a href="Numbas.storage.BlankStorage.html#partAnswered">Numbas.storage.BlankStorage#partAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#pause"><a href="Numbas.storage.BlankStorage.html#pause">Numbas.storage.BlankStorage#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#questionSubmitted"><a href="Numbas.storage.BlankStorage.html#questionSubmitted">Numbas.storage.BlankStorage#questionSubmitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#resume"><a href="Numbas.storage.BlankStorage.html#resume">Numbas.storage.BlankStorage#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#save"><a href="Numbas.storage.BlankStorage.html#save">Numbas.storage.BlankStorage#save</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#saveExam"><a href="Numbas.storage.BlankStorage.html#saveExam">Numbas.storage.BlankStorage#saveExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#start"><a href="Numbas.storage.BlankStorage.html#start">Numbas.storage.BlankStorage#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#stepsHidden"><a href="Numbas.storage.BlankStorage.html#stepsHidden">Numbas.storage.BlankStorage#stepsHidden</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#stepsShown"><a href="Numbas.storage.BlankStorage.html#stepsShown">Numbas.storage.BlankStorage#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.exam_suspend_data"><a href="Numbas.storage.html#.exam_suspend_data">Numbas.storage.exam_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.part_suspend_data"><a href="Numbas.storage.html#.part_suspend_data">Numbas.storage.part_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.question_suspend_data"><a href="Numbas.storage.html#.question_suspend_data">Numbas.storage.question_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage"><a href="Numbas.storage.SCORMStorage.html">Numbas.storage.SCORMStorage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#adviceDisplayed"><a href="Numbas.storage.SCORMStorage.html#adviceDisplayed">Numbas.storage.SCORMStorage#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#answerRevealed"><a href="Numbas.storage.SCORMStorage.html#answerRevealed">Numbas.storage.SCORMStorage#answerRevealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#changeQuestion"><a href="Numbas.storage.SCORMStorage.html#changeQuestion">Numbas.storage.SCORMStorage#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#end"><a href="Numbas.storage.SCORMStorage.html#end">Numbas.storage.SCORMStorage#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#exam"><a href="Numbas.storage.SCORMStorage.html#exam">Numbas.storage.SCORMStorage#exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#get"><a href="Numbas.storage.SCORMStorage.html#get">Numbas.storage.SCORMStorage#get</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#get_student_name"><a href="Numbas.storage.SCORMStorage.html#get_student_name">Numbas.storage.SCORMStorage#get_student_name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getEntry"><a href="Numbas.storage.SCORMStorage.html#getEntry">Numbas.storage.SCORMStorage#getEntry</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getMode"><a href="Numbas.storage.SCORMStorage.html#getMode">Numbas.storage.SCORMStorage#getMode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getPartId"><a href="Numbas.storage.SCORMStorage.html#getPartId">Numbas.storage.SCORMStorage#getPartId</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getQuestionId"><a href="Numbas.storage.SCORMStorage.html#getQuestionId">Numbas.storage.SCORMStorage#getQuestionId</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getStudentID"><a href="Numbas.storage.SCORMStorage.html#getStudentID">Numbas.storage.SCORMStorage#getStudentID</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getSuspendData"><a href="Numbas.storage.SCORMStorage.html#getSuspendData">Numbas.storage.SCORMStorage#getSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#init"><a href="Numbas.storage.SCORMStorage.html#init">Numbas.storage.SCORMStorage#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#initPart"><a href="Numbas.storage.SCORMStorage.html#initPart">Numbas.storage.SCORMStorage#initPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#initQuestion"><a href="Numbas.storage.SCORMStorage.html#initQuestion">Numbas.storage.SCORMStorage#initQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#lmsConnected"><a href="Numbas.storage.SCORMStorage.html#lmsConnected">Numbas.storage.SCORMStorage#lmsConnected</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#load"><a href="Numbas.storage.SCORMStorage.html#load">Numbas.storage.SCORMStorage#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadExtensionPart"><a href="Numbas.storage.SCORMStorage.html#loadExtensionPart">Numbas.storage.SCORMStorage#loadExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadJMEPart"><a href="Numbas.storage.SCORMStorage.html#loadJMEPart">Numbas.storage.SCORMStorage#loadJMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadMatrixEntryPart"><a href="Numbas.storage.SCORMStorage.html#loadMatrixEntryPart">Numbas.storage.SCORMStorage#loadMatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadMultipleResponsePart"><a href="Numbas.storage.SCORMStorage.html#loadMultipleResponsePart">Numbas.storage.SCORMStorage#loadMultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadNumberEntryPart"><a href="Numbas.storage.SCORMStorage.html#loadNumberEntryPart">Numbas.storage.SCORMStorage#loadNumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadPart"><a href="Numbas.storage.SCORMStorage.html#loadPart">Numbas.storage.SCORMStorage#loadPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadPatternMatchPart"><a href="Numbas.storage.SCORMStorage.html#loadPatternMatchPart">Numbas.storage.SCORMStorage#loadPatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadQuestion"><a href="Numbas.storage.SCORMStorage.html#loadQuestion">Numbas.storage.SCORMStorage#loadQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#mode"><a href="Numbas.storage.SCORMStorage.html#mode">Numbas.storage.SCORMStorage#mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partAnswered"><a href="Numbas.storage.SCORMStorage.html#partAnswered">Numbas.storage.SCORMStorage#partAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partIndices"><a href="Numbas.storage.SCORMStorage.html#partIndices">Numbas.storage.SCORMStorage#partIndices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partSuspendData"><a href="Numbas.storage.SCORMStorage.html#partSuspendData">Numbas.storage.SCORMStorage#partSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#pause"><a href="Numbas.storage.SCORMStorage.html#pause">Numbas.storage.SCORMStorage#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionIndices"><a href="Numbas.storage.SCORMStorage.html#questionIndices">Numbas.storage.SCORMStorage#questionIndices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionSubmitted"><a href="Numbas.storage.SCORMStorage.html#questionSubmitted">Numbas.storage.SCORMStorage#questionSubmitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionSuspendData"><a href="Numbas.storage.SCORMStorage.html#questionSuspendData">Numbas.storage.SCORMStorage#questionSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#resume"><a href="Numbas.storage.SCORMStorage.html#resume">Numbas.storage.SCORMStorage#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#save"><a href="Numbas.storage.SCORMStorage.html#save">Numbas.storage.SCORMStorage#save</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#saveExam"><a href="Numbas.storage.SCORMStorage.html#saveExam">Numbas.storage.SCORMStorage#saveExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#saveQuestion"><a href="Numbas.storage.SCORMStorage.html#saveQuestion">Numbas.storage.SCORMStorage#saveQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#set"><a href="Numbas.storage.SCORMStorage.html#set">Numbas.storage.SCORMStorage#set</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#setSessionTime"><a href="Numbas.storage.SCORMStorage.html#setSessionTime">Numbas.storage.SCORMStorage#setSessionTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#setSuspendData"><a href="Numbas.storage.SCORMStorage.html#setSuspendData">Numbas.storage.SCORMStorage#setSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#start"><a href="Numbas.storage.SCORMStorage.html#start">Numbas.storage.SCORMStorage#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#stepsHidden"><a href="Numbas.storage.SCORMStorage.html#stepsHidden">Numbas.storage.SCORMStorage#stepsHidden</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#stepsShown"><a href="Numbas.storage.SCORMStorage.html#stepsShown">Numbas.storage.SCORMStorage#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#suspendData"><a href="Numbas.storage.SCORMStorage.html#suspendData">Numbas.storage.SCORMStorage#suspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.store"><a href="Numbas.html#.store">Numbas.store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing"><a href="Numbas.timing.html">Numbas.timing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.accs"><a href="Numbas.timing.html#.accs">Numbas.timing.accs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.displayDate"><a href="Numbas.timing.html#.displayDate">Numbas.timing.displayDate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.end"><a href="Numbas.timing.html#.end">Numbas.timing.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.endacc"><a href="Numbas.timing.html#.endacc">Numbas.timing.endacc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.messages"><a href="Numbas.timing.html#.messages">Numbas.timing.messages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.secsToDisplayTime"><a href="Numbas.timing.html#.secsToDisplayTime">Numbas.timing.secsToDisplayTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.show"><a href="Numbas.timing.html#.show">Numbas.timing.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.start"><a href="Numbas.timing.html#.start">Numbas.timing.start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.startacc"><a href="Numbas.timing.html#.startacc">Numbas.timing.startacc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.stress"><a href="Numbas.timing.html#.stress">Numbas.timing.stress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.timers"><a href="Numbas.timing.html#.timers">Numbas.timing.timers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.tryInit"><a href="Numbas.html#.tryInit">Numbas.tryInit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util"><a href="Numbas.util.html">Numbas.util</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.arraysEqual"><a href="Numbas.util.html#.arraysEqual">Numbas.util.arraysEqual</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.capitalise"><a href="Numbas.util.html#.capitalise">Numbas.util.capitalise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.cartesian_power"><a href="Numbas.util.html#.cartesian_power">Numbas.util.cartesian_power</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.cleanNumber"><a href="Numbas.util.html#.cleanNumber">Numbas.util.cleanNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.combinations"><a href="Numbas.util.html#.combinations">Numbas.util.combinations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.combinations_with_replacement"><a href="Numbas.util.html#.combinations_with_replacement">Numbas.util.combinations_with_replacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.contains"><a href="Numbas.util.html#.contains">Numbas.util.contains</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.contentsplitbrackets"><a href="Numbas.util.html#.contentsplitbrackets">Numbas.util.contentsplitbrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyarray"><a href="Numbas.util.html#.copyarray">Numbas.util.copyarray</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyinto"><a href="Numbas.util.html#.copyinto">Numbas.util.copyinto</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyobj"><a href="Numbas.util.html#.copyobj">Numbas.util.copyobj</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.currency"><a href="Numbas.util.html#.currency">Numbas.util.currency</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.distinct"><a href="Numbas.util.html#.distinct">Numbas.util.distinct</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.eq"><a href="Numbas.util.html#.eq">Numbas.util.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.equalityTests"><a href="Numbas.util.html#.equalityTests">Numbas.util.equalityTests</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.escapeHTML"><a href="Numbas.util.html#.escapeHTML">Numbas.util.escapeHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.except"><a href="Numbas.util.html#.except">Numbas.util.except</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.extend"><a href="Numbas.util.html#.extend">Numbas.util.extend</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.extend_object"><a href="Numbas.util.html#.extend_object">Numbas.util.extend_object</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.formatString"><a href="Numbas.util.html#.formatString">Numbas.util.formatString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.formatTime"><a href="Numbas.util.html#.formatTime">Numbas.util.formatTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.hashCode"><a href="Numbas.util.html#.hashCode">Numbas.util.hashCode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isBool"><a href="Numbas.util.html#.isBool">Numbas.util.isBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isFloat"><a href="Numbas.util.html#.isFloat">Numbas.util.isFloat</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isFraction"><a href="Numbas.util.html#.isFraction">Numbas.util.isFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isInt"><a href="Numbas.util.html#.isInt">Numbas.util.isInt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isNonemptyHTML"><a href="Numbas.util.html#.isNonemptyHTML">Numbas.util.isNonemptyHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isNumber"><a href="Numbas.util.html#.isNumber">Numbas.util.isNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.letterOrdinal"><a href="Numbas.util.html#.letterOrdinal">Numbas.util.letterOrdinal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.lpad"><a href="Numbas.util.html#.lpad">Numbas.util.lpad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.matchNotationStyle"><a href="Numbas.util.html#.matchNotationStyle">Numbas.util.matchNotationStyle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.neq"><a href="Numbas.util.html#.neq">Numbas.util.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.nicePartName"><a href="Numbas.util.html#.nicePartName">Numbas.util.nicePartName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.numberNotationStyles"><a href="Numbas.util.html#.numberNotationStyles">Numbas.util.numberNotationStyles</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.objects_equal"><a href="Numbas.util.html#.objects_equal">Numbas.util.objects_equal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseBool"><a href="Numbas.util.html#.parseBool">Numbas.util.parseBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseDecimal"><a href="Numbas.util.html#.parseDecimal">Numbas.util.parseDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseFraction"><a href="Numbas.util.html#.parseFraction">Numbas.util.parseFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseNumber"><a href="Numbas.util.html#.parseNumber">Numbas.util.parseNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.permutations"><a href="Numbas.util.html#.permutations">Numbas.util.permutations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.pluralise"><a href="Numbas.util.html#.pluralise">Numbas.util.pluralise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.product"><a href="Numbas.util.html#.product">Numbas.util.product</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.re_fraction"><a href="Numbas.util.html#.re_fraction">Numbas.util.re_fraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.rpad"><a href="Numbas.util.html#.rpad">Numbas.util.rpad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.separateThousands"><a href="Numbas.util.html#.separateThousands">Numbas.util.separateThousands</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.sortBy"><a href="Numbas.util.html#.sortBy">Numbas.util.sortBy</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.splitbrackets"><a href="Numbas.util.html#.splitbrackets">Numbas.util.splitbrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.standardNumberFormatter"><a href="Numbas.util.html#.standardNumberFormatter">Numbas.util.standardNumberFormatter</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.unPercent"><a href="Numbas.util.html#.unPercent">Numbas.util.unPercent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.wrapListIndex"><a href="Numbas.util.html#.wrapListIndex">Numbas.util.wrapListIndex</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.zip"><a href="Numbas.util.html#.zip">Numbas.util.zip</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath"><a href="Numbas.vectormath.html">Numbas.vectormath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.abs"><a href="Numbas.vectormath.html#.abs">Numbas.vectormath.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.abs_squared"><a href="Numbas.vectormath.html#.abs_squared">Numbas.vectormath.abs_squared</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.add"><a href="Numbas.vectormath.html#.add">Numbas.vectormath.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.angle"><a href="Numbas.vectormath.html#.angle">Numbas.vectormath.angle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.cross"><a href="Numbas.vectormath.html#.cross">Numbas.vectormath.cross</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.div"><a href="Numbas.vectormath.html#.div">Numbas.vectormath.div</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.dot"><a href="Numbas.vectormath.html#.dot">Numbas.vectormath.dot</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.eq"><a href="Numbas.vectormath.html#.eq">Numbas.vectormath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.is_zero"><a href="Numbas.vectormath.html#.is_zero">Numbas.vectormath.is_zero</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.map"><a href="Numbas.vectormath.html#.map">Numbas.vectormath.map</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.matrixmul"><a href="Numbas.vectormath.html#.matrixmul">Numbas.vectormath.matrixmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.mul"><a href="Numbas.vectormath.html#.mul">Numbas.vectormath.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.negate"><a href="Numbas.vectormath.html#.negate">Numbas.vectormath.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.neq"><a href="Numbas.vectormath.html#.neq">Numbas.vectormath.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.precround"><a href="Numbas.vectormath.html#.precround">Numbas.vectormath.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.siground"><a href="Numbas.vectormath.html#.siground">Numbas.vectormath.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.sub"><a href="Numbas.vectormath.html#.sub">Numbas.vectormath.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.toMatrix"><a href="Numbas.vectormath.html#.toMatrix">Numbas.vectormath.toMatrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.transpose"><a href="Numbas.vectormath.html#.transpose">Numbas.vectormath.transpose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.vectormatrixmul"><a href="Numbas.vectormath.html#.vectormatrixmul">Numbas.vectormath.vectormatrixmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml"><a href="Numbas.xml.html">Numbas.xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.examXML"><a href="Numbas.xml.html#.examXML">Numbas.xml.examXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.getTextContent"><a href="Numbas.xml.html#.getTextContent">Numbas.xml.getTextContent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.isEmpty"><a href="Numbas.xml.html#.isEmpty">Numbas.xml.isEmpty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadFunctions"><a href="Numbas.xml.html#.loadFunctions">Numbas.xml.loadFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadVariables"><a href="Numbas.xml.html#.loadVariables">Numbas.xml.loadVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadXML"><a href="Numbas.xml.html#.loadXML">Numbas.xml.loadXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadXMLDocs"><a href="Numbas.xml.html#.loadXMLDocs">Numbas.xml.loadXMLDocs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.localise"><a href="Numbas.xml.html#.localise">Numbas.xml.localise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.serializeMessage"><a href="Numbas.xml.html#.serializeMessage">Numbas.xml.serializeMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.setTextContent"><a href="Numbas.xml.html#.setTextContent">Numbas.xml.setTextContent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.templates"><a href="Numbas.xml.html#.templates">Numbas.xml.templates</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.tryGetAttribute"><a href="Numbas.xml.html#.tryGetAttribute">Numbas.xml.tryGetAttribute</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.tryGetAttribute_options"><a href="Numbas.xml.html#.tryGetAttribute_options">Numbas.xml.tryGetAttribute_options</a></li>
-		
+
 			<li class="search-result" data-longname="package:undefined"><a href="global.html#package:">package:undefined</a></li>
-		
+
 			<li class="search-result" data-longname="range"><a href="global.html#range">range</a></li>
-		
+
 			<li class="search-result" data-longname="RequireScript"><a href="RequireScript.html">RequireScript</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/controls.js"><a href="global.html#runtime/scripts/controls.js">runtime/scripts/controls.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/exam.js"><a href="global.html#runtime/scripts/exam.js">runtime/scripts/exam.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme.js"><a href="global.html#runtime/scripts/jme.js">runtime/scripts/jme.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-builtins.js"><a href="global.html#runtime/scripts/jme-builtins.js">runtime/scripts/jme-builtins.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-display.js"><a href="global.html#runtime/scripts/jme-display.js">runtime/scripts/jme-display.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-rules.js"><a href="global.html#runtime/scripts/jme-rules.js">runtime/scripts/jme-rules.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-variables.js"><a href="global.html#runtime/scripts/jme-variables.js">runtime/scripts/jme-variables.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/json.js"><a href="global.html#runtime/scripts/json.js">runtime/scripts/json.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/math.js"><a href="global.html#runtime/scripts/math.js">runtime/scripts/math.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/numbas.js"><a href="global.html#runtime/scripts/numbas.js">runtime/scripts/numbas.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/part.js"><a href="global.html#runtime/scripts/part.js">runtime/scripts/part.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/custom_part_type.js"><a href="global.html#runtime/scripts/parts/custom_part_type.js">runtime/scripts/parts/custom_part_type.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/extension.js"><a href="global.html#runtime/scripts/parts/extension.js">runtime/scripts/parts/extension.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/gapfill.js"><a href="global.html#runtime/scripts/parts/gapfill.js">runtime/scripts/parts/gapfill.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/information.js"><a href="global.html#runtime/scripts/parts/information.js">runtime/scripts/parts/information.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/jme.js"><a href="global.html#runtime/scripts/parts/jme.js">runtime/scripts/parts/jme.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/matrixentry.js"><a href="global.html#runtime/scripts/parts/matrixentry.js">runtime/scripts/parts/matrixentry.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/multipleresponse.js"><a href="global.html#runtime/scripts/parts/multipleresponse.js">runtime/scripts/parts/multipleresponse.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/numberentry.js"><a href="global.html#runtime/scripts/parts/numberentry.js">runtime/scripts/parts/numberentry.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/patternmatch.js"><a href="global.html#runtime/scripts/parts/patternmatch.js">runtime/scripts/parts/patternmatch.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/question.js"><a href="global.html#runtime/scripts/question.js">runtime/scripts/question.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/schedule.js"><a href="global.html#runtime/scripts/schedule.js">runtime/scripts/schedule.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/scorm-storage.js"><a href="global.html#runtime/scripts/scorm-storage.js">runtime/scripts/scorm-storage.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/start-exam.js"><a href="global.html#runtime/scripts/start-exam.js">runtime/scripts/start-exam.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/timing.js"><a href="global.html#runtime/scripts/timing.js">runtime/scripts/timing.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/util.js"><a href="global.html#runtime/scripts/util.js">runtime/scripts/util.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/xml.js"><a href="global.html#runtime/scripts/xml.js">runtime/scripts/xml.js</a></li>
-		
+
 			<li class="search-result" data-longname="set"><a href="global.html#set">set</a></li>
-		
+
 			<li class="search-result" data-longname="TeX"><a href="global.html#TeX">TeX</a></li>
-		
+
 			<li class="search-result" data-longname="themes/default/files/scripts/display.js"><a href="global.html#themes/default/files/scripts/display.js">themes/default/files/scripts/display.js</a></li>
-		
+
 			<li class="search-result" data-longname="vector"><a href="global.html#vector">vector</a></li>
-		
+
 			<li class="search-result" data-longname="viewModel"><a href="viewModel.html">viewModel</a></li>
-		
+
 			<li class="search-result" data-longname="Number"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></li>
-		
+
 			<li class="search-result" data-longname="String"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></li>
-		
+
 			<li class="search-result" data-longname="RegExp"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a></li>
-		
+
 			<li class="search-result" data-longname="Date"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a></li>
-		
+
 			<li class="search-result" data-longname="Element"><a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a></li>
-		
+
 			<li class="search-result" data-longname="observable"><a href="http://knockoutjs.com/documentation/observables.html">observable</a></li>
-		
+
 			<li class="search-result" data-longname="jQuery"><a href="http://api.jquery.com/Types/#jQuery">jQuery</a></li>
-		
+
 			<li class="search-result" data-longname="Error"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a></li>
-		
+
 			<li class="search-result" data-longname="Boolean"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></li>
-		
+
 			<li class="search-result" data-longname="Array"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></li>
-		
+
 			<li class="search-result" data-longname="function"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></li>
-		
+
 			<li class="search-result" data-longname="XMLDocument"><a href="https://developer.mozilla.org/en/docs/Web/API/XMLDocument">XMLDocument</a></li>
-		
+
 			<li class="search-result" data-longname="Object"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></li>
-		
+
 	</ul>
 </div>
 <div class="main-nav-item"><h3>Namespaces</h3><ul><li><a href="Numbas.html">Numbas</a></li><li><a href="Numbas.controls.html">Numbas.controls</a></li><li><a href="Numbas.display.html">Numbas.display</a></li><li><a href="Numbas.jme.html">Numbas.jme</a></li><li><a href="Numbas.jme.display.html">Numbas.jme.display</a></li><li><a href="Numbas.jme.rules.html">Numbas.jme.rules</a></li><li><a href="Numbas.jme.types.html">Numbas.jme.types</a></li><li><a href="Numbas.jme.variables.html">Numbas.jme.variables</a></li><li><a href="Numbas.json.html">Numbas.json</a></li><li><a href="Numbas.marking.html">Numbas.marking</a></li><li><a href="Numbas.math.html">Numbas.math</a></li><li><a href="Numbas.matrixmath.html">Numbas.matrixmath</a></li><li><a href="Numbas.parts.html">Numbas.parts</a></li><li><a href="Numbas.schedule.html">Numbas.schedule</a></li><li><a href="Numbas.setmath.html">Numbas.setmath</a></li><li><a href="Numbas.storage.html">Numbas.storage</a></li><li><a href="Numbas.timing.html">Numbas.timing</a></li><li><a href="Numbas.util.html">Numbas.util</a></li><li><a href="Numbas.vectormath.html">Numbas.vectormath</a></li><li><a href="Numbas.xml.html">Numbas.xml</a></li></ul></div><div class="main-nav-item"><h3>Classes</h3><ul><li><a href="Numbas.storage.BlankStorage.html">BlankStorage</a></li><li><a href="Numbas.math.ComplexDecimal.html">ComplexDecimal</a></li><li><a href="Numbas.parts.CustomPart.html">CustomPart</a></li><li><a href="Numbas.jme.variables.DOMcontentsubber.html">DOMcontentsubber</a></li><li><a href="Numbas.Error.html">Error</a></li><li><a href="Numbas.Exam.html">Exam</a></li><li><a href="Numbas.display.ExamDisplay.html">ExamDisplay</a></li><li><a href="Numbas.ExamEvent.html">ExamEvent</a></li><li><a href="Numbas.parts.ExtensionPart.html">ExtensionPart</a></li><li><a href="Numbas.math.Fraction.html">Fraction</a></li><li><a href="Numbas.jme.funcObj.html">funcObj</a></li><li><a href="Numbas.parts.GapFillPart.html">GapFillPart</a></li><li><a href="Numbas.parts.InformationPart.html">InformationPart</a></li><li><a href="Numbas.parts.JMEPart.html">JMEPart</a></li><li><a href="Numbas.marking.MarkingNote.html">MarkingNote</a></li><li><a href="Numbas.marking.MarkingScript.html">MarkingScript</a></li><li><a href="Numbas.parts.MatrixEntryPart.html">MatrixEntryPart</a></li><li><a href="Numbas.parts.MultipleResponsePart.html">MultipleResponsePart</a></li><li><a href="Numbas.parts.NumberEntryPart.html">NumberEntryPart</a></li><li><a href="Numbas.jme.Parser.html">Parser</a></li><li><a href="Numbas.parts.Part_.html">Part</a></li><li><a href="Numbas.display.PartDisplay.html">PartDisplay</a></li><li><a href="Numbas.parts.PatternMatchPart.html">PatternMatchPart</a></li><li><a href="Numbas.Question.html">Question</a></li><li><a href="Numbas.display.QuestionDisplay.html">QuestionDisplay</a></li><li><a href="Numbas.QuestionGroup.html">QuestionGroup</a></li><li><a href="RequireScript.html">RequireScript</a></li><li><a href="Numbas.jme.rules.Rule.html">Rule</a></li><li><a href="Numbas.jme.rules.Ruleset.html">Ruleset</a></li><li><a href="Numbas.jme.Scope.html">Scope</a></li><li><a href="Numbas.storage.SCORMStorage.html">SCORMStorage</a></li><li><a href="Numbas.schedule.SignalBox.html">SignalBox</a></li><li><a href="Numbas.marking.StatefulScope.html">StatefulScope</a></li><li><a href="Numbas.jme.types.TBool.html">TBool</a></li><li><a href="Numbas.jme.types.TDict.html">TDict</a></li><li><a href="Numbas.jme.types.TExpression.html">TExpression</a></li><li><a href="Numbas.jme.types.TFunc.html">TFunc</a></li><li><a href="Numbas.jme.types.THTML.html">THTML</a></li><li><a href="Numbas.jme.types.TKeyPair.html">TKeyPair</a></li><li><a href="Numbas.jme.types.TList.html">TList</a></li><li><a href="Numbas.jme.types.TMatrix.html">TMatrix</a></li><li><a href="Numbas.jme.types.TName.html">TName</a></li><li><a href="Numbas.jme.types.TNothing.html">TNothing</a></li><li><a href="Numbas.jme.types.TNum.html">TNum</a></li><li><a href="Numbas.jme.types.TOp.html">TOp</a></li><li><a href="Numbas.jme.types.TPunc.html">TPunc</a></li><li><a href="Numbas.jme.types.TRange.html">TRange</a></li><li><a href="Numbas.jme.types.TSet.html">TSet</a></li><li><a href="Numbas.jme.types.TString.html">TString</a></li><li><a href="Numbas.jme.types.TVector.html">TVector</a></li></ul></div><div class="main-nav-item"><h3>Events</h3><ul><li><a href="Numbas.Question.html#event:functionsLoaded">functionsLoaded</a></li><li><a href="Numbas.Question.html#event:functionsMade">functionsMade</a></li><li><a href="Numbas.Question.html#event:generateVariables">generateVariables</a></li><li><a href="Numbas.Question.html#event:HTMLAttached">HTMLAttached</a></li><li><a href="Numbas.Question.html#event:partsGenerated">partsGenerated</a></li><li><a href="Numbas.Question.html#event:partsResumed">partsResumed</a></li><li><a href="Numbas.Question.html#event:preambleLoaded">preambleLoaded</a></li><li><a href="Numbas.Question.html#event:preambleRun">preambleRun</a></li><li><a href="Numbas.Exam.html#event:questionlistinitialised">question list initialised</a></li><li><a href="Numbas.Exam.html#event:ready">ready</a></li><li><a href="Numbas.Question.html#event:ready">ready</a></li><li><a href="Numbas.Question.html#event:rulesetsLoaded">rulesetsLoaded</a></li><li><a href="Numbas.Question.html#event:rulesetsMade">rulesetsMade</a></li><li><a href="Numbas.Question.html#event:variableDefinitionsLoaded">variableDefinitionsLoaded</a></li><li><a href="Numbas.Question.html#event:variablesGenerated">variablesGenerated</a></li><li><a href="Numbas.Question.html#event:variablesSet">variablesSet</a></li></ul></div><h3>Global variables</h3><ul><li><a href="global.html#get">get</a></li><li><a href="global.html#hasWarnings">hasWarnings</a></li></ul>

--- a/docs/runtime_scripts_jme-display.js.html
+++ b/docs/runtime_scripts_jme-display.js.html
@@ -343,7 +343,18 @@ var texOps = jme.display.texOps = {
         }
         return s;
     }),
-    '/': (function(thing,texArgs) { return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }'); }),
+    '/': (function(thing,texArgs,settings) {
+        if (settings.flatfractions) {
+            for (var i=0; i<2; i++) {
+                // identifying if the numerator and denominator need brackets around them by
+                // checking whether they contain whitespaces
+                if (texArgs[i].includes(' ')) texArgs[i] = '(' + texArgs[i] + ')'
+            }
+            return ('\\left. '+texArgs[0]+' \\middle/ '+texArgs[1]+' \\right.');
+        } else {
+            return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }');
+        }
+    }),
     '+': (function(thing,texArgs,settings) {
         var a = thing.args[0];
         var b = thing.args[1];

--- a/docs/runtime_scripts_jme-rules.js.html
+++ b/docs/runtime_scripts_jme-rules.js.html
@@ -1779,7 +1779,8 @@ var displayFlags = jme.rules.displayFlags = {
     fractionnumbers: undefined,
     rowvector: undefined,
     alwaystimes: undefined,
-    mixedfractions: undefined
+    mixedfractions: undefined,
+    flatfractions: undefined
 };
 /** Flags used in JME simplification rulesets
  * @type Object.&lt;Boolean>
@@ -1787,6 +1788,7 @@ var displayFlags = jme.rules.displayFlags = {
  * @property {Boolean} fractionnumbers - Show all numbers as fractions?
  * @property {Boolean} rowvector - Display vectors as a horizontal list of components?
  * @property {Boolean} alwaystimes - Always show the multiplication symbol between multiplicands?
+ * @property {Boolean} flatfractions - Display fractions horizontally?
  * @see Numbas.jme.rules.Ruleset
  */
 /** Set of simplification rules

--- a/docs/runtime_scripts_jme-rules.js.html
+++ b/docs/runtime_scripts_jme-rules.js.html
@@ -23,11 +23,11 @@
 
 		<h1 class="page-title">Source: runtime/scripts/jme-rules.js</h1>
 
-		
 
 
 
-    
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>Numbas.queueScript('jme-rules',['base','math','jme-base','util'],function() {
@@ -275,7 +275,7 @@ var Term = Numbas.jme.rules.Term = function(tree) {
 }
 
 /** Replacements to make when identifying terms in a sequence of applications of a given op.
- * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`. 
+ * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`.
  * A tree `A op B` should be replaced with `replacement(tree)`.
  * For example, `x-y` should be rewritten to `x+(-y)`.
  */
@@ -285,7 +285,7 @@ var nonStrictReplacements = {
             return {tok: new jme.types.TOp('+',false,false,2,true,true), args: [tree.args[0],insertUnaryMinus(tree.args[1])]};
         }
     },
-    '*': { 
+    '*': {
         '/': function(tree) {
             tree = {tok: new jme.types.TOp('*',false,false,2,true,true), args: [tree.args[0],{tok:new jme.types.TOp('/u',false,true,1,false,false),args:[tree.args[1]]}]};
             return tree;
@@ -354,12 +354,12 @@ var getTerms = Numbas.jme.rules.getTerms = function(tree,op,options,calculate_mi
     function add_existing_names(items,existing_names,existing_equal_names) {
         return existing_names.length==0 &amp;&amp; existing_equal_names.length==0 ? items : items.map(function(item) {
             return {
-                term: item.term, 
+                term: item.term,
                 names: existing_names.concat(item.names),
                 inside_equalnames: item.inside_equalnames,
                 outside_equalnames: existing_equal_names.concat(item.outside_equalnames),
-                quantifier: item.quantifier, 
-                min: item.min, 
+                quantifier: item.quantifier,
+                min: item.min,
                 max: item.max,
                 defaultValue: item.defaultValue,
             };
@@ -736,7 +736,7 @@ function matchFunction(ruleTree,exprTree,options) {
     }
     if(ruleTok.name in specialMatchFunctions) {
         return specialMatchFunctions[ruleTok.name](ruleTree,exprTree,options);
-    } else { 
+    } else {
         return matchOrdinaryFunction(ruleTree,exprTree,options);
     }
 }
@@ -1150,7 +1150,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * The indices of the input and rule terms are given so the result of the match can be cached
      * @param {Numbas.jme.rules.term} exprTerm - the input term
      * @param {Numbas.jme.rules.term} ruleTerm - the term in the pattern which must be matched
-     * @param {Number} ic - the index of the input term 
+     * @param {Number} ic - the index of the input term
      * @param {Number} pc - the index of the rule term
      * @returns {Boolean}
      */
@@ -1179,7 +1179,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
                 outside_equalnames: outside_equalnames
             }
         }
-        return matches[ic][pc].match!==false; 
+        return matches[ic][pc].match!==false;
     }
 
     /** Does the given assignment satisfy the constraints of the matching algorithm?
@@ -1250,7 +1250,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * @param {Numbas.jme.rules.term} ruleTerm
      * @param {Numbas.jme.tree} exprTree
      */
-    function matchTerm(ruleTerm,exprTree){ 
+    function matchTerm(ruleTerm,exprTree){
         ruleTerm.names.forEach(function(name) {
             var o = resolveName(name,exprTree);
             nameTerm(o.name,o.value,ruleTerm);
@@ -1352,8 +1352,8 @@ var findSequenceMatch = jme.rules.findSequenceMatch = function(pattern,input,opt
             capture.push(-1);
             increment_start();
             return;
-        } 
-        
+        }
+
         ic -= 1;
         while(ic>=start &amp;&amp; (ic>=capture.length || capture[ic]>=pattern.length)) {
             ic -= 1;
@@ -1581,7 +1581,7 @@ function matchType(wantedType,exprTree) {
     }
 }
 
-/** Match all of the given patterns against the given expression. 
+/** Match all of the given patterns against the given expression.
  * Return `false` if any of the patterns don't match.
  * @param {Array.&lt;Numbas.jme.tree>} patterns
  * @param {Numbas.jme.tree} exprTree
@@ -1702,7 +1702,7 @@ var transform = jme.rules.transform = function(ruleTree,resultTree,exprTree,opti
 var transformAll = jme.rules.transformAll = function(ruleTree,resultTree,exprTree,options) {
     var changed = false;
     if(exprTree.args) {
-        var args = exprTree.args.map(function(arg){ 
+        var args = exprTree.args.map(function(arg){
             var o = transformAll(ruleTree,resultTree,arg,options);
             changed = changed || o.changed;
             return  o.expression;
@@ -1733,7 +1733,7 @@ patternParser.addPostfixOperator('`?','`?',{precedence: 0.5});  // optional
 patternParser.addPostfixOperator('`*','`*',{precedence: 0.5}); // any number of times
 patternParser.addPostfixOperator('`+','`+',{precedence: 0.5}); // at least one time
 
-patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not 
+patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not
 patternParser.addPrefixOperator('`+-','`+-',{precedence: 0.5});  // unary plus or minus
 patternParser.addPrefixOperator('`*/','`*/',{precedence: 0.5});  // unary multiply or divide
 
@@ -1813,7 +1813,7 @@ Ruleset.prototype = /** @lends Numbas.jme.rules.Ruleset.prototype */ {
             return false;
     },
 
-    /** Apply this set's rules to the given expression until they don't change any more 
+    /** Apply this set's rules to the given expression until they don't change any more
      * @param {Numbas.jme.tree} exprTree
      * @param {Numbas.jme.Scope} scope
      * @see Numbas.jme.rules.transform
@@ -2095,3397 +2095,3397 @@ jme.rules.simplificationRules = compiledSimplificationRules;
 		<h2><a href="index.html">Home</a></h2><div class="search">
 	<input id="search-query" type="text" placeholder="Search"/>
 	<ul id="search-results">
-		
+
 			<li class="search-result" data-longname="global"><a href="global.html">global</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree"><a href="AnnotatedTree.html">AnnotatedTree</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#assign"><a href="AnnotatedTree.html#assign">AnnotatedTree#assign</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#assign_args"><a href="AnnotatedTree.html#assign_args">AnnotatedTree#assign_args</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#backtrack"><a href="AnnotatedTree.html#backtrack">AnnotatedTree#backtrack</a></li>
-		
+
 			<li class="search-result" data-longname="AnnotatedTree#next"><a href="AnnotatedTree.html#next">AnnotatedTree#next</a></li>
-		
+
 			<li class="search-result" data-longname="complex"><a href="global.html#complex">complex</a></li>
-		
+
 			<li class="search-result" data-longname="fraction"><a href="global.html#fraction">fraction</a></li>
-		
+
 			<li class="search-result" data-longname="get"><a href="global.html#get">get</a></li>
-		
+
 			<li class="search-result" data-longname="hasWarnings"><a href="global.html#hasWarnings">hasWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="JME"><a href="global.html#JME">JME</a></li>
-		
+
 			<li class="search-result" data-longname="matrix"><a href="global.html#matrix">matrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas"><a href="Numbas.html">Numbas</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.addExtension"><a href="Numbas.html#.addExtension">Numbas.addExtension</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.checkAllScriptsLoaded"><a href="Numbas.html#.checkAllScriptsLoaded">Numbas.checkAllScriptsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls"><a href="Numbas.controls.html">Numbas.controls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.backToResults"><a href="Numbas.controls.html#.backToResults">Numbas.controls.backToResults</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.beginExam"><a href="Numbas.controls.html#.beginExam">Numbas.controls.beginExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.endExam"><a href="Numbas.controls.html#.endExam">Numbas.controls.endExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.exitExam"><a href="Numbas.controls.html#.exitExam">Numbas.controls.exitExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.getAdvice"><a href="Numbas.controls.html#.getAdvice">Numbas.controls.getAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.hideSteps"><a href="Numbas.controls.html#.hideSteps">Numbas.controls.hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.jumpQuestion"><a href="Numbas.controls.html#.jumpQuestion">Numbas.controls.jumpQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.makeQuestionJumper"><a href="Numbas.controls.html#.makeQuestionJumper">Numbas.controls.makeQuestionJumper</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.nextQuestion"><a href="Numbas.controls.html#.nextQuestion">Numbas.controls.nextQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.pauseExam"><a href="Numbas.controls.html#.pauseExam">Numbas.controls.pauseExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.previousQuestion"><a href="Numbas.controls.html#.previousQuestion">Numbas.controls.previousQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.regenQuestion"><a href="Numbas.controls.html#.regenQuestion">Numbas.controls.regenQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.resumeExam"><a href="Numbas.controls.html#.resumeExam">Numbas.controls.resumeExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.revealAnswer"><a href="Numbas.controls.html#.revealAnswer">Numbas.controls.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.controls.submitQuestion"><a href="Numbas.controls.html#.submitQuestion">Numbas.controls.submitQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPart"><a href="Numbas.html#.createPart">Numbas.createPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPartFromJSON"><a href="Numbas.html#.createPartFromJSON">Numbas.createPartFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createPartFromXML"><a href="Numbas.html#.createPartFromXML">Numbas.createPartFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createQuestionFromJSON"><a href="Numbas.html#.createQuestionFromJSON">Numbas.createQuestionFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.createQuestionFromXML"><a href="Numbas.html#.createQuestionFromXML">Numbas.createQuestionFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.custom_part_types"><a href="Numbas.html#.custom_part_types">Numbas.custom_part_types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.debug"><a href="Numbas.html#.debug">Numbas.debug</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display"><a href="Numbas.display.html">Numbas.display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.die"><a href="Numbas.display.html#.die">Numbas.display.die</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay"><a href="Numbas.display.ExamDisplay.html">Numbas.display.ExamDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay._endTime"><a href="Numbas.display.ExamDisplay.html#._endTime">Numbas.display.ExamDisplay._endTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay._startTime"><a href="Numbas.display.ExamDisplay.html#._startTime">Numbas.display.ExamDisplay._startTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.allowPause"><a href="Numbas.display.ExamDisplay.html#.allowPause">Numbas.display.ExamDisplay.allowPause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.applyQuestionBindings"><a href="Numbas.display.ExamDisplay.html#.applyQuestionBindings">Numbas.display.ExamDisplay.applyQuestionBindings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.beginExam"><a href="Numbas.display.ExamDisplay.html#.beginExam">Numbas.display.ExamDisplay.beginExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canAdvance"><a href="Numbas.display.ExamDisplay.html#.canAdvance">Numbas.display.ExamDisplay.canAdvance</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canBegin"><a href="Numbas.display.ExamDisplay.html#.canBegin">Numbas.display.ExamDisplay.canBegin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.canReverse"><a href="Numbas.display.ExamDisplay.html#.canReverse">Numbas.display.ExamDisplay.canReverse</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.currentQuestion"><a href="Numbas.display.ExamDisplay.html#.currentQuestion">Numbas.display.ExamDisplay.currentQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.currentQuestionNumber"><a href="Numbas.display.ExamDisplay.html#.currentQuestionNumber">Numbas.display.ExamDisplay.currentQuestionNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.displayTime"><a href="Numbas.display.ExamDisplay.html#.displayTime">Numbas.display.ExamDisplay.displayTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.end"><a href="Numbas.display.ExamDisplay.html#.end">Numbas.display.ExamDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.endRegen"><a href="Numbas.display.ExamDisplay.html#.endRegen">Numbas.display.ExamDisplay.endRegen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.enteredPassword"><a href="Numbas.display.ExamDisplay.html#.enteredPassword">Numbas.display.ExamDisplay.enteredPassword</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.exam"><a href="Numbas.display.ExamDisplay.html#.exam">Numbas.display.ExamDisplay.exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.examScoreDisplay"><a href="Numbas.display.ExamDisplay.html#.examScoreDisplay">Numbas.display.ExamDisplay.examScoreDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.feedbackMessage"><a href="Numbas.display.ExamDisplay.html#.feedbackMessage">Numbas.display.ExamDisplay.feedbackMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.hideNavMenu"><a href="Numbas.display.ExamDisplay.html#.hideNavMenu">Numbas.display.ExamDisplay.hideNavMenu</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.hideTiming"><a href="Numbas.display.ExamDisplay.html#.hideTiming">Numbas.display.ExamDisplay.hideTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.infoPage"><a href="Numbas.display.ExamDisplay.html#.infoPage">Numbas.display.ExamDisplay.infoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.initQuestionList"><a href="Numbas.display.ExamDisplay.html#.initQuestionList">Numbas.display.ExamDisplay.initQuestionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.marks"><a href="Numbas.display.ExamDisplay.html#.marks">Numbas.display.ExamDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.mode"><a href="Numbas.display.ExamDisplay.html#.mode">Numbas.display.ExamDisplay.mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.passed"><a href="Numbas.display.ExamDisplay.html#.passed">Numbas.display.ExamDisplay.passed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.passwordFeedback."><a href="Numbas.display.ExamDisplay.html#.passwordFeedback.">Numbas.display.ExamDisplay.passwordFeedback.</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.percentPass"><a href="Numbas.display.ExamDisplay.html#.percentPass">Numbas.display.ExamDisplay.percentPass</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.percentScore"><a href="Numbas.display.ExamDisplay.html#.percentScore">Numbas.display.ExamDisplay.percentScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questions"><a href="Numbas.display.ExamDisplay.html#.questions">Numbas.display.ExamDisplay.questions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questionsAttempted"><a href="Numbas.display.ExamDisplay.html#.questionsAttempted">Numbas.display.ExamDisplay.questionsAttempted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.questionsAttemptedDisplay"><a href="Numbas.display.ExamDisplay.html#.questionsAttemptedDisplay">Numbas.display.ExamDisplay.questionsAttemptedDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.result"><a href="Numbas.display.ExamDisplay.html#.result">Numbas.display.ExamDisplay.result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.saving"><a href="Numbas.display.ExamDisplay.html#.saving">Numbas.display.ExamDisplay.saving</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.score"><a href="Numbas.display.ExamDisplay.html#.score">Numbas.display.ExamDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showInfoPage"><a href="Numbas.display.ExamDisplay.html#.showInfoPage">Numbas.display.ExamDisplay.showInfoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showQuestion"><a href="Numbas.display.ExamDisplay.html#.showQuestion">Numbas.display.ExamDisplay.showQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showQuestionGroupNames"><a href="Numbas.display.ExamDisplay.html#.showQuestionGroupNames">Numbas.display.ExamDisplay.showQuestionGroupNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showScore"><a href="Numbas.display.ExamDisplay.html#.showScore">Numbas.display.ExamDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.showTiming"><a href="Numbas.display.ExamDisplay.html#.showTiming">Numbas.display.ExamDisplay.showTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.startRegen"><a href="Numbas.display.ExamDisplay.html#.startRegen">Numbas.display.ExamDisplay.startRegen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.timeSpent"><a href="Numbas.display.ExamDisplay.html#.timeSpent">Numbas.display.ExamDisplay.timeSpent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.updateQuestionMenu"><a href="Numbas.display.ExamDisplay.html#.updateQuestionMenu">Numbas.display.ExamDisplay.updateQuestionMenu</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.ExamDisplay.viewType"><a href="Numbas.display.ExamDisplay.html#.viewType">Numbas.display.ExamDisplay.viewType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.feedback_state"><a href="Numbas.display.html#.feedback_state">Numbas.display.feedback_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.feedbackable"><a href="Numbas.display.html#.feedbackable">Numbas.display.feedbackable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.getLocalisedAttribute"><a href="Numbas.display.html#.getLocalisedAttribute">Numbas.display.getLocalisedAttribute</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.init"><a href="Numbas.display.html#.init">Numbas.display.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.localisePage"><a href="Numbas.display.html#.localisePage">Numbas.display.localisePage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.modal"><a href="Numbas.display.html#.modal">Numbas.display.modal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay"><a href="Numbas.display.PartDisplay.html">Numbas.display.PartDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.answered"><a href="Numbas.display.PartDisplay.html#.answered">Numbas.display.PartDisplay.answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.controls"><a href="Numbas.display.PartDisplay.html#.controls">Numbas.display.PartDisplay.controls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.credit"><a href="Numbas.display.PartDisplay.html#.credit">Numbas.display.PartDisplay.credit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.doesMarking"><a href="Numbas.display.PartDisplay.html#.doesMarking">Numbas.display.PartDisplay.doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.end"><a href="Numbas.display.PartDisplay.html#.end">Numbas.display.PartDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.feedbackMessages"><a href="Numbas.display.PartDisplay.html#.feedbackMessages">Numbas.display.PartDisplay.feedbackMessages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.feedbackShown"><a href="Numbas.display.PartDisplay.html#.feedbackShown">Numbas.display.PartDisplay.feedbackShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.hideSteps"><a href="Numbas.display.PartDisplay.html#.hideSteps">Numbas.display.PartDisplay.hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.hideWarnings"><a href="Numbas.display.PartDisplay.html#.hideWarnings">Numbas.display.PartDisplay.hideWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.init"><a href="Numbas.display.PartDisplay.html#.init">Numbas.display.PartDisplay.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.inputEvents"><a href="Numbas.display.PartDisplay.html#.inputEvents">Numbas.display.PartDisplay.inputEvents</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.isDirty"><a href="Numbas.display.PartDisplay.html#.isDirty">Numbas.display.PartDisplay.isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.isNotOnlyPart"><a href="Numbas.display.PartDisplay.html#.isNotOnlyPart">Numbas.display.PartDisplay.isNotOnlyPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.marks"><a href="Numbas.display.PartDisplay.html#.marks">Numbas.display.PartDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.part"><a href="Numbas.display.PartDisplay.html#.part">Numbas.display.PartDisplay.part</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.question"><a href="Numbas.display.PartDisplay.html#.question">Numbas.display.PartDisplay.question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.removeWarnings"><a href="Numbas.display.PartDisplay.html#.removeWarnings">Numbas.display.PartDisplay.removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.restoreAnswer"><a href="Numbas.display.PartDisplay.html#.restoreAnswer">Numbas.display.PartDisplay.restoreAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.revealAnswer"><a href="Numbas.display.PartDisplay.html#.revealAnswer">Numbas.display.PartDisplay.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.revealed"><a href="Numbas.display.PartDisplay.html#.revealed">Numbas.display.PartDisplay.revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.score"><a href="Numbas.display.PartDisplay.html#.score">Numbas.display.PartDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.scoreFeedback"><a href="Numbas.display.PartDisplay.html#.scoreFeedback">Numbas.display.PartDisplay.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.setWarnings"><a href="Numbas.display.PartDisplay.html#.setWarnings">Numbas.display.PartDisplay.setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.show"><a href="Numbas.display.PartDisplay.html#.show">Numbas.display.PartDisplay.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showCorrectAnswer"><a href="Numbas.display.PartDisplay.html#.showCorrectAnswer">Numbas.display.PartDisplay.showCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackBox"><a href="Numbas.display.PartDisplay.html#.showFeedbackBox">Numbas.display.PartDisplay.showFeedbackBox</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackIcon"><a href="Numbas.display.PartDisplay.html#.showFeedbackIcon">Numbas.display.PartDisplay.showFeedbackIcon</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showFeedbackMessages"><a href="Numbas.display.PartDisplay.html#.showFeedbackMessages">Numbas.display.PartDisplay.showFeedbackMessages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showMarks"><a href="Numbas.display.PartDisplay.html#.showMarks">Numbas.display.PartDisplay.showMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showScore"><a href="Numbas.display.PartDisplay.html#.showScore">Numbas.display.PartDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showSteps"><a href="Numbas.display.PartDisplay.html#.showSteps">Numbas.display.PartDisplay.showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showSubmitPart"><a href="Numbas.display.PartDisplay.html#.showSubmitPart">Numbas.display.PartDisplay.showSubmitPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.showWarnings"><a href="Numbas.display.PartDisplay.html#.showWarnings">Numbas.display.PartDisplay.showWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsOpen"><a href="Numbas.display.PartDisplay.html#.stepsOpen">Numbas.display.PartDisplay.stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsPenaltyMessage"><a href="Numbas.display.PartDisplay.html#.stepsPenaltyMessage">Numbas.display.PartDisplay.stepsPenaltyMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.stepsShown"><a href="Numbas.display.PartDisplay.html#.stepsShown">Numbas.display.PartDisplay.stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.toggleFeedbackText"><a href="Numbas.display.PartDisplay.html#.toggleFeedbackText">Numbas.display.PartDisplay.toggleFeedbackText</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.updateCorrectAnswer"><a href="Numbas.display.PartDisplay.html#.updateCorrectAnswer">Numbas.display.PartDisplay.updateCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warning"><a href="Numbas.display.PartDisplay.html#.warning">Numbas.display.PartDisplay.warning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warnings"><a href="Numbas.display.PartDisplay.html#.warnings">Numbas.display.PartDisplay.warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay.warningsShown"><a href="Numbas.display.PartDisplay.html#.warningsShown">Numbas.display.PartDisplay.warningsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.PartDisplay#setName"><a href="Numbas.display.PartDisplay.html#setName">Numbas.display.PartDisplay#setName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay"><a href="Numbas.display.QuestionDisplay.html">Numbas.display.QuestionDisplay</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.adviceDisplayed"><a href="Numbas.display.QuestionDisplay.html#.adviceDisplayed">Numbas.display.QuestionDisplay.adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.answered"><a href="Numbas.display.QuestionDisplay.html#.answered">Numbas.display.QuestionDisplay.answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.anyAnswered"><a href="Numbas.display.QuestionDisplay.html#.anyAnswered">Numbas.display.QuestionDisplay.anyAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.canReveal"><a href="Numbas.display.QuestionDisplay.html#.canReveal">Numbas.display.QuestionDisplay.canReveal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.credit"><a href="Numbas.display.QuestionDisplay.html#.credit">Numbas.display.QuestionDisplay.credit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.displayName"><a href="Numbas.display.QuestionDisplay.html#.displayName">Numbas.display.QuestionDisplay.displayName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.doesMarking"><a href="Numbas.display.QuestionDisplay.html#.doesMarking">Numbas.display.QuestionDisplay.doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.end"><a href="Numbas.display.QuestionDisplay.html#.end">Numbas.display.QuestionDisplay.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.getPart"><a href="Numbas.display.QuestionDisplay.html#.getPart">Numbas.display.QuestionDisplay.getPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.html"><a href="Numbas.display.QuestionDisplay.html#.html">Numbas.display.QuestionDisplay.html</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.init"><a href="Numbas.display.QuestionDisplay.html#.init">Numbas.display.QuestionDisplay.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.isDirty"><a href="Numbas.display.QuestionDisplay.html#.isDirty">Numbas.display.QuestionDisplay.isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.leave"><a href="Numbas.display.QuestionDisplay.html#.leave">Numbas.display.QuestionDisplay.leave</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.makeHTML"><a href="Numbas.display.QuestionDisplay.html#.makeHTML">Numbas.display.QuestionDisplay.makeHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.marks"><a href="Numbas.display.QuestionDisplay.html#.marks">Numbas.display.QuestionDisplay.marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.numParts"><a href="Numbas.display.QuestionDisplay.html#.numParts">Numbas.display.QuestionDisplay.numParts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.question"><a href="Numbas.display.QuestionDisplay.html#.question">Numbas.display.QuestionDisplay.question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.revealAnswer"><a href="Numbas.display.QuestionDisplay.html#.revealAnswer">Numbas.display.QuestionDisplay.revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.revealed"><a href="Numbas.display.QuestionDisplay.html#.revealed">Numbas.display.QuestionDisplay.revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.review"><a href="Numbas.display.QuestionDisplay.html#.review">Numbas.display.QuestionDisplay.review</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.score"><a href="Numbas.display.QuestionDisplay.html#.score">Numbas.display.QuestionDisplay.score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.scoreFeedback"><a href="Numbas.display.QuestionDisplay.html#.scoreFeedback">Numbas.display.QuestionDisplay.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.scrollToError"><a href="Numbas.display.QuestionDisplay.html#.scrollToError">Numbas.display.QuestionDisplay.scrollToError</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.show"><a href="Numbas.display.QuestionDisplay.html#.show">Numbas.display.QuestionDisplay.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.showAdvice"><a href="Numbas.display.QuestionDisplay.html#.showAdvice">Numbas.display.QuestionDisplay.showAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.showScore"><a href="Numbas.display.QuestionDisplay.html#.showScore">Numbas.display.QuestionDisplay.showScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.submitMessage"><a href="Numbas.display.QuestionDisplay.html#.submitMessage">Numbas.display.QuestionDisplay.submitMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.visible"><a href="Numbas.display.QuestionDisplay.html#.visible">Numbas.display.QuestionDisplay.visible</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.QuestionDisplay.visited"><a href="Numbas.display.QuestionDisplay.html#.visited">Numbas.display.QuestionDisplay.visited</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.scoreFeedback"><a href="Numbas.display.html#.scoreFeedback">Numbas.display.scoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showAlert"><a href="Numbas.display.html#.showAlert">Numbas.display.showAlert</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showConfirm"><a href="Numbas.display.html#.showConfirm">Numbas.display.showConfirm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showLoadProgress"><a href="Numbas.display.html#.showLoadProgress">Numbas.display.showLoadProgress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showScoreFeedback"><a href="Numbas.display.html#.showScoreFeedback">Numbas.display.showScoreFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.showScoreFeedback_settings"><a href="Numbas.display.html#.showScoreFeedback_settings">Numbas.display.showScoreFeedback_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.display.typeset"><a href="Numbas.display.html#.typeset">Numbas.display.typeset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Error"><a href="Numbas.Error.html">Numbas.Error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam"><a href="Numbas.Exam.html">Numbas.Exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.exam"><a href="Numbas.html#.exam">Numbas.exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#acceptPassword"><a href="Numbas.Exam.html#acceptPassword">Numbas.Exam#acceptPassword</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#begin"><a href="Numbas.Exam.html#begin">Numbas.Exam#begin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#calculateScore"><a href="Numbas.Exam.html#calculateScore">Numbas.Exam#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#changeQuestion"><a href="Numbas.Exam.html#changeQuestion">Numbas.Exam#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#chooseQuestionSubset"><a href="Numbas.Exam.html#chooseQuestionSubset">Numbas.Exam#chooseQuestionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#countDown"><a href="Numbas.Exam.html#countDown">Numbas.Exam#countDown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#currentQuestion"><a href="Numbas.Exam.html#currentQuestion">Numbas.Exam#currentQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#currentQuestionNumber"><a href="Numbas.Exam.html#currentQuestionNumber">Numbas.Exam#currentQuestionNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#displayDuration"><a href="Numbas.Exam.html#displayDuration">Numbas.Exam#displayDuration</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#end"><a href="Numbas.Exam.html#end">Numbas.Exam#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#endTime"><a href="Numbas.Exam.html#endTime">Numbas.Exam#endTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#endTiming"><a href="Numbas.Exam.html#endTiming">Numbas.Exam#endTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#event:question list initialised"><a href="Numbas.Exam.html#event:questionlistinitialised">Numbas.Exam#event:question list initialised</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#event:ready"><a href="Numbas.Exam.html#event:ready">Numbas.Exam#event:ready</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#exit"><a href="Numbas.Exam.html#exit">Numbas.Exam#exit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#init"><a href="Numbas.Exam.html#init">Numbas.Exam#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#inProgress"><a href="Numbas.Exam.html#inProgress">Numbas.Exam#inProgress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#load"><a href="Numbas.Exam.html#load">Numbas.Exam#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#makeQuestionList"><a href="Numbas.Exam.html#makeQuestionList">Numbas.Exam#makeQuestionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#mark"><a href="Numbas.Exam.html#mark">Numbas.Exam#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#mode"><a href="Numbas.Exam.html#mode">Numbas.Exam#mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#passed"><a href="Numbas.Exam.html#passed">Numbas.Exam#passed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#pause"><a href="Numbas.Exam.html#pause">Numbas.Exam#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#percentScore"><a href="Numbas.Exam.html#percentScore">Numbas.Exam#percentScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#question_groups"><a href="Numbas.Exam.html#question_groups">Numbas.Exam#question_groups</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#questionList"><a href="Numbas.Exam.html#questionList">Numbas.Exam#questionList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#questionSubset"><a href="Numbas.Exam.html#questionSubset">Numbas.Exam#questionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#regenQuestion"><a href="Numbas.Exam.html#regenQuestion">Numbas.Exam#regenQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#resume"><a href="Numbas.Exam.html#resume">Numbas.Exam#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#reviewQuestion"><a href="Numbas.Exam.html#reviewQuestion">Numbas.Exam#reviewQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#scope"><a href="Numbas.Exam.html#scope">Numbas.Exam#scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#score"><a href="Numbas.Exam.html#score">Numbas.Exam#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#settings"><a href="Numbas.Exam.html#settings">Numbas.Exam#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#showInfoPage"><a href="Numbas.Exam.html#showInfoPage">Numbas.Exam#showInfoPage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#signals"><a href="Numbas.Exam.html#signals">Numbas.Exam#signals</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#start"><a href="Numbas.Exam.html#start">Numbas.Exam#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#startTiming"><a href="Numbas.Exam.html#startTiming">Numbas.Exam#startTiming</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#stop"><a href="Numbas.Exam.html#stop">Numbas.Exam#stop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#stopwatch"><a href="Numbas.Exam.html#stopwatch">Numbas.Exam#stopwatch</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#store"><a href="Numbas.Exam.html#store">Numbas.Exam#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#student_id"><a href="Numbas.Exam.html#student_id">Numbas.Exam#student_id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#student_name"><a href="Numbas.Exam.html#student_name">Numbas.Exam#student_name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#timeRemaining"><a href="Numbas.Exam.html#timeRemaining">Numbas.Exam#timeRemaining</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#timeSpent"><a href="Numbas.Exam.html#timeSpent">Numbas.Exam#timeSpent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#tryChangeQuestion"><a href="Numbas.Exam.html#tryChangeQuestion">Numbas.Exam#tryChangeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#tryEnd"><a href="Numbas.Exam.html#tryEnd">Numbas.Exam#tryEnd</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#updateScore"><a href="Numbas.Exam.html#updateScore">Numbas.Exam#updateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Exam#xml"><a href="Numbas.Exam.html#xml">Numbas.Exam#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent"><a href="Numbas.ExamEvent.html">Numbas.ExamEvent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#action"><a href="Numbas.ExamEvent.html#action">Numbas.ExamEvent#action</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#message"><a href="Numbas.ExamEvent.html#message">Numbas.ExamEvent#message</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.ExamEvent#type"><a href="Numbas.ExamEvent.html#type">Numbas.ExamEvent#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.extensions"><a href="Numbas.html#.extensions">Numbas.extensions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.init"><a href="Numbas.html#.init">Numbas.init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme"><a href="Numbas.jme.html">Numbas.jme</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addBinaryOperator"><a href="Numbas.jme.html#.addBinaryOperator">Numbas.jme.addBinaryOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addPostfixOperator"><a href="Numbas.jme.html#.addPostfixOperator">Numbas.jme.addPostfixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.addPrefixOperator"><a href="Numbas.jme.html#.addPrefixOperator">Numbas.jme.addPrefixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.arity"><a href="Numbas.jme.html#.arity">Numbas.jme.arity</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.associative"><a href="Numbas.jme.html#.associative">Numbas.jme.associative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.builtinScope"><a href="Numbas.jme.html#.builtinScope">Numbas.jme.builtinScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.castToType"><a href="Numbas.jme.html#.castToType">Numbas.jme.castToType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.checkingFunction"><a href="Numbas.jme.html#.checkingFunction">Numbas.jme.checkingFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.checkingFunctions"><a href="Numbas.jme.html#.checkingFunctions">Numbas.jme.checkingFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.commutative"><a href="Numbas.jme.html#.commutative">Numbas.jme.commutative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compare"><a href="Numbas.jme.html#.compare">Numbas.jme.compare</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compare_settings"><a href="Numbas.jme.html#.compare_settings">Numbas.jme.compare_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTokens"><a href="Numbas.jme.html#.compareTokens">Numbas.jme.compareTokens</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTokensByValue"><a href="Numbas.jme.html#.compareTokensByValue">Numbas.jme.compareTokensByValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compareTrees"><a href="Numbas.jme.html#.compareTrees">Numbas.jme.compareTrees</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compile"><a href="Numbas.jme.html#.compile">Numbas.jme.compile</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.compileList"><a href="Numbas.jme.html#.compileList">Numbas.jme.compileList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.constants"><a href="Numbas.jme.html#.constants">Numbas.jme.constants</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.contentsubvars"><a href="Numbas.jme.html#.contentsubvars">Numbas.jme.contentsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.converseOps"><a href="Numbas.jme.html#.converseOps">Numbas.jme.converseOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display"><a href="Numbas.jme.display.html">Numbas.jme.display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.exprToLaTeX"><a href="Numbas.jme.display.html#.exprToLaTeX">Numbas.jme.display.exprToLaTeX</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jme.display.specialNumbers"><a href="Numbas.jme.display.html#.jme.display.specialNumbers">Numbas.jme.display.jme.display.specialNumbers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jme_display_settings"><a href="Numbas.jme.display.html#.jme_display_settings">Numbas.jme.display.jme_display_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.jmeFunctions"><a href="Numbas.jme.display.html#.jmeFunctions">Numbas.jme.display.jmeFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets"><a href="Numbas.jme.display.opBrackets.html">Numbas.jme.display.opBrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."*""><a href="Numbas.jme.display.opBrackets.html#.%22*%22">Numbas.jme.display.opBrackets."*"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."+""><a href="Numbas.jme.display.opBrackets.html#.%22+%22">Numbas.jme.display.opBrackets."+"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."+u""><a href="Numbas.jme.display.opBrackets.html#.%22+u%22">Numbas.jme.display.opBrackets."+u"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."-""><a href="Numbas.jme.display.opBrackets.html#.%22-%22">Numbas.jme.display.opBrackets."-"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."-u""><a href="Numbas.jme.display.opBrackets.html#.%22-u%22">Numbas.jme.display.opBrackets."-u"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."/""><a href="Numbas.jme.display.opBrackets.html#.%22/%22">Numbas.jme.display.opBrackets."/"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."=""><a href="Numbas.jme.display.opBrackets.html#.%22=%22">Numbas.jme.display.opBrackets."="</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets."^""><a href="Numbas.jme.display.opBrackets.html#.%22%5E%22">Numbas.jme.display.opBrackets."^"</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.and"><a href="Numbas.jme.display.opBrackets.html#.and">Numbas.jme.display.opBrackets.and</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.fact"><a href="Numbas.jme.display.opBrackets.html#.fact">Numbas.jme.display.opBrackets.fact</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.or"><a href="Numbas.jme.display.opBrackets.html#.or">Numbas.jme.display.opBrackets.or</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.opBrackets.xor"><a href="Numbas.jme.display.opBrackets.html#.xor">Numbas.jme.display.opBrackets.xor</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplify"><a href="Numbas.jme.display.html#.simplify">Numbas.jme.display.simplify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplifyExpression"><a href="Numbas.jme.display.html#.simplifyExpression">Numbas.jme.display.simplifyExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.simplifyTree"><a href="Numbas.jme.display.html#.simplifyTree">Numbas.jme.display.simplifyTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.special_number_definition"><a href="Numbas.jme.display.html#.special_number_definition">Numbas.jme.display.special_number_definition</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.specialNames"><a href="Numbas.jme.display.html#.specialNames">Numbas.jme.display.specialNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texify"><a href="Numbas.jme.display.html#.texify">Numbas.jme.display.texify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texify_settings"><a href="Numbas.jme.display.html#.texify_settings">Numbas.jme.display.texify_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texName"><a href="Numbas.jme.display.html#.texName">Numbas.jme.display.texName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texNameAnnotations"><a href="Numbas.jme.display.html#.texNameAnnotations">Numbas.jme.display.texNameAnnotations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.texOps"><a href="Numbas.jme.display.html#.texOps">Numbas.jme.display.texOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.treeToJME"><a href="Numbas.jme.display.html#.treeToJME">Numbas.jme.display.treeToJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME"><a href="Numbas.jme.display.html#.typeToJME">Numbas.jme.display.typeToJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.boolean"><a href="Numbas.jme.display.html#.typeToJME#.boolean">Numbas.jme.display.typeToJME.boolean</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.decimal"><a href="Numbas.jme.display.html#.typeToJME#.decimal">Numbas.jme.display.typeToJME.decimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.dict"><a href="Numbas.jme.display.html#.typeToJME#.dict">Numbas.jme.display.typeToJME.dict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.expression"><a href="Numbas.jme.display.html#.typeToJME#.expression">Numbas.jme.display.typeToJME.expression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.function"><a href="Numbas.jme.display.html#.typeToJME#.function">Numbas.jme.display.typeToJME.function</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.html"><a href="Numbas.jme.display.html#.typeToJME#.html">Numbas.jme.display.typeToJME.html</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.integer"><a href="Numbas.jme.display.html#.typeToJME#.integer">Numbas.jme.display.typeToJME.integer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.keypair"><a href="Numbas.jme.display.html#.typeToJME#.keypair">Numbas.jme.display.typeToJME.keypair</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.list"><a href="Numbas.jme.display.html#.typeToJME#.list">Numbas.jme.display.typeToJME.list</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.matrix"><a href="Numbas.jme.display.html#.typeToJME#.matrix">Numbas.jme.display.typeToJME.matrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.name"><a href="Numbas.jme.display.html#.typeToJME#.name">Numbas.jme.display.typeToJME.name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.nothing"><a href="Numbas.jme.display.html#.typeToJME#.nothing">Numbas.jme.display.typeToJME.nothing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.number"><a href="Numbas.jme.display.html#.typeToJME#.number">Numbas.jme.display.typeToJME.number</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.op"><a href="Numbas.jme.display.html#.typeToJME#.op">Numbas.jme.display.typeToJME.op</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.range"><a href="Numbas.jme.display.html#.typeToJME#.range">Numbas.jme.display.typeToJME.range</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.rational"><a href="Numbas.jme.display.html#.typeToJME#.rational">Numbas.jme.display.typeToJME.rational</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.set"><a href="Numbas.jme.display.html#.typeToJME#.set">Numbas.jme.display.typeToJME.set</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.string"><a href="Numbas.jme.display.html#.typeToJME#.string">Numbas.jme.display.typeToJME.string</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToJME.vector"><a href="Numbas.jme.display.html#.typeToJME#.vector">Numbas.jme.display.typeToJME.vector</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.display.typeToTeX"><a href="Numbas.jme.display.html#.typeToTeX">Numbas.jme.display.typeToTeX</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.escape"><a href="Numbas.jme.html#.escape">Numbas.jme.escape</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.evaluate"><a href="Numbas.jme.html#.evaluate">Numbas.jme.evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.evaluate_fn"><a href="Numbas.jme.html#.evaluate_fn">Numbas.jme.evaluate_fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findCompatibleType"><a href="Numbas.jme.html#.findCompatibleType">Numbas.jme.findCompatibleType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findvars"><a href="Numbas.jme.html#.findvars">Numbas.jme.findvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.findvarsOps"><a href="Numbas.jme.html#.findvarsOps">Numbas.jme.findvarsOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj"><a href="Numbas.jme.funcObj.html">Numbas.jme.funcObj</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.description"><a href="Numbas.jme.funcObj.html#.description">Numbas.jme.funcObj.description</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.evaluate"><a href="Numbas.jme.funcObj.html#.evaluate">Numbas.jme.funcObj.evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.fn"><a href="Numbas.jme.funcObj.html#.fn">Numbas.jme.funcObj.fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.id"><a href="Numbas.jme.funcObj.html#.id">Numbas.jme.funcObj.id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.intype"><a href="Numbas.jme.funcObj.html#.intype">Numbas.jme.funcObj.intype</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.name"><a href="Numbas.jme.funcObj.html#.name">Numbas.jme.funcObj.name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.outtype"><a href="Numbas.jme.funcObj.html#.outtype">Numbas.jme.funcObj.outtype</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.random"><a href="Numbas.jme.funcObj.html#.random">Numbas.jme.funcObj.random</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj.typecheck"><a href="Numbas.jme.funcObj.html#.typecheck">Numbas.jme.funcObj.typecheck</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcObj_options"><a href="Numbas.jme.html#.funcObj_options">Numbas.jme.funcObj_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.funcSynonyms"><a href="Numbas.jme.html#.funcSynonyms">Numbas.jme.funcSynonyms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isFunction"><a href="Numbas.jme.html#.isFunction">Numbas.jme.isFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isMonomial"><a href="Numbas.jme.html#.isMonomial">Numbas.jme.isMonomial</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isName"><a href="Numbas.jme.html#.isName">Numbas.jme.isName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isOp"><a href="Numbas.jme.html#.isOp">Numbas.jme.isOp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isRandom"><a href="Numbas.jme.html#.isRandom">Numbas.jme.isRandom</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.isType"><a href="Numbas.jme.html#.isType">Numbas.jme.isType</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.jme.sortTokensBy"><a href="Numbas.jme.html#.jme.sortTokensBy">Numbas.jme.jme.sortTokensBy</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.lazyOps"><a href="Numbas.jme.html#.lazyOps">Numbas.jme.lazyOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.makeSafe"><a href="Numbas.jme.html#.makeSafe">Numbas.jme.makeSafe</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.mapFunctions"><a href="Numbas.jme.html#.mapFunctions">Numbas.jme.mapFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.operatorOptions"><a href="Numbas.jme.html#.operatorOptions">Numbas.jme.operatorOptions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.opSynonyms"><a href="Numbas.jme.html#.opSynonyms">Numbas.jme.opSynonyms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser"><a href="Numbas.jme.Parser.html">Numbas.jme.Parser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addBinaryOperator"><a href="Numbas.jme.Parser.html#addBinaryOperator">Numbas.jme.Parser#addBinaryOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addOperator"><a href="Numbas.jme.Parser.html#addOperator">Numbas.jme.Parser#addOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addPostfixOperator"><a href="Numbas.jme.Parser.html#addPostfixOperator">Numbas.jme.Parser#addPostfixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#addPrefixOperator"><a href="Numbas.jme.Parser.html#addPrefixOperator">Numbas.jme.Parser#addPrefixOperator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#compile"><a href="Numbas.jme.Parser.html#compile">Numbas.jme.Parser#compile</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#funcSynonym"><a href="Numbas.jme.Parser.html#funcSynonym">Numbas.jme.Parser#funcSynonym</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getArity"><a href="Numbas.jme.Parser.html#getArity">Numbas.jme.Parser#getArity</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getConstant"><a href="Numbas.jme.Parser.html#getConstant">Numbas.jme.Parser#getConstant</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPostfixForm"><a href="Numbas.jme.Parser.html#getPostfixForm">Numbas.jme.Parser#getPostfixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPrecedence"><a href="Numbas.jme.Parser.html#getPrecedence">Numbas.jme.Parser#getPrecedence</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getPrefixForm"><a href="Numbas.jme.Parser.html#getPrefixForm">Numbas.jme.Parser#getPrefixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#getSetting"><a href="Numbas.jme.Parser.html#getSetting">Numbas.jme.Parser#getSetting</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isAssociative"><a href="Numbas.jme.Parser.html#isAssociative">Numbas.jme.Parser#isAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isCommutative"><a href="Numbas.jme.Parser.html#isCommutative">Numbas.jme.Parser#isCommutative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#isRightAssociative"><a href="Numbas.jme.Parser.html#isRightAssociative">Numbas.jme.Parser#isRightAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#ops"><a href="Numbas.jme.Parser.html#ops">Numbas.jme.Parser#ops</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#opSynonym"><a href="Numbas.jme.Parser.html#opSynonym">Numbas.jme.Parser#opSynonym</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#option_defaults"><a href="Numbas.jme.Parser.html#option_defaults">Numbas.jme.Parser#option_defaults</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#re"><a href="Numbas.jme.Parser.html#re">Numbas.jme.Parser#re</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#setOperatorProperties"><a href="Numbas.jme.Parser.html#setOperatorProperties">Numbas.jme.Parser#setOperatorProperties</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#shunt"><a href="Numbas.jme.Parser.html#shunt">Numbas.jme.Parser#shunt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#shunt_type_actions.op"><a href="Numbas.jme.Parser_shunt_type_actions.op.html">Numbas.jme.Parser#shunt_type_actions.op</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#tokenise"><a href="Numbas.jme.Parser.html#tokenise">Numbas.jme.Parser#tokenise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Parser#tokeniser_types"><a href="Numbas.jme.Parser.html#tokeniser_types">Numbas.jme.Parser#tokeniser_types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.parser_options"><a href="Numbas.jme.html#.parser_options">Numbas.jme.parser_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.postfixForm"><a href="Numbas.jme.html#.postfixForm">Numbas.jme.postfixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.precedence"><a href="Numbas.jme.html#.precedence">Numbas.jme.precedence</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.prefixForm"><a href="Numbas.jme.html#.prefixForm">Numbas.jme.prefixForm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.resultsEqual"><a href="Numbas.jme.html#.resultsEqual">Numbas.jme.resultsEqual</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rightAssociative"><a href="Numbas.jme.html#.rightAssociative">Numbas.jme.rightAssociative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules"><a href="Numbas.jme.rules.html">Numbas.jme.rules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.applyPostReplacement"><a href="Numbas.jme.rules.html#.applyPostReplacement">Numbas.jme.rules.applyPostReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.collectRuleset"><a href="Numbas.jme.rules.html#.collectRuleset">Numbas.jme.rules.collectRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.compileRules"><a href="Numbas.jme.rules.html#.compileRules">Numbas.jme.rules.compileRules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.displayFlags"><a href="Numbas.jme.rules.html#.displayFlags">Numbas.jme.rules.displayFlags</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.extend_options"><a href="Numbas.jme.rules.html#.extend_options">Numbas.jme.rules.extend_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.findSequenceMatch"><a href="Numbas.jme.rules.html#.findSequenceMatch">Numbas.jme.rules.findSequenceMatch</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.findSequenceMatch_options"><a href="Numbas.jme.rules.html#.findSequenceMatch_options">Numbas.jme.rules.findSequenceMatch_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.getTerms"><a href="Numbas.jme.rules.html#.getTerms">Numbas.jme.rules.getTerms</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.getTerms_options"><a href="Numbas.jme.rules.html#.getTerms_options">Numbas.jme.rules.getTerms_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.jme_pattern_match"><a href="Numbas.jme.rules.html#.jme_pattern_match">Numbas.jme.rules.jme_pattern_match</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchAllTree"><a href="Numbas.jme.rules.html#.matchAllTree">Numbas.jme.rules.matchAllTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchExpression"><a href="Numbas.jme.rules.html#.matchExpression">Numbas.jme.rules.matchExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchTree"><a href="Numbas.jme.rules.html#.matchTree">Numbas.jme.rules.matchTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.matchTree_options"><a href="Numbas.jme.rules.html#.matchTree_options">Numbas.jme.rules.matchTree_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.number_conditions"><a href="Numbas.jme.rules.html#.number_conditions">Numbas.jme.rules.number_conditions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.patternParser"><a href="Numbas.jme.rules.html#.patternParser">Numbas.jme.rules.patternParser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule"><a href="Numbas.jme.rules.Rule.html">Numbas.jme.rules.Rule</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#get_options"><a href="Numbas.jme.rules.Rule.html#get_options">Numbas.jme.rules.Rule#get_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#match"><a href="Numbas.jme.rules.Rule.html#match">Numbas.jme.rules.Rule#match</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#matchAll"><a href="Numbas.jme.rules.Rule.html#matchAll">Numbas.jme.rules.Rule#matchAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#replace"><a href="Numbas.jme.rules.Rule.html#replace">Numbas.jme.rules.Rule#replace</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Rule#replaceAll"><a href="Numbas.jme.rules.Rule.html#replaceAll">Numbas.jme.rules.Rule#replaceAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset"><a href="Numbas.jme.rules.Ruleset.html">Numbas.jme.rules.Ruleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset#flagSet"><a href="Numbas.jme.rules.Ruleset.html#flagSet">Numbas.jme.rules.Ruleset#flagSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Ruleset#simplify"><a href="Numbas.jme.rules.Ruleset.html#simplify">Numbas.jme.rules.Ruleset#simplify</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.ruleset_flags"><a href="Numbas.jme.rules.html#.ruleset_flags">Numbas.jme.rules.ruleset_flags</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.simplificationRules"><a href="Numbas.jme.rules.html#.simplificationRules">Numbas.jme.rules.simplificationRules</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchFunctions"><a href="Numbas.jme.rules.html#.specialMatchFunctions">Numbas.jme.rules.specialMatchFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchNames"><a href="Numbas.jme.rules.html#.specialMatchNames">Numbas.jme.rules.specialMatchNames</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.specialMatchOps"><a href="Numbas.jme.rules.html#.specialMatchOps">Numbas.jme.rules.specialMatchOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.term"><a href="Numbas.jme.rules.html#.term">Numbas.jme.rules.term</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.Term"><a href="Numbas.jme.rules.Term.html">Numbas.jme.rules.Term</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transform"><a href="Numbas.jme.rules.html#.transform">Numbas.jme.rules.transform</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transform_result"><a href="Numbas.jme.rules.html#.transform_result">Numbas.jme.rules.transform_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.rules.transformAll"><a href="Numbas.jme.rules.html#.transformAll">Numbas.jme.rules.transformAll</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope"><a href="Numbas.jme.Scope.html">Numbas.jme.Scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#addFunction"><a href="Numbas.jme.Scope.html#addFunction">Numbas.jme.Scope#addFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#addRuleset"><a href="Numbas.jme.Scope.html#addRuleset">Numbas.jme.Scope#addRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allFunctions"><a href="Numbas.jme.Scope.html#allFunctions">Numbas.jme.Scope#allFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allRulesets"><a href="Numbas.jme.Scope.html#allRulesets">Numbas.jme.Scope#allRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#allVariables"><a href="Numbas.jme.Scope.html#allVariables">Numbas.jme.Scope#allVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#collect"><a href="Numbas.jme.Scope.html#collect">Numbas.jme.Scope#collect</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteFunction"><a href="Numbas.jme.Scope.html#deleteFunction">Numbas.jme.Scope#deleteFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteRuleset"><a href="Numbas.jme.Scope.html#deleteRuleset">Numbas.jme.Scope#deleteRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#deleteVariable"><a href="Numbas.jme.Scope.html#deleteVariable">Numbas.jme.Scope#deleteVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#evaluate"><a href="Numbas.jme.Scope.html#evaluate">Numbas.jme.Scope#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#flatten"><a href="Numbas.jme.Scope.html#flatten">Numbas.jme.Scope#flatten</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getFunction"><a href="Numbas.jme.Scope.html#getFunction">Numbas.jme.Scope#getFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getRuleset"><a href="Numbas.jme.Scope.html#getRuleset">Numbas.jme.Scope#getRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#getVariable"><a href="Numbas.jme.Scope.html#getVariable">Numbas.jme.Scope#getVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#matchFunctionToArguments"><a href="Numbas.jme.Scope.html#matchFunctionToArguments">Numbas.jme.Scope#matchFunctionToArguments</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#resolve"><a href="Numbas.jme.Scope.html#resolve">Numbas.jme.Scope#resolve</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#setRuleset"><a href="Numbas.jme.Scope.html#setRuleset">Numbas.jme.Scope#setRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#setVariable"><a href="Numbas.jme.Scope.html#setVariable">Numbas.jme.Scope#setVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.Scope#unset"><a href="Numbas.jme.Scope.html#unset">Numbas.jme.Scope#unset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.scope_deletions"><a href="Numbas.jme.html#.scope_deletions">Numbas.jme.scope_deletions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.shunt"><a href="Numbas.jme.html#.shunt">Numbas.jme.shunt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature"><a href="Numbas.jme.html#.signature">Numbas.jme.signature</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature_result"><a href="Numbas.jme.html#.signature_result">Numbas.jme.signature_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.signature_result_argument"><a href="Numbas.jme.html#.signature_result_argument">Numbas.jme.signature_result_argument</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.standardParser"><a href="Numbas.jme.html#.standardParser">Numbas.jme.standardParser</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.substituteTree"><a href="Numbas.jme.html#.substituteTree">Numbas.jme.substituteTree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.substituteTreeOps"><a href="Numbas.jme.html#.substituteTreeOps">Numbas.jme.substituteTreeOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.subvars"><a href="Numbas.jme.html#.subvars">Numbas.jme.subvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.texsplit"><a href="Numbas.jme.html#.texsplit">Numbas.jme.texsplit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.token"><a href="Numbas.jme.html#.token">Numbas.jme.token</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenComparisons"><a href="Numbas.jme.html#.tokenComparisons">Numbas.jme.tokenComparisons</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenise"><a href="Numbas.jme.html#.tokenise">Numbas.jme.tokenise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tokenToDisplayString"><a href="Numbas.jme.html#.tokenToDisplayString">Numbas.jme.tokenToDisplayString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.tree"><a href="Numbas.jme.html#.tree">Numbas.jme.tree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.treesSame"><a href="Numbas.jme.html#.treesSame">Numbas.jme.treesSame</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.typecheck_fn"><a href="Numbas.jme.html#.typecheck_fn">Numbas.jme.typecheck_fn</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types"><a href="Numbas.jme.types.html">Numbas.jme.types</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TBool"><a href="Numbas.jme.types.TBool.html">Numbas.jme.types.TBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TDict"><a href="Numbas.jme.types.TDict.html">Numbas.jme.types.TDict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TExpression"><a href="Numbas.jme.types.TExpression.html">Numbas.jme.types.TExpression</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TFunc"><a href="Numbas.jme.types.TFunc.html">Numbas.jme.types.TFunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.THTML"><a href="Numbas.jme.types.THTML.html">Numbas.jme.types.THTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TKeyPair"><a href="Numbas.jme.types.TKeyPair.html">Numbas.jme.types.TKeyPair</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TList"><a href="Numbas.jme.types.TList.html">Numbas.jme.types.TList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TMatrix"><a href="Numbas.jme.types.TMatrix.html">Numbas.jme.types.TMatrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TName"><a href="Numbas.jme.types.TName.html">Numbas.jme.types.TName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TNothing"><a href="Numbas.jme.types.TNothing.html">Numbas.jme.types.TNothing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TNum"><a href="Numbas.jme.types.TNum.html">Numbas.jme.types.TNum</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TOp"><a href="Numbas.jme.types.TOp.html">Numbas.jme.types.TOp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TPunc"><a href="Numbas.jme.types.TPunc.html">Numbas.jme.types.TPunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TRange"><a href="Numbas.jme.types.TRange.html">Numbas.jme.types.TRange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TSet"><a href="Numbas.jme.types.TSet.html">Numbas.jme.types.TSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TString"><a href="Numbas.jme.types.TString.html">Numbas.jme.types.TString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.types.TVector"><a href="Numbas.jme.types.TVector.html">Numbas.jme.types.TVector</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.typeToDisplayString"><a href="Numbas.jme.html#.typeToDisplayString">Numbas.jme.typeToDisplayString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.unescape"><a href="Numbas.jme.html#.unescape">Numbas.jme.unescape</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.unwrapValue"><a href="Numbas.jme.html#.unwrapValue">Numbas.jme.unwrapValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables"><a href="Numbas.jme.variables.html">Numbas.jme.variables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.computeRuleset"><a href="Numbas.jme.variables.html#.computeRuleset">Numbas.jme.variables.computeRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.computeVariable"><a href="Numbas.jme.variables.html#.computeVariable">Numbas.jme.variables.computeVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubber"><a href="Numbas.jme.variables.DOMcontentsubber.html">Numbas.jme.variables.DOMcontentsubber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubber#sub_element"><a href="Numbas.jme.variables.DOMcontentsubber_sub_element.html">Numbas.jme.variables.DOMcontentsubber#sub_element</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMcontentsubvars"><a href="Numbas.jme.variables.html#.DOMcontentsubvars">Numbas.jme.variables.DOMcontentsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.DOMsubvars"><a href="Numbas.jme.variables.html#.DOMsubvars">Numbas.jme.variables.DOMsubvars</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.func_data"><a href="Numbas.jme.variables.html#.func_data">Numbas.jme.variables.func_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeFunction"><a href="Numbas.jme.variables.html#.makeFunction">Numbas.jme.variables.makeFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeFunctions"><a href="Numbas.jme.variables.html#.makeFunctions">Numbas.jme.variables.makeFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeJavascriptFunction"><a href="Numbas.jme.variables.html#.makeJavascriptFunction">Numbas.jme.variables.makeJavascriptFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeJMEFunction"><a href="Numbas.jme.variables.html#.makeJMEFunction">Numbas.jme.variables.makeJMEFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeRulesets"><a href="Numbas.jme.variables.html#.makeRulesets">Numbas.jme.variables.makeRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.makeVariables"><a href="Numbas.jme.variables.html#.makeVariables">Numbas.jme.variables.makeVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.variable_data_dict"><a href="Numbas.jme.variables.html#.variable_data_dict">Numbas.jme.variables.variable_data_dict</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.variables.variableDependants"><a href="Numbas.jme.variables.html#.variableDependants">Numbas.jme.variables.variableDependants</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.varsUsed"><a href="Numbas.jme.html#.varsUsed">Numbas.jme.varsUsed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.jme.wrapValue"><a href="Numbas.jme.html#.wrapValue">Numbas.jme.wrapValue</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart"><a href="Numbas.JMEPart.html">Numbas.JMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#addValueGenerator"><a href="Numbas.JMEPart.html#addValueGenerator">Numbas.JMEPart#addValueGenerator</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#baseMarkingScript"><a href="Numbas.JMEPart.html#baseMarkingScript">Numbas.JMEPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#getCorrectAnswer"><a href="Numbas.JMEPart.html#getCorrectAnswer">Numbas.JMEPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#input_options"><a href="Numbas.JMEPart.html#input_options">Numbas.JMEPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#input_widget"><a href="Numbas.JMEPart.html#input_widget">Numbas.JMEPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#rawStudentAnswerAsJME"><a href="Numbas.JMEPart.html#rawStudentAnswerAsJME">Numbas.JMEPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#setStudentAnswer"><a href="Numbas.JMEPart.html#setStudentAnswer">Numbas.JMEPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#settings"><a href="Numbas.JMEPart.html#settings">Numbas.JMEPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.JMEPart#studentAnswer"><a href="Numbas.JMEPart.html#studentAnswer">Numbas.JMEPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json"><a href="Numbas.json.html">Numbas.json</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json.tryGet"><a href="Numbas.json.html#.tryGet">Numbas.json.tryGet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.json.tryLoad"><a href="Numbas.json.html#.tryLoad">Numbas.json.tryLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.loadScript"><a href="Numbas.html#.loadScript">Numbas.loadScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.locale"><a href="Numbas.html#.locale">Numbas.locale</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking"><a href="Numbas.marking.html">Numbas.marking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.compute_note"><a href="Numbas.marking.html#.compute_note">Numbas.marking.compute_note</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.feedback"><a href="Numbas.marking.html#.feedback">Numbas.marking.feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.feedback_item"><a href="Numbas.marking.html#.feedback_item">Numbas.marking.feedback_item</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps"><a href="Numbas.marking.html#.FeedbackOps">Numbas.marking.FeedbackOps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.ADD_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.ADD_CREDIT">Numbas.marking.FeedbackOps.ADD_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.CONCAT"><a href="Numbas.marking.html#.FeedbackOps#.CONCAT">Numbas.marking.FeedbackOps.CONCAT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.END"><a href="Numbas.marking.html#.FeedbackOps#.END">Numbas.marking.FeedbackOps.END</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.FEEDBACK"><a href="Numbas.marking.html#.FeedbackOps#.FEEDBACK">Numbas.marking.FeedbackOps.FEEDBACK</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.MULTIPLY_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.MULTIPLY_CREDIT">Numbas.marking.FeedbackOps.MULTIPLY_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.SET_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.SET_CREDIT">Numbas.marking.FeedbackOps.SET_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.SUB_CREDIT"><a href="Numbas.marking.html#.FeedbackOps#.SUB_CREDIT">Numbas.marking.FeedbackOps.SUB_CREDIT</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.FeedbackOps.WARNING"><a href="Numbas.marking.html#.FeedbackOps#.WARNING">Numbas.marking.FeedbackOps.WARNING</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.finalise_state"><a href="Numbas.marking.html#.finalise_state">Numbas.marking.finalise_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.finalised_state"><a href="Numbas.marking.html#.finalised_state">Numbas.marking.finalised_state</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.marking_script_result"><a href="Numbas.marking.html#.marking_script_result">Numbas.marking.marking_script_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingNote"><a href="Numbas.marking.MarkingNote.html">Numbas.marking.MarkingNote</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript"><a href="Numbas.marking.MarkingScript.html">Numbas.marking.MarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript#evaluate"><a href="Numbas.marking.MarkingScript.html#evaluate">Numbas.marking.MarkingScript#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.MarkingScript#source"><a href="Numbas.marking.MarkingScript.html#source">Numbas.marking.MarkingScript#source</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.note_definition"><a href="Numbas.marking.html#.note_definition">Numbas.marking.note_definition</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope"><a href="Numbas.marking.StatefulScope.html">Numbas.marking.StatefulScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#addFunction"><a href="Numbas.marking.StatefulScope.html#addFunction">Numbas.marking.StatefulScope#addFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#addRuleset"><a href="Numbas.marking.StatefulScope.html#addRuleset">Numbas.marking.StatefulScope#addRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allFunctions"><a href="Numbas.marking.StatefulScope.html#allFunctions">Numbas.marking.StatefulScope#allFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allRulesets"><a href="Numbas.marking.StatefulScope.html#allRulesets">Numbas.marking.StatefulScope#allRulesets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#allVariables"><a href="Numbas.marking.StatefulScope.html#allVariables">Numbas.marking.StatefulScope#allVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#collect"><a href="Numbas.marking.StatefulScope.html#collect">Numbas.marking.StatefulScope#collect</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteFunction"><a href="Numbas.marking.StatefulScope.html#deleteFunction">Numbas.marking.StatefulScope#deleteFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteRuleset"><a href="Numbas.marking.StatefulScope.html#deleteRuleset">Numbas.marking.StatefulScope#deleteRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#deleteVariable"><a href="Numbas.marking.StatefulScope.html#deleteVariable">Numbas.marking.StatefulScope#deleteVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#evaluate"><a href="Numbas.marking.StatefulScope.html#evaluate">Numbas.marking.StatefulScope#evaluate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#flatten"><a href="Numbas.marking.StatefulScope.html#flatten">Numbas.marking.StatefulScope#flatten</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getFunction"><a href="Numbas.marking.StatefulScope.html#getFunction">Numbas.marking.StatefulScope#getFunction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getRuleset"><a href="Numbas.marking.StatefulScope.html#getRuleset">Numbas.marking.StatefulScope#getRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#getVariable"><a href="Numbas.marking.StatefulScope.html#getVariable">Numbas.marking.StatefulScope#getVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#matchFunctionToArguments"><a href="Numbas.marking.StatefulScope.html#matchFunctionToArguments">Numbas.marking.StatefulScope#matchFunctionToArguments</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#resolve"><a href="Numbas.marking.StatefulScope.html#resolve">Numbas.marking.StatefulScope#resolve</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#setRuleset"><a href="Numbas.marking.StatefulScope.html#setRuleset">Numbas.marking.StatefulScope#setRuleset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#setVariable"><a href="Numbas.marking.StatefulScope.html#setVariable">Numbas.marking.StatefulScope#setVariable</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking.StatefulScope#unset"><a href="Numbas.marking.StatefulScope.html#unset">Numbas.marking.StatefulScope#unset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.marking_scripts"><a href="Numbas.html#.marking_scripts">Numbas.marking_scripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math"><a href="Numbas.math.html">Numbas.math</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.abs"><a href="Numbas.math.html#.abs">Numbas.math.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.add"><a href="Numbas.math.html#.add">Numbas.math.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.addDigits"><a href="Numbas.math.html#.addDigits">Numbas.math.addDigits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arccos"><a href="Numbas.math.html#.arccos">Numbas.math.arccos</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arccosh"><a href="Numbas.math.html#.arccosh">Numbas.math.arccosh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arcsin"><a href="Numbas.math.html#.arcsin">Numbas.math.arcsin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arcsinh"><a href="Numbas.math.html#.arcsinh">Numbas.math.arcsinh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arctan"><a href="Numbas.math.html#.arctan">Numbas.math.arctan</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arctanh"><a href="Numbas.math.html#.arctanh">Numbas.math.arctanh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.arg"><a href="Numbas.math.html#.arg">Numbas.math.arg</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.binomialCoefficients"><a href="Numbas.math.html#.binomialCoefficients">Numbas.math.binomialCoefficients</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.ceil"><a href="Numbas.math.html#.ceil">Numbas.math.ceil</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.choose"><a href="Numbas.math.html#.choose">Numbas.math.choose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.combinations"><a href="Numbas.math.html#.combinations">Numbas.math.combinations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.complex"><a href="Numbas.math.html#.complex">Numbas.math.complex</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.ComplexDecimal"><a href="Numbas.math.ComplexDecimal.html">Numbas.math.ComplexDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.complexToString"><a href="Numbas.math.html#.complexToString">Numbas.math.complexToString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.conjugate"><a href="Numbas.math.html#.conjugate">Numbas.math.conjugate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.coprime"><a href="Numbas.math.html#.coprime">Numbas.math.coprime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cos"><a href="Numbas.math.html#.cos">Numbas.math.cos</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosec"><a href="Numbas.math.html#.cosec">Numbas.math.cosec</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosech"><a href="Numbas.math.html#.cosech">Numbas.math.cosech</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cosh"><a href="Numbas.math.html#.cosh">Numbas.math.cosh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.cot"><a href="Numbas.math.html#.cot">Numbas.math.cot</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.coth"><a href="Numbas.math.html#.coth">Numbas.math.coth</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.countDP"><a href="Numbas.math.html#.countDP">Numbas.math.countDP</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.countSigFigs"><a href="Numbas.math.html#.countSigFigs">Numbas.math.countSigFigs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.deal"><a href="Numbas.math.html#.deal">Numbas.math.deal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.defineRange"><a href="Numbas.math.html#.defineRange">Numbas.math.defineRange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.degrees"><a href="Numbas.math.html#.degrees">Numbas.math.degrees</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.div"><a href="Numbas.math.html#.div">Numbas.math.div</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.divides"><a href="Numbas.math.html#.divides">Numbas.math.divides</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.eq"><a href="Numbas.math.html#.eq">Numbas.math.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.except"><a href="Numbas.math.html#.except">Numbas.math.except</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.exp"><a href="Numbas.math.html#.exp">Numbas.math.exp</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.factorial"><a href="Numbas.math.html#.factorial">Numbas.math.factorial</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.factorise"><a href="Numbas.math.html#.factorise">Numbas.math.factorise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.floor"><a href="Numbas.math.html#.floor">Numbas.math.floor</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.fract"><a href="Numbas.math.html#.fract">Numbas.math.fract</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.Fraction"><a href="Numbas.math.Fraction.html">Numbas.math.Fraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gamma"><a href="Numbas.math.html#.gamma">Numbas.math.gamma</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gcd"><a href="Numbas.math.html#.gcd">Numbas.math.gcd</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.geq"><a href="Numbas.math.html#.geq">Numbas.math.geq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.gt"><a href="Numbas.math.html#.gt">Numbas.math.gt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.im"><a href="Numbas.math.html#.im">Numbas.math.im</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.inverse"><a href="Numbas.math.html#.inverse">Numbas.math.inverse</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.isclose"><a href="Numbas.math.html#.isclose">Numbas.math.isclose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.lcm"><a href="Numbas.math.html#.lcm">Numbas.math.lcm</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.leq"><a href="Numbas.math.html#.leq">Numbas.math.leq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.listmax"><a href="Numbas.math.html#.listmax">Numbas.math.listmax</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.listmin"><a href="Numbas.math.html#.listmin">Numbas.math.listmin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log"><a href="Numbas.math.html#.log">Numbas.math.log</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log10"><a href="Numbas.math.html#.log10">Numbas.math.log10</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.log_base"><a href="Numbas.math.html#.log_base">Numbas.math.log_base</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.lt"><a href="Numbas.math.html#.lt">Numbas.math.lt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.max"><a href="Numbas.math.html#.max">Numbas.math.max</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.min"><a href="Numbas.math.html#.min">Numbas.math.min</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.mod"><a href="Numbas.math.html#.mod">Numbas.math.mod</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.mul"><a href="Numbas.math.html#.mul">Numbas.math.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.negate"><a href="Numbas.math.html#.negate">Numbas.math.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.negative"><a href="Numbas.math.html#.negative">Numbas.math.negative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.neq"><a href="Numbas.math.html#.neq">Numbas.math.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceComplexDecimal"><a href="Numbas.math.html#.niceComplexDecimal">Numbas.math.niceComplexDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceDecimal"><a href="Numbas.math.html#.niceDecimal">Numbas.math.niceDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceNumber"><a href="Numbas.math.html#.niceNumber">Numbas.math.niceNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.niceNumber_settings"><a href="Numbas.math.html#.niceNumber_settings">Numbas.math.niceNumber_settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.nonnegative"><a href="Numbas.math.html#.nonnegative">Numbas.math.nonnegative</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.parseScientific"><a href="Numbas.math.html#.parseScientific">Numbas.math.parseScientific</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.permutations"><a href="Numbas.math.html#.permutations">Numbas.math.permutations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.piDegree"><a href="Numbas.math.html#.piDegree">Numbas.math.piDegree</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.positive"><a href="Numbas.math.html#.positive">Numbas.math.positive</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.pow"><a href="Numbas.math.html#.pow">Numbas.math.pow</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.precround"><a href="Numbas.math.html#.precround">Numbas.math.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.primes"><a href="Numbas.math.html#.primes">Numbas.math.primes</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.radians"><a href="Numbas.math.html#.radians">Numbas.math.radians</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.random"><a href="Numbas.math.html#.random">Numbas.math.random</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.randomint"><a href="Numbas.math.html#.randomint">Numbas.math.randomint</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.randomrange"><a href="Numbas.math.html#.randomrange">Numbas.math.randomrange</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeSize"><a href="Numbas.math.html#.rangeSize">Numbas.math.rangeSize</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeSteps"><a href="Numbas.math.html#.rangeSteps">Numbas.math.rangeSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rangeToList"><a href="Numbas.math.html#.rangeToList">Numbas.math.rangeToList</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.rationalApproximation"><a href="Numbas.math.html#.rationalApproximation">Numbas.math.rationalApproximation</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.re"><a href="Numbas.math.html#.re">Numbas.math.re</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.re_scientificNumber"><a href="Numbas.math.html#.re_scientificNumber">Numbas.math.re_scientificNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.root"><a href="Numbas.math.html#.root">Numbas.math.root</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.round"><a href="Numbas.math.html#.round">Numbas.math.round</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sec"><a href="Numbas.math.html#.sec">Numbas.math.sec</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sech"><a href="Numbas.math.html#.sech">Numbas.math.sech</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.shuffle"><a href="Numbas.math.html#.shuffle">Numbas.math.shuffle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sign"><a href="Numbas.math.html#.sign">Numbas.math.sign</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.siground"><a href="Numbas.math.html#.siground">Numbas.math.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sin"><a href="Numbas.math.html#.sin">Numbas.math.sin</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sinh"><a href="Numbas.math.html#.sinh">Numbas.math.sinh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sqrt"><a href="Numbas.math.html#.sqrt">Numbas.math.sqrt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sub"><a href="Numbas.math.html#.sub">Numbas.math.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.sum"><a href="Numbas.math.html#.sum">Numbas.math.sum</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.tan"><a href="Numbas.math.html#.tan">Numbas.math.tan</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.tanh"><a href="Numbas.math.html#.tanh">Numbas.math.tanh</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.toGivenPrecision"><a href="Numbas.math.html#.toGivenPrecision">Numbas.math.toGivenPrecision</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.toNearest"><a href="Numbas.math.html#.toNearest">Numbas.math.toNearest</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.trunc"><a href="Numbas.math.html#.trunc">Numbas.math.trunc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.unscientific"><a href="Numbas.math.html#.unscientific">Numbas.math.unscientific</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.math.withinTolerance"><a href="Numbas.math.html#.withinTolerance">Numbas.math.withinTolerance</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath"><a href="Numbas.matrixmath.html">Numbas.matrixmath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.abs"><a href="Numbas.matrixmath.html#.abs">Numbas.matrixmath.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.add"><a href="Numbas.matrixmath.html#.add">Numbas.matrixmath.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.eq"><a href="Numbas.matrixmath.html#.eq">Numbas.matrixmath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.id"><a href="Numbas.matrixmath.html#.id">Numbas.matrixmath.id</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.map"><a href="Numbas.matrixmath.html#.map">Numbas.matrixmath.map</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.mul"><a href="Numbas.matrixmath.html#.mul">Numbas.matrixmath.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.negate"><a href="Numbas.matrixmath.html#.negate">Numbas.matrixmath.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.neq"><a href="Numbas.matrixmath.html#.neq">Numbas.matrixmath.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.precround"><a href="Numbas.matrixmath.html#.precround">Numbas.matrixmath.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.scalardiv"><a href="Numbas.matrixmath.html#.scalardiv">Numbas.matrixmath.scalardiv</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.scalarmul"><a href="Numbas.matrixmath.html#.scalarmul">Numbas.matrixmath.scalarmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.siground"><a href="Numbas.matrixmath.html#.siground">Numbas.matrixmath.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.sub"><a href="Numbas.matrixmath.html#.sub">Numbas.matrixmath.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.sum_cells"><a href="Numbas.matrixmath.html#.sum_cells">Numbas.matrixmath.sum_cells</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.matrixmath.transpose"><a href="Numbas.matrixmath.html#.transpose">Numbas.matrixmath.transpose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.partConstructors"><a href="Numbas.html#.partConstructors">Numbas.partConstructors</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts"><a href="Numbas.parts.html">Numbas.parts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart"><a href="Numbas.parts.CustomPart.html">Numbas.parts.CustomPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addCredit"><a href="Numbas.parts.CustomPart.html#addCredit">Numbas.parts.CustomPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addStep"><a href="Numbas.parts.CustomPart.html#addStep">Numbas.parts.CustomPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#addVariableReplacement"><a href="Numbas.parts.CustomPart.html#addVariableReplacement">Numbas.parts.CustomPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#answered"><a href="Numbas.parts.CustomPart.html#answered">Numbas.parts.CustomPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#apply_feedback"><a href="Numbas.parts.CustomPart.html#apply_feedback">Numbas.parts.CustomPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#applyScoreLimits"><a href="Numbas.parts.CustomPart.html#applyScoreLimits">Numbas.parts.CustomPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#assignName"><a href="Numbas.parts.CustomPart.html#assignName">Numbas.parts.CustomPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#baseMarkingScript"><a href="Numbas.parts.CustomPart.html#baseMarkingScript">Numbas.parts.CustomPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#calculateScore"><a href="Numbas.parts.CustomPart.html#calculateScore">Numbas.parts.CustomPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#creditFraction"><a href="Numbas.parts.CustomPart.html#creditFraction">Numbas.parts.CustomPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#customName"><a href="Numbas.parts.CustomPart.html#customName">Numbas.parts.CustomPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#display"><a href="Numbas.parts.CustomPart.html#display">Numbas.parts.CustomPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#doesMarking"><a href="Numbas.parts.CustomPart.html#doesMarking">Numbas.parts.CustomPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#error"><a href="Numbas.parts.CustomPart.html#error">Numbas.parts.CustomPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#errorCarriedForwardScope"><a href="Numbas.parts.CustomPart.html#errorCarriedForwardScope">Numbas.parts.CustomPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#finalised_result"><a href="Numbas.parts.CustomPart.html#finalised_result">Numbas.parts.CustomPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#finaliseLoad"><a href="Numbas.parts.CustomPart.html#finaliseLoad">Numbas.parts.CustomPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#gaps"><a href="Numbas.parts.CustomPart.html#gaps">Numbas.parts.CustomPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#getCorrectAnswer"><a href="Numbas.parts.CustomPart.html#getCorrectAnswer">Numbas.parts.CustomPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#getScope"><a href="Numbas.parts.CustomPart.html#getScope">Numbas.parts.CustomPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#giveWarning"><a href="Numbas.parts.CustomPart.html#giveWarning">Numbas.parts.CustomPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#hasStagedAnswer"><a href="Numbas.parts.CustomPart.html#hasStagedAnswer">Numbas.parts.CustomPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#hideSteps"><a href="Numbas.parts.CustomPart.html#hideSteps">Numbas.parts.CustomPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#input_options"><a href="Numbas.parts.CustomPart.html#input_options">Numbas.parts.CustomPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#input_widget"><a href="Numbas.parts.CustomPart.html#input_widget">Numbas.parts.CustomPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#isDirty"><a href="Numbas.parts.CustomPart.html#isDirty">Numbas.parts.CustomPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#loadFromJSON"><a href="Numbas.parts.CustomPart.html#loadFromJSON">Numbas.parts.CustomPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#loadFromXML"><a href="Numbas.parts.CustomPart.html#loadFromXML">Numbas.parts.CustomPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#mark"><a href="Numbas.parts.CustomPart.html#mark">Numbas.parts.CustomPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#mark_answer"><a href="Numbas.parts.CustomPart.html#mark_answer">Numbas.parts.CustomPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markAgainstScope"><a href="Numbas.parts.CustomPart.html#markAgainstScope">Numbas.parts.CustomPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingComment"><a href="Numbas.parts.CustomPart.html#markingComment">Numbas.parts.CustomPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingFeedback"><a href="Numbas.parts.CustomPart.html#markingFeedback">Numbas.parts.CustomPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#markingScript"><a href="Numbas.parts.CustomPart.html#markingScript">Numbas.parts.CustomPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#marks"><a href="Numbas.parts.CustomPart.html#marks">Numbas.parts.CustomPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#multCredit"><a href="Numbas.parts.CustomPart.html#multCredit">Numbas.parts.CustomPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#name"><a href="Numbas.parts.CustomPart.html#name">Numbas.parts.CustomPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#openSteps"><a href="Numbas.parts.CustomPart.html#openSteps">Numbas.parts.CustomPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#parentPart"><a href="Numbas.parts.CustomPart.html#parentPart">Numbas.parts.CustomPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#path"><a href="Numbas.parts.CustomPart.html#path">Numbas.parts.CustomPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#pleaseResubmit"><a href="Numbas.parts.CustomPart.html#pleaseResubmit">Numbas.parts.CustomPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#question"><a href="Numbas.parts.CustomPart.html#question">Numbas.parts.CustomPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#rawStudentAnswerAsJME"><a href="Numbas.parts.CustomPart.html#rawStudentAnswerAsJME">Numbas.parts.CustomPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#removeWarnings"><a href="Numbas.parts.CustomPart.html#removeWarnings">Numbas.parts.CustomPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#resume"><a href="Numbas.parts.CustomPart.html#resume">Numbas.parts.CustomPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#revealAnswer"><a href="Numbas.parts.CustomPart.html#revealAnswer">Numbas.parts.CustomPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#score"><a href="Numbas.parts.CustomPart.html#score">Numbas.parts.CustomPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setCredit"><a href="Numbas.parts.CustomPart.html#setCredit">Numbas.parts.CustomPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setDirty"><a href="Numbas.parts.CustomPart.html#setDirty">Numbas.parts.CustomPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setMarkingScript"><a href="Numbas.parts.CustomPart.html#setMarkingScript">Numbas.parts.CustomPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setScript"><a href="Numbas.parts.CustomPart.html#setScript">Numbas.parts.CustomPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setStudentAnswer"><a href="Numbas.parts.CustomPart.html#setStudentAnswer">Numbas.parts.CustomPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#settings"><a href="Numbas.parts.CustomPart.html#settings">Numbas.parts.CustomPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#setWarnings"><a href="Numbas.parts.CustomPart.html#setWarnings">Numbas.parts.CustomPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#shouldResubmit"><a href="Numbas.parts.CustomPart.html#shouldResubmit">Numbas.parts.CustomPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#showSteps"><a href="Numbas.parts.CustomPart.html#showSteps">Numbas.parts.CustomPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stagedAnswer"><a href="Numbas.parts.CustomPart.html#stagedAnswer">Numbas.parts.CustomPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#steps"><a href="Numbas.parts.CustomPart.html#steps">Numbas.parts.CustomPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsMarks"><a href="Numbas.parts.CustomPart.html#stepsMarks">Numbas.parts.CustomPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsOpen"><a href="Numbas.parts.CustomPart.html#stepsOpen">Numbas.parts.CustomPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#stepsShown"><a href="Numbas.parts.CustomPart.html#stepsShown">Numbas.parts.CustomPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#store"><a href="Numbas.parts.CustomPart.html#store">Numbas.parts.CustomPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#storeAnswer"><a href="Numbas.parts.CustomPart.html#storeAnswer">Numbas.parts.CustomPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#studentAnswerAsJME"><a href="Numbas.parts.CustomPart.html#studentAnswerAsJME">Numbas.parts.CustomPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#subCredit"><a href="Numbas.parts.CustomPart.html#subCredit">Numbas.parts.CustomPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#submit"><a href="Numbas.parts.CustomPart.html#submit">Numbas.parts.CustomPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#type"><a href="Numbas.parts.CustomPart.html#type">Numbas.parts.CustomPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#useCustomName"><a href="Numbas.parts.CustomPart.html#useCustomName">Numbas.parts.CustomPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#warnings"><a href="Numbas.parts.CustomPart.html#warnings">Numbas.parts.CustomPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.CustomPart#xml"><a href="Numbas.parts.CustomPart.html#xml">Numbas.parts.CustomPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart"><a href="Numbas.parts.ExtensionPart.html">Numbas.parts.ExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addCredit"><a href="Numbas.parts.ExtensionPart.html#addCredit">Numbas.parts.ExtensionPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addStep"><a href="Numbas.parts.ExtensionPart.html#addStep">Numbas.parts.ExtensionPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#addVariableReplacement"><a href="Numbas.parts.ExtensionPart.html#addVariableReplacement">Numbas.parts.ExtensionPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#answered"><a href="Numbas.parts.ExtensionPart.html#answered">Numbas.parts.ExtensionPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#apply_feedback"><a href="Numbas.parts.ExtensionPart.html#apply_feedback">Numbas.parts.ExtensionPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#applyScoreLimits"><a href="Numbas.parts.ExtensionPart.html#applyScoreLimits">Numbas.parts.ExtensionPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#assignName"><a href="Numbas.parts.ExtensionPart.html#assignName">Numbas.parts.ExtensionPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#baseMarkingScript"><a href="Numbas.parts.ExtensionPart.html#baseMarkingScript">Numbas.parts.ExtensionPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#calculateScore"><a href="Numbas.parts.ExtensionPart.html#calculateScore">Numbas.parts.ExtensionPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#createSuspendData"><a href="Numbas.parts.ExtensionPart.html#createSuspendData">Numbas.parts.ExtensionPart#createSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#creditFraction"><a href="Numbas.parts.ExtensionPart.html#creditFraction">Numbas.parts.ExtensionPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#customName"><a href="Numbas.parts.ExtensionPart.html#customName">Numbas.parts.ExtensionPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#display"><a href="Numbas.parts.ExtensionPart.html#display">Numbas.parts.ExtensionPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#doesMarking"><a href="Numbas.parts.ExtensionPart.html#doesMarking">Numbas.parts.ExtensionPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#error"><a href="Numbas.parts.ExtensionPart.html#error">Numbas.parts.ExtensionPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#errorCarriedForwardScope"><a href="Numbas.parts.ExtensionPart.html#errorCarriedForwardScope">Numbas.parts.ExtensionPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#finalised_result"><a href="Numbas.parts.ExtensionPart.html#finalised_result">Numbas.parts.ExtensionPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#finaliseLoad"><a href="Numbas.parts.ExtensionPart.html#finaliseLoad">Numbas.parts.ExtensionPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#gaps"><a href="Numbas.parts.ExtensionPart.html#gaps">Numbas.parts.ExtensionPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#getCorrectAnswer"><a href="Numbas.parts.ExtensionPart.html#getCorrectAnswer">Numbas.parts.ExtensionPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#getScope"><a href="Numbas.parts.ExtensionPart.html#getScope">Numbas.parts.ExtensionPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#giveWarning"><a href="Numbas.parts.ExtensionPart.html#giveWarning">Numbas.parts.ExtensionPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#hasStagedAnswer"><a href="Numbas.parts.ExtensionPart.html#hasStagedAnswer">Numbas.parts.ExtensionPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#hideSteps"><a href="Numbas.parts.ExtensionPart.html#hideSteps">Numbas.parts.ExtensionPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#input_options"><a href="Numbas.parts.ExtensionPart.html#input_options">Numbas.parts.ExtensionPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#input_widget"><a href="Numbas.parts.ExtensionPart.html#input_widget">Numbas.parts.ExtensionPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#isDirty"><a href="Numbas.parts.ExtensionPart.html#isDirty">Numbas.parts.ExtensionPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadFromJSON"><a href="Numbas.parts.ExtensionPart.html#loadFromJSON">Numbas.parts.ExtensionPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadFromXML"><a href="Numbas.parts.ExtensionPart.html#loadFromXML">Numbas.parts.ExtensionPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#loadSuspendData"><a href="Numbas.parts.ExtensionPart.html#loadSuspendData">Numbas.parts.ExtensionPart#loadSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#mark"><a href="Numbas.parts.ExtensionPart.html#mark">Numbas.parts.ExtensionPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#mark_answer"><a href="Numbas.parts.ExtensionPart.html#mark_answer">Numbas.parts.ExtensionPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markAgainstScope"><a href="Numbas.parts.ExtensionPart.html#markAgainstScope">Numbas.parts.ExtensionPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingComment"><a href="Numbas.parts.ExtensionPart.html#markingComment">Numbas.parts.ExtensionPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingFeedback"><a href="Numbas.parts.ExtensionPart.html#markingFeedback">Numbas.parts.ExtensionPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#markingScript"><a href="Numbas.parts.ExtensionPart.html#markingScript">Numbas.parts.ExtensionPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#marks"><a href="Numbas.parts.ExtensionPart.html#marks">Numbas.parts.ExtensionPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#multCredit"><a href="Numbas.parts.ExtensionPart.html#multCredit">Numbas.parts.ExtensionPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#name"><a href="Numbas.parts.ExtensionPart.html#name">Numbas.parts.ExtensionPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#openSteps"><a href="Numbas.parts.ExtensionPart.html#openSteps">Numbas.parts.ExtensionPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#parentPart"><a href="Numbas.parts.ExtensionPart.html#parentPart">Numbas.parts.ExtensionPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#path"><a href="Numbas.parts.ExtensionPart.html#path">Numbas.parts.ExtensionPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#pleaseResubmit"><a href="Numbas.parts.ExtensionPart.html#pleaseResubmit">Numbas.parts.ExtensionPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#question"><a href="Numbas.parts.ExtensionPart.html#question">Numbas.parts.ExtensionPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#rawStudentAnswerAsJME"><a href="Numbas.parts.ExtensionPart.html#rawStudentAnswerAsJME">Numbas.parts.ExtensionPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#removeWarnings"><a href="Numbas.parts.ExtensionPart.html#removeWarnings">Numbas.parts.ExtensionPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#resume"><a href="Numbas.parts.ExtensionPart.html#resume">Numbas.parts.ExtensionPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#revealAnswer"><a href="Numbas.parts.ExtensionPart.html#revealAnswer">Numbas.parts.ExtensionPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#score"><a href="Numbas.parts.ExtensionPart.html#score">Numbas.parts.ExtensionPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setCredit"><a href="Numbas.parts.ExtensionPart.html#setCredit">Numbas.parts.ExtensionPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setDirty"><a href="Numbas.parts.ExtensionPart.html#setDirty">Numbas.parts.ExtensionPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setMarkingScript"><a href="Numbas.parts.ExtensionPart.html#setMarkingScript">Numbas.parts.ExtensionPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setScript"><a href="Numbas.parts.ExtensionPart.html#setScript">Numbas.parts.ExtensionPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setStudentAnswer"><a href="Numbas.parts.ExtensionPart.html#setStudentAnswer">Numbas.parts.ExtensionPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#settings"><a href="Numbas.parts.ExtensionPart.html#settings">Numbas.parts.ExtensionPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#setWarnings"><a href="Numbas.parts.ExtensionPart.html#setWarnings">Numbas.parts.ExtensionPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#shouldResubmit"><a href="Numbas.parts.ExtensionPart.html#shouldResubmit">Numbas.parts.ExtensionPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#showSteps"><a href="Numbas.parts.ExtensionPart.html#showSteps">Numbas.parts.ExtensionPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stagedAnswer"><a href="Numbas.parts.ExtensionPart.html#stagedAnswer">Numbas.parts.ExtensionPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#steps"><a href="Numbas.parts.ExtensionPart.html#steps">Numbas.parts.ExtensionPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsMarks"><a href="Numbas.parts.ExtensionPart.html#stepsMarks">Numbas.parts.ExtensionPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsOpen"><a href="Numbas.parts.ExtensionPart.html#stepsOpen">Numbas.parts.ExtensionPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#stepsShown"><a href="Numbas.parts.ExtensionPart.html#stepsShown">Numbas.parts.ExtensionPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#store"><a href="Numbas.parts.ExtensionPart.html#store">Numbas.parts.ExtensionPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#storeAnswer"><a href="Numbas.parts.ExtensionPart.html#storeAnswer">Numbas.parts.ExtensionPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#studentAnswerAsJME"><a href="Numbas.parts.ExtensionPart.html#studentAnswerAsJME">Numbas.parts.ExtensionPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#subCredit"><a href="Numbas.parts.ExtensionPart.html#subCredit">Numbas.parts.ExtensionPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#submit"><a href="Numbas.parts.ExtensionPart.html#submit">Numbas.parts.ExtensionPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#type"><a href="Numbas.parts.ExtensionPart.html#type">Numbas.parts.ExtensionPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#useCustomName"><a href="Numbas.parts.ExtensionPart.html#useCustomName">Numbas.parts.ExtensionPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#warnings"><a href="Numbas.parts.ExtensionPart.html#warnings">Numbas.parts.ExtensionPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.ExtensionPart#xml"><a href="Numbas.parts.ExtensionPart.html#xml">Numbas.parts.ExtensionPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.feedbackmessage"><a href="Numbas.parts.html#.feedbackmessage">Numbas.parts.feedbackmessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart"><a href="Numbas.parts.GapFillPart.html">Numbas.parts.GapFillPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addCredit"><a href="Numbas.parts.GapFillPart.html#addCredit">Numbas.parts.GapFillPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addGap"><a href="Numbas.parts.GapFillPart.html#addGap">Numbas.parts.GapFillPart#addGap</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addStep"><a href="Numbas.parts.GapFillPart.html#addStep">Numbas.parts.GapFillPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#addVariableReplacement"><a href="Numbas.parts.GapFillPart.html#addVariableReplacement">Numbas.parts.GapFillPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#answered"><a href="Numbas.parts.GapFillPart.html#answered">Numbas.parts.GapFillPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#apply_feedback"><a href="Numbas.parts.GapFillPart.html#apply_feedback">Numbas.parts.GapFillPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#applyScoreLimits"><a href="Numbas.parts.GapFillPart.html#applyScoreLimits">Numbas.parts.GapFillPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#assignName"><a href="Numbas.parts.GapFillPart.html#assignName">Numbas.parts.GapFillPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#baseMarkingScript"><a href="Numbas.parts.GapFillPart.html#baseMarkingScript">Numbas.parts.GapFillPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#calculateScore"><a href="Numbas.parts.GapFillPart.html#calculateScore">Numbas.parts.GapFillPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#creditFraction"><a href="Numbas.parts.GapFillPart.html#creditFraction">Numbas.parts.GapFillPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#customName"><a href="Numbas.parts.GapFillPart.html#customName">Numbas.parts.GapFillPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#display"><a href="Numbas.parts.GapFillPart.html#display">Numbas.parts.GapFillPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#doesMarking"><a href="Numbas.parts.GapFillPart.html#doesMarking">Numbas.parts.GapFillPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#error"><a href="Numbas.parts.GapFillPart.html#error">Numbas.parts.GapFillPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#errorCarriedForwardScope"><a href="Numbas.parts.GapFillPart.html#errorCarriedForwardScope">Numbas.parts.GapFillPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#finalised_result"><a href="Numbas.parts.GapFillPart.html#finalised_result">Numbas.parts.GapFillPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#finaliseLoad"><a href="Numbas.parts.GapFillPart.html#finaliseLoad">Numbas.parts.GapFillPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#gaps"><a href="Numbas.parts.GapFillPart.html#gaps">Numbas.parts.GapFillPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#getCorrectAnswer"><a href="Numbas.parts.GapFillPart.html#getCorrectAnswer">Numbas.parts.GapFillPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#getScope"><a href="Numbas.parts.GapFillPart.html#getScope">Numbas.parts.GapFillPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#giveWarning"><a href="Numbas.parts.GapFillPart.html#giveWarning">Numbas.parts.GapFillPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#hasStagedAnswer"><a href="Numbas.parts.GapFillPart.html#hasStagedAnswer">Numbas.parts.GapFillPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#hideSteps"><a href="Numbas.parts.GapFillPart.html#hideSteps">Numbas.parts.GapFillPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#input_options"><a href="Numbas.parts.GapFillPart.html#input_options">Numbas.parts.GapFillPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#input_widget"><a href="Numbas.parts.GapFillPart.html#input_widget">Numbas.parts.GapFillPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#isDirty"><a href="Numbas.parts.GapFillPart.html#isDirty">Numbas.parts.GapFillPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#loadFromJSON"><a href="Numbas.parts.GapFillPart.html#loadFromJSON">Numbas.parts.GapFillPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#loadFromXML"><a href="Numbas.parts.GapFillPart.html#loadFromXML">Numbas.parts.GapFillPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#mark"><a href="Numbas.parts.GapFillPart.html#mark">Numbas.parts.GapFillPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#mark_answer"><a href="Numbas.parts.GapFillPart.html#mark_answer">Numbas.parts.GapFillPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markAgainstScope"><a href="Numbas.parts.GapFillPart.html#markAgainstScope">Numbas.parts.GapFillPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingComment"><a href="Numbas.parts.GapFillPart.html#markingComment">Numbas.parts.GapFillPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingFeedback"><a href="Numbas.parts.GapFillPart.html#markingFeedback">Numbas.parts.GapFillPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#markingScript"><a href="Numbas.parts.GapFillPart.html#markingScript">Numbas.parts.GapFillPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#marks"><a href="Numbas.parts.GapFillPart.html#marks">Numbas.parts.GapFillPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#multCredit"><a href="Numbas.parts.GapFillPart.html#multCredit">Numbas.parts.GapFillPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#name"><a href="Numbas.parts.GapFillPart.html#name">Numbas.parts.GapFillPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#openSteps"><a href="Numbas.parts.GapFillPart.html#openSteps">Numbas.parts.GapFillPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#parentPart"><a href="Numbas.parts.GapFillPart.html#parentPart">Numbas.parts.GapFillPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#path"><a href="Numbas.parts.GapFillPart.html#path">Numbas.parts.GapFillPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#pleaseResubmit"><a href="Numbas.parts.GapFillPart.html#pleaseResubmit">Numbas.parts.GapFillPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#question"><a href="Numbas.parts.GapFillPart.html#question">Numbas.parts.GapFillPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#rawStudentAnswerAsJME"><a href="Numbas.parts.GapFillPart.html#rawStudentAnswerAsJME">Numbas.parts.GapFillPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#removeWarnings"><a href="Numbas.parts.GapFillPart.html#removeWarnings">Numbas.parts.GapFillPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#resume"><a href="Numbas.parts.GapFillPart.html#resume">Numbas.parts.GapFillPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#revealAnswer"><a href="Numbas.parts.GapFillPart.html#revealAnswer">Numbas.parts.GapFillPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#score"><a href="Numbas.parts.GapFillPart.html#score">Numbas.parts.GapFillPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setCredit"><a href="Numbas.parts.GapFillPart.html#setCredit">Numbas.parts.GapFillPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setDirty"><a href="Numbas.parts.GapFillPart.html#setDirty">Numbas.parts.GapFillPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setMarkingScript"><a href="Numbas.parts.GapFillPart.html#setMarkingScript">Numbas.parts.GapFillPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setScript"><a href="Numbas.parts.GapFillPart.html#setScript">Numbas.parts.GapFillPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setStudentAnswer"><a href="Numbas.parts.GapFillPart.html#setStudentAnswer">Numbas.parts.GapFillPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#settings"><a href="Numbas.parts.GapFillPart.html#settings">Numbas.parts.GapFillPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#setWarnings"><a href="Numbas.parts.GapFillPart.html#setWarnings">Numbas.parts.GapFillPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#shouldResubmit"><a href="Numbas.parts.GapFillPart.html#shouldResubmit">Numbas.parts.GapFillPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#showSteps"><a href="Numbas.parts.GapFillPart.html#showSteps">Numbas.parts.GapFillPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stagedAnswer"><a href="Numbas.parts.GapFillPart.html#stagedAnswer">Numbas.parts.GapFillPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#steps"><a href="Numbas.parts.GapFillPart.html#steps">Numbas.parts.GapFillPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsMarks"><a href="Numbas.parts.GapFillPart.html#stepsMarks">Numbas.parts.GapFillPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsOpen"><a href="Numbas.parts.GapFillPart.html#stepsOpen">Numbas.parts.GapFillPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#stepsShown"><a href="Numbas.parts.GapFillPart.html#stepsShown">Numbas.parts.GapFillPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#store"><a href="Numbas.parts.GapFillPart.html#store">Numbas.parts.GapFillPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#storeAnswer"><a href="Numbas.parts.GapFillPart.html#storeAnswer">Numbas.parts.GapFillPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#studentAnswerAsJME"><a href="Numbas.parts.GapFillPart.html#studentAnswerAsJME">Numbas.parts.GapFillPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#subCredit"><a href="Numbas.parts.GapFillPart.html#subCredit">Numbas.parts.GapFillPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#submit"><a href="Numbas.parts.GapFillPart.html#submit">Numbas.parts.GapFillPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#type"><a href="Numbas.parts.GapFillPart.html#type">Numbas.parts.GapFillPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#useCustomName"><a href="Numbas.parts.GapFillPart.html#useCustomName">Numbas.parts.GapFillPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#warnings"><a href="Numbas.parts.GapFillPart.html#warnings">Numbas.parts.GapFillPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.GapFillPart#xml"><a href="Numbas.parts.GapFillPart.html#xml">Numbas.parts.GapFillPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart"><a href="Numbas.parts.InformationOnlyPart.html">Numbas.parts.InformationOnlyPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart#setDirty"><a href="Numbas.parts.InformationOnlyPart.html#setDirty">Numbas.parts.InformationOnlyPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationOnlyPart#validate"><a href="Numbas.parts.InformationOnlyPart.html#validate">Numbas.parts.InformationOnlyPart#validate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart"><a href="Numbas.parts.InformationPart.html">Numbas.parts.InformationPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addCredit"><a href="Numbas.parts.InformationPart.html#addCredit">Numbas.parts.InformationPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addStep"><a href="Numbas.parts.InformationPart.html#addStep">Numbas.parts.InformationPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#addVariableReplacement"><a href="Numbas.parts.InformationPart.html#addVariableReplacement">Numbas.parts.InformationPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#answered"><a href="Numbas.parts.InformationPart.html#answered">Numbas.parts.InformationPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#apply_feedback"><a href="Numbas.parts.InformationPart.html#apply_feedback">Numbas.parts.InformationPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#applyScoreLimits"><a href="Numbas.parts.InformationPart.html#applyScoreLimits">Numbas.parts.InformationPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#assignName"><a href="Numbas.parts.InformationPart.html#assignName">Numbas.parts.InformationPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#baseMarkingScript"><a href="Numbas.parts.InformationPart.html#baseMarkingScript">Numbas.parts.InformationPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#calculateScore"><a href="Numbas.parts.InformationPart.html#calculateScore">Numbas.parts.InformationPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#creditFraction"><a href="Numbas.parts.InformationPart.html#creditFraction">Numbas.parts.InformationPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#customName"><a href="Numbas.parts.InformationPart.html#customName">Numbas.parts.InformationPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#display"><a href="Numbas.parts.InformationPart.html#display">Numbas.parts.InformationPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#doesMarking"><a href="Numbas.parts.InformationPart.html#doesMarking">Numbas.parts.InformationPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#error"><a href="Numbas.parts.InformationPart.html#error">Numbas.parts.InformationPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#errorCarriedForwardScope"><a href="Numbas.parts.InformationPart.html#errorCarriedForwardScope">Numbas.parts.InformationPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#finalised_result"><a href="Numbas.parts.InformationPart.html#finalised_result">Numbas.parts.InformationPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#finaliseLoad"><a href="Numbas.parts.InformationPart.html#finaliseLoad">Numbas.parts.InformationPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#gaps"><a href="Numbas.parts.InformationPart.html#gaps">Numbas.parts.InformationPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#getCorrectAnswer"><a href="Numbas.parts.InformationPart.html#getCorrectAnswer">Numbas.parts.InformationPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#getScope"><a href="Numbas.parts.InformationPart.html#getScope">Numbas.parts.InformationPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#giveWarning"><a href="Numbas.parts.InformationPart.html#giveWarning">Numbas.parts.InformationPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#hasStagedAnswer"><a href="Numbas.parts.InformationPart.html#hasStagedAnswer">Numbas.parts.InformationPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#hideSteps"><a href="Numbas.parts.InformationPart.html#hideSteps">Numbas.parts.InformationPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#input_options"><a href="Numbas.parts.InformationPart.html#input_options">Numbas.parts.InformationPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#input_widget"><a href="Numbas.parts.InformationPart.html#input_widget">Numbas.parts.InformationPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#isDirty"><a href="Numbas.parts.InformationPart.html#isDirty">Numbas.parts.InformationPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#loadFromJSON"><a href="Numbas.parts.InformationPart.html#loadFromJSON">Numbas.parts.InformationPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#loadFromXML"><a href="Numbas.parts.InformationPart.html#loadFromXML">Numbas.parts.InformationPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#mark"><a href="Numbas.parts.InformationPart.html#mark">Numbas.parts.InformationPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#mark_answer"><a href="Numbas.parts.InformationPart.html#mark_answer">Numbas.parts.InformationPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markAgainstScope"><a href="Numbas.parts.InformationPart.html#markAgainstScope">Numbas.parts.InformationPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingComment"><a href="Numbas.parts.InformationPart.html#markingComment">Numbas.parts.InformationPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingFeedback"><a href="Numbas.parts.InformationPart.html#markingFeedback">Numbas.parts.InformationPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#markingScript"><a href="Numbas.parts.InformationPart.html#markingScript">Numbas.parts.InformationPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#marks"><a href="Numbas.parts.InformationPart.html#marks">Numbas.parts.InformationPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#multCredit"><a href="Numbas.parts.InformationPart.html#multCredit">Numbas.parts.InformationPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#name"><a href="Numbas.parts.InformationPart.html#name">Numbas.parts.InformationPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#openSteps"><a href="Numbas.parts.InformationPart.html#openSteps">Numbas.parts.InformationPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#parentPart"><a href="Numbas.parts.InformationPart.html#parentPart">Numbas.parts.InformationPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#path"><a href="Numbas.parts.InformationPart.html#path">Numbas.parts.InformationPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#pleaseResubmit"><a href="Numbas.parts.InformationPart.html#pleaseResubmit">Numbas.parts.InformationPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#question"><a href="Numbas.parts.InformationPart.html#question">Numbas.parts.InformationPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#rawStudentAnswerAsJME"><a href="Numbas.parts.InformationPart.html#rawStudentAnswerAsJME">Numbas.parts.InformationPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#removeWarnings"><a href="Numbas.parts.InformationPart.html#removeWarnings">Numbas.parts.InformationPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#resume"><a href="Numbas.parts.InformationPart.html#resume">Numbas.parts.InformationPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#revealAnswer"><a href="Numbas.parts.InformationPart.html#revealAnswer">Numbas.parts.InformationPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#score"><a href="Numbas.parts.InformationPart.html#score">Numbas.parts.InformationPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setCredit"><a href="Numbas.parts.InformationPart.html#setCredit">Numbas.parts.InformationPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setDirty"><a href="Numbas.parts.InformationPart.html#setDirty">Numbas.parts.InformationPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setMarkingScript"><a href="Numbas.parts.InformationPart.html#setMarkingScript">Numbas.parts.InformationPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setScript"><a href="Numbas.parts.InformationPart.html#setScript">Numbas.parts.InformationPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setStudentAnswer"><a href="Numbas.parts.InformationPart.html#setStudentAnswer">Numbas.parts.InformationPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#settings"><a href="Numbas.parts.InformationPart.html#settings">Numbas.parts.InformationPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#setWarnings"><a href="Numbas.parts.InformationPart.html#setWarnings">Numbas.parts.InformationPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#shouldResubmit"><a href="Numbas.parts.InformationPart.html#shouldResubmit">Numbas.parts.InformationPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#showSteps"><a href="Numbas.parts.InformationPart.html#showSteps">Numbas.parts.InformationPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stagedAnswer"><a href="Numbas.parts.InformationPart.html#stagedAnswer">Numbas.parts.InformationPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#steps"><a href="Numbas.parts.InformationPart.html#steps">Numbas.parts.InformationPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsMarks"><a href="Numbas.parts.InformationPart.html#stepsMarks">Numbas.parts.InformationPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsOpen"><a href="Numbas.parts.InformationPart.html#stepsOpen">Numbas.parts.InformationPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#stepsShown"><a href="Numbas.parts.InformationPart.html#stepsShown">Numbas.parts.InformationPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#store"><a href="Numbas.parts.InformationPart.html#store">Numbas.parts.InformationPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#storeAnswer"><a href="Numbas.parts.InformationPart.html#storeAnswer">Numbas.parts.InformationPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#studentAnswerAsJME"><a href="Numbas.parts.InformationPart.html#studentAnswerAsJME">Numbas.parts.InformationPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#subCredit"><a href="Numbas.parts.InformationPart.html#subCredit">Numbas.parts.InformationPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#submit"><a href="Numbas.parts.InformationPart.html#submit">Numbas.parts.InformationPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#type"><a href="Numbas.parts.InformationPart.html#type">Numbas.parts.InformationPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#useCustomName"><a href="Numbas.parts.InformationPart.html#useCustomName">Numbas.parts.InformationPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#warnings"><a href="Numbas.parts.InformationPart.html#warnings">Numbas.parts.InformationPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.InformationPart#xml"><a href="Numbas.parts.InformationPart.html#xml">Numbas.parts.InformationPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart"><a href="Numbas.parts.JMEPart.html">Numbas.parts.JMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addCredit"><a href="Numbas.parts.JMEPart.html#addCredit">Numbas.parts.JMEPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addStep"><a href="Numbas.parts.JMEPart.html#addStep">Numbas.parts.JMEPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#addVariableReplacement"><a href="Numbas.parts.JMEPart.html#addVariableReplacement">Numbas.parts.JMEPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#answered"><a href="Numbas.parts.JMEPart.html#answered">Numbas.parts.JMEPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#apply_feedback"><a href="Numbas.parts.JMEPart.html#apply_feedback">Numbas.parts.JMEPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#applyScoreLimits"><a href="Numbas.parts.JMEPart.html#applyScoreLimits">Numbas.parts.JMEPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#assignName"><a href="Numbas.parts.JMEPart.html#assignName">Numbas.parts.JMEPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#baseMarkingScript"><a href="Numbas.parts.JMEPart.html#baseMarkingScript">Numbas.parts.JMEPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#calculateScore"><a href="Numbas.parts.JMEPart.html#calculateScore">Numbas.parts.JMEPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#creditFraction"><a href="Numbas.parts.JMEPart.html#creditFraction">Numbas.parts.JMEPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#customName"><a href="Numbas.parts.JMEPart.html#customName">Numbas.parts.JMEPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#display"><a href="Numbas.parts.JMEPart.html#display">Numbas.parts.JMEPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#doesMarking"><a href="Numbas.parts.JMEPart.html#doesMarking">Numbas.parts.JMEPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#error"><a href="Numbas.parts.JMEPart.html#error">Numbas.parts.JMEPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#errorCarriedForwardScope"><a href="Numbas.parts.JMEPart.html#errorCarriedForwardScope">Numbas.parts.JMEPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#finalised_result"><a href="Numbas.parts.JMEPart.html#finalised_result">Numbas.parts.JMEPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#finaliseLoad"><a href="Numbas.parts.JMEPart.html#finaliseLoad">Numbas.parts.JMEPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#gaps"><a href="Numbas.parts.JMEPart.html#gaps">Numbas.parts.JMEPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#getCorrectAnswer"><a href="Numbas.parts.JMEPart.html#getCorrectAnswer">Numbas.parts.JMEPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#getScope"><a href="Numbas.parts.JMEPart.html#getScope">Numbas.parts.JMEPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#giveWarning"><a href="Numbas.parts.JMEPart.html#giveWarning">Numbas.parts.JMEPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#hasStagedAnswer"><a href="Numbas.parts.JMEPart.html#hasStagedAnswer">Numbas.parts.JMEPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#hideSteps"><a href="Numbas.parts.JMEPart.html#hideSteps">Numbas.parts.JMEPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#input_options"><a href="Numbas.parts.JMEPart.html#input_options">Numbas.parts.JMEPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#input_widget"><a href="Numbas.parts.JMEPart.html#input_widget">Numbas.parts.JMEPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#isDirty"><a href="Numbas.parts.JMEPart.html#isDirty">Numbas.parts.JMEPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#loadFromJSON"><a href="Numbas.parts.JMEPart.html#loadFromJSON">Numbas.parts.JMEPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#loadFromXML"><a href="Numbas.parts.JMEPart.html#loadFromXML">Numbas.parts.JMEPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#mark"><a href="Numbas.parts.JMEPart.html#mark">Numbas.parts.JMEPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#mark_answer"><a href="Numbas.parts.JMEPart.html#mark_answer">Numbas.parts.JMEPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markAgainstScope"><a href="Numbas.parts.JMEPart.html#markAgainstScope">Numbas.parts.JMEPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingComment"><a href="Numbas.parts.JMEPart.html#markingComment">Numbas.parts.JMEPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingFeedback"><a href="Numbas.parts.JMEPart.html#markingFeedback">Numbas.parts.JMEPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#markingScript"><a href="Numbas.parts.JMEPart.html#markingScript">Numbas.parts.JMEPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#marks"><a href="Numbas.parts.JMEPart.html#marks">Numbas.parts.JMEPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#multCredit"><a href="Numbas.parts.JMEPart.html#multCredit">Numbas.parts.JMEPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#name"><a href="Numbas.parts.JMEPart.html#name">Numbas.parts.JMEPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#openSteps"><a href="Numbas.parts.JMEPart.html#openSteps">Numbas.parts.JMEPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#parentPart"><a href="Numbas.parts.JMEPart.html#parentPart">Numbas.parts.JMEPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#path"><a href="Numbas.parts.JMEPart.html#path">Numbas.parts.JMEPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#pleaseResubmit"><a href="Numbas.parts.JMEPart.html#pleaseResubmit">Numbas.parts.JMEPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#question"><a href="Numbas.parts.JMEPart.html#question">Numbas.parts.JMEPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#rawStudentAnswerAsJME"><a href="Numbas.parts.JMEPart.html#rawStudentAnswerAsJME">Numbas.parts.JMEPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#removeWarnings"><a href="Numbas.parts.JMEPart.html#removeWarnings">Numbas.parts.JMEPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#resume"><a href="Numbas.parts.JMEPart.html#resume">Numbas.parts.JMEPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#revealAnswer"><a href="Numbas.parts.JMEPart.html#revealAnswer">Numbas.parts.JMEPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#score"><a href="Numbas.parts.JMEPart.html#score">Numbas.parts.JMEPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setCredit"><a href="Numbas.parts.JMEPart.html#setCredit">Numbas.parts.JMEPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setDirty"><a href="Numbas.parts.JMEPart.html#setDirty">Numbas.parts.JMEPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setMarkingScript"><a href="Numbas.parts.JMEPart.html#setMarkingScript">Numbas.parts.JMEPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setScript"><a href="Numbas.parts.JMEPart.html#setScript">Numbas.parts.JMEPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setStudentAnswer"><a href="Numbas.parts.JMEPart.html#setStudentAnswer">Numbas.parts.JMEPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#settings"><a href="Numbas.parts.JMEPart.html#settings">Numbas.parts.JMEPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#setWarnings"><a href="Numbas.parts.JMEPart.html#setWarnings">Numbas.parts.JMEPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#shouldResubmit"><a href="Numbas.parts.JMEPart.html#shouldResubmit">Numbas.parts.JMEPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#showSteps"><a href="Numbas.parts.JMEPart.html#showSteps">Numbas.parts.JMEPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stagedAnswer"><a href="Numbas.parts.JMEPart.html#stagedAnswer">Numbas.parts.JMEPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#steps"><a href="Numbas.parts.JMEPart.html#steps">Numbas.parts.JMEPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsMarks"><a href="Numbas.parts.JMEPart.html#stepsMarks">Numbas.parts.JMEPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsOpen"><a href="Numbas.parts.JMEPart.html#stepsOpen">Numbas.parts.JMEPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#stepsShown"><a href="Numbas.parts.JMEPart.html#stepsShown">Numbas.parts.JMEPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#store"><a href="Numbas.parts.JMEPart.html#store">Numbas.parts.JMEPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#storeAnswer"><a href="Numbas.parts.JMEPart.html#storeAnswer">Numbas.parts.JMEPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#studentAnswerAsJME"><a href="Numbas.parts.JMEPart.html#studentAnswerAsJME">Numbas.parts.JMEPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#subCredit"><a href="Numbas.parts.JMEPart.html#subCredit">Numbas.parts.JMEPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#submit"><a href="Numbas.parts.JMEPart.html#submit">Numbas.parts.JMEPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#type"><a href="Numbas.parts.JMEPart.html#type">Numbas.parts.JMEPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#useCustomName"><a href="Numbas.parts.JMEPart.html#useCustomName">Numbas.parts.JMEPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#warnings"><a href="Numbas.parts.JMEPart.html#warnings">Numbas.parts.JMEPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.JMEPart#xml"><a href="Numbas.parts.JMEPart.html#xml">Numbas.parts.JMEPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.marking_results"><a href="Numbas.parts.html#.marking_results">Numbas.parts.marking_results</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart"><a href="Numbas.parts.MatrixEntryPart.html">Numbas.parts.MatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addCredit"><a href="Numbas.parts.MatrixEntryPart.html#addCredit">Numbas.parts.MatrixEntryPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addStep"><a href="Numbas.parts.MatrixEntryPart.html#addStep">Numbas.parts.MatrixEntryPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#addVariableReplacement"><a href="Numbas.parts.MatrixEntryPart.html#addVariableReplacement">Numbas.parts.MatrixEntryPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#answered"><a href="Numbas.parts.MatrixEntryPart.html#answered">Numbas.parts.MatrixEntryPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#apply_feedback"><a href="Numbas.parts.MatrixEntryPart.html#apply_feedback">Numbas.parts.MatrixEntryPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#applyScoreLimits"><a href="Numbas.parts.MatrixEntryPart.html#applyScoreLimits">Numbas.parts.MatrixEntryPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#assignName"><a href="Numbas.parts.MatrixEntryPart.html#assignName">Numbas.parts.MatrixEntryPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#baseMarkingScript"><a href="Numbas.parts.MatrixEntryPart.html#baseMarkingScript">Numbas.parts.MatrixEntryPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#calculateScore"><a href="Numbas.parts.MatrixEntryPart.html#calculateScore">Numbas.parts.MatrixEntryPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#creditFraction"><a href="Numbas.parts.MatrixEntryPart.html#creditFraction">Numbas.parts.MatrixEntryPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#customName"><a href="Numbas.parts.MatrixEntryPart.html#customName">Numbas.parts.MatrixEntryPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#display"><a href="Numbas.parts.MatrixEntryPart.html#display">Numbas.parts.MatrixEntryPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#doesMarking"><a href="Numbas.parts.MatrixEntryPart.html#doesMarking">Numbas.parts.MatrixEntryPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#error"><a href="Numbas.parts.MatrixEntryPart.html#error">Numbas.parts.MatrixEntryPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#errorCarriedForwardScope"><a href="Numbas.parts.MatrixEntryPart.html#errorCarriedForwardScope">Numbas.parts.MatrixEntryPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#finalised_result"><a href="Numbas.parts.MatrixEntryPart.html#finalised_result">Numbas.parts.MatrixEntryPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#finaliseLoad"><a href="Numbas.parts.MatrixEntryPart.html#finaliseLoad">Numbas.parts.MatrixEntryPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#gaps"><a href="Numbas.parts.MatrixEntryPart.html#gaps">Numbas.parts.MatrixEntryPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#getCorrectAnswer"><a href="Numbas.parts.MatrixEntryPart.html#getCorrectAnswer">Numbas.parts.MatrixEntryPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#getScope"><a href="Numbas.parts.MatrixEntryPart.html#getScope">Numbas.parts.MatrixEntryPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#giveWarning"><a href="Numbas.parts.MatrixEntryPart.html#giveWarning">Numbas.parts.MatrixEntryPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#hasStagedAnswer"><a href="Numbas.parts.MatrixEntryPart.html#hasStagedAnswer">Numbas.parts.MatrixEntryPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#hideSteps"><a href="Numbas.parts.MatrixEntryPart.html#hideSteps">Numbas.parts.MatrixEntryPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#input_options"><a href="Numbas.parts.MatrixEntryPart.html#input_options">Numbas.parts.MatrixEntryPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#input_widget"><a href="Numbas.parts.MatrixEntryPart.html#input_widget">Numbas.parts.MatrixEntryPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#isDirty"><a href="Numbas.parts.MatrixEntryPart.html#isDirty">Numbas.parts.MatrixEntryPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#loadFromJSON"><a href="Numbas.parts.MatrixEntryPart.html#loadFromJSON">Numbas.parts.MatrixEntryPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#loadFromXML"><a href="Numbas.parts.MatrixEntryPart.html#loadFromXML">Numbas.parts.MatrixEntryPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#mark"><a href="Numbas.parts.MatrixEntryPart.html#mark">Numbas.parts.MatrixEntryPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#mark_answer"><a href="Numbas.parts.MatrixEntryPart.html#mark_answer">Numbas.parts.MatrixEntryPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markAgainstScope"><a href="Numbas.parts.MatrixEntryPart.html#markAgainstScope">Numbas.parts.MatrixEntryPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingComment"><a href="Numbas.parts.MatrixEntryPart.html#markingComment">Numbas.parts.MatrixEntryPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingFeedback"><a href="Numbas.parts.MatrixEntryPart.html#markingFeedback">Numbas.parts.MatrixEntryPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#markingScript"><a href="Numbas.parts.MatrixEntryPart.html#markingScript">Numbas.parts.MatrixEntryPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#marks"><a href="Numbas.parts.MatrixEntryPart.html#marks">Numbas.parts.MatrixEntryPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#multCredit"><a href="Numbas.parts.MatrixEntryPart.html#multCredit">Numbas.parts.MatrixEntryPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#name"><a href="Numbas.parts.MatrixEntryPart.html#name">Numbas.parts.MatrixEntryPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#openSteps"><a href="Numbas.parts.MatrixEntryPart.html#openSteps">Numbas.parts.MatrixEntryPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#parentPart"><a href="Numbas.parts.MatrixEntryPart.html#parentPart">Numbas.parts.MatrixEntryPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#path"><a href="Numbas.parts.MatrixEntryPart.html#path">Numbas.parts.MatrixEntryPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#pleaseResubmit"><a href="Numbas.parts.MatrixEntryPart.html#pleaseResubmit">Numbas.parts.MatrixEntryPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#question"><a href="Numbas.parts.MatrixEntryPart.html#question">Numbas.parts.MatrixEntryPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#rawStudentAnswerAsJME"><a href="Numbas.parts.MatrixEntryPart.html#rawStudentAnswerAsJME">Numbas.parts.MatrixEntryPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#removeWarnings"><a href="Numbas.parts.MatrixEntryPart.html#removeWarnings">Numbas.parts.MatrixEntryPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#resume"><a href="Numbas.parts.MatrixEntryPart.html#resume">Numbas.parts.MatrixEntryPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#revealAnswer"><a href="Numbas.parts.MatrixEntryPart.html#revealAnswer">Numbas.parts.MatrixEntryPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#score"><a href="Numbas.parts.MatrixEntryPart.html#score">Numbas.parts.MatrixEntryPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setCredit"><a href="Numbas.parts.MatrixEntryPart.html#setCredit">Numbas.parts.MatrixEntryPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setDirty"><a href="Numbas.parts.MatrixEntryPart.html#setDirty">Numbas.parts.MatrixEntryPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setMarkingScript"><a href="Numbas.parts.MatrixEntryPart.html#setMarkingScript">Numbas.parts.MatrixEntryPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setScript"><a href="Numbas.parts.MatrixEntryPart.html#setScript">Numbas.parts.MatrixEntryPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setStudentAnswer"><a href="Numbas.parts.MatrixEntryPart.html#setStudentAnswer">Numbas.parts.MatrixEntryPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#settings"><a href="Numbas.parts.MatrixEntryPart.html#settings">Numbas.parts.MatrixEntryPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#setWarnings"><a href="Numbas.parts.MatrixEntryPart.html#setWarnings">Numbas.parts.MatrixEntryPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#shouldResubmit"><a href="Numbas.parts.MatrixEntryPart.html#shouldResubmit">Numbas.parts.MatrixEntryPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#showSteps"><a href="Numbas.parts.MatrixEntryPart.html#showSteps">Numbas.parts.MatrixEntryPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stagedAnswer"><a href="Numbas.parts.MatrixEntryPart.html#stagedAnswer">Numbas.parts.MatrixEntryPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#steps"><a href="Numbas.parts.MatrixEntryPart.html#steps">Numbas.parts.MatrixEntryPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsMarks"><a href="Numbas.parts.MatrixEntryPart.html#stepsMarks">Numbas.parts.MatrixEntryPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsOpen"><a href="Numbas.parts.MatrixEntryPart.html#stepsOpen">Numbas.parts.MatrixEntryPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#stepsShown"><a href="Numbas.parts.MatrixEntryPart.html#stepsShown">Numbas.parts.MatrixEntryPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#store"><a href="Numbas.parts.MatrixEntryPart.html#store">Numbas.parts.MatrixEntryPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#storeAnswer"><a href="Numbas.parts.MatrixEntryPart.html#storeAnswer">Numbas.parts.MatrixEntryPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#studentAnswer"><a href="Numbas.parts.MatrixEntryPart.html#studentAnswer">Numbas.parts.MatrixEntryPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#studentAnswerAsJME"><a href="Numbas.parts.MatrixEntryPart.html#studentAnswerAsJME">Numbas.parts.MatrixEntryPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#subCredit"><a href="Numbas.parts.MatrixEntryPart.html#subCredit">Numbas.parts.MatrixEntryPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#submit"><a href="Numbas.parts.MatrixEntryPart.html#submit">Numbas.parts.MatrixEntryPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#type"><a href="Numbas.parts.MatrixEntryPart.html#type">Numbas.parts.MatrixEntryPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#useCustomName"><a href="Numbas.parts.MatrixEntryPart.html#useCustomName">Numbas.parts.MatrixEntryPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#warnings"><a href="Numbas.parts.MatrixEntryPart.html#warnings">Numbas.parts.MatrixEntryPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MatrixEntryPart#xml"><a href="Numbas.parts.MatrixEntryPart.html#xml">Numbas.parts.MatrixEntryPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart"><a href="Numbas.parts.MultipleResponsePart.html">Numbas.parts.MultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart.layoutTypes"><a href="Numbas.parts.MultipleResponsePart.html#.layoutTypes">Numbas.parts.MultipleResponsePart.layoutTypes</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addCredit"><a href="Numbas.parts.MultipleResponsePart.html#addCredit">Numbas.parts.MultipleResponsePart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addStep"><a href="Numbas.parts.MultipleResponsePart.html#addStep">Numbas.parts.MultipleResponsePart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#addVariableReplacement"><a href="Numbas.parts.MultipleResponsePart.html#addVariableReplacement">Numbas.parts.MultipleResponsePart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#answered"><a href="Numbas.parts.MultipleResponsePart.html#answered">Numbas.parts.MultipleResponsePart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#apply_feedback"><a href="Numbas.parts.MultipleResponsePart.html#apply_feedback">Numbas.parts.MultipleResponsePart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#applyScoreLimits"><a href="Numbas.parts.MultipleResponsePart.html#applyScoreLimits">Numbas.parts.MultipleResponsePart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#assignName"><a href="Numbas.parts.MultipleResponsePart.html#assignName">Numbas.parts.MultipleResponsePart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#baseMarkingScript"><a href="Numbas.parts.MultipleResponsePart.html#baseMarkingScript">Numbas.parts.MultipleResponsePart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#calculateScore"><a href="Numbas.parts.MultipleResponsePart.html#calculateScore">Numbas.parts.MultipleResponsePart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#creditFraction"><a href="Numbas.parts.MultipleResponsePart.html#creditFraction">Numbas.parts.MultipleResponsePart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#customName"><a href="Numbas.parts.MultipleResponsePart.html#customName">Numbas.parts.MultipleResponsePart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#display"><a href="Numbas.parts.MultipleResponsePart.html#display">Numbas.parts.MultipleResponsePart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#doesMarking"><a href="Numbas.parts.MultipleResponsePart.html#doesMarking">Numbas.parts.MultipleResponsePart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#error"><a href="Numbas.parts.MultipleResponsePart.html#error">Numbas.parts.MultipleResponsePart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#errorCarriedForwardScope"><a href="Numbas.parts.MultipleResponsePart.html#errorCarriedForwardScope">Numbas.parts.MultipleResponsePart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#finalised_result"><a href="Numbas.parts.MultipleResponsePart.html#finalised_result">Numbas.parts.MultipleResponsePart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#finaliseLoad"><a href="Numbas.parts.MultipleResponsePart.html#finaliseLoad">Numbas.parts.MultipleResponsePart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#flipped"><a href="Numbas.parts.MultipleResponsePart.html#flipped">Numbas.parts.MultipleResponsePart#flipped</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#gaps"><a href="Numbas.parts.MultipleResponsePart.html#gaps">Numbas.parts.MultipleResponsePart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#getCorrectAnswer"><a href="Numbas.parts.MultipleResponsePart.html#getCorrectAnswer">Numbas.parts.MultipleResponsePart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#getScope"><a href="Numbas.parts.MultipleResponsePart.html#getScope">Numbas.parts.MultipleResponsePart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#giveWarning"><a href="Numbas.parts.MultipleResponsePart.html#giveWarning">Numbas.parts.MultipleResponsePart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#hasStagedAnswer"><a href="Numbas.parts.MultipleResponsePart.html#hasStagedAnswer">Numbas.parts.MultipleResponsePart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#hideSteps"><a href="Numbas.parts.MultipleResponsePart.html#hideSteps">Numbas.parts.MultipleResponsePart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#input_options"><a href="Numbas.parts.MultipleResponsePart.html#input_options">Numbas.parts.MultipleResponsePart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#input_widget"><a href="Numbas.parts.MultipleResponsePart.html#input_widget">Numbas.parts.MultipleResponsePart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#isDirty"><a href="Numbas.parts.MultipleResponsePart.html#isDirty">Numbas.parts.MultipleResponsePart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#loadFromJSON"><a href="Numbas.parts.MultipleResponsePart.html#loadFromJSON">Numbas.parts.MultipleResponsePart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#loadFromXML"><a href="Numbas.parts.MultipleResponsePart.html#loadFromXML">Numbas.parts.MultipleResponsePart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#mark"><a href="Numbas.parts.MultipleResponsePart.html#mark">Numbas.parts.MultipleResponsePart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#mark_answer"><a href="Numbas.parts.MultipleResponsePart.html#mark_answer">Numbas.parts.MultipleResponsePart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markAgainstScope"><a href="Numbas.parts.MultipleResponsePart.html#markAgainstScope">Numbas.parts.MultipleResponsePart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingComment"><a href="Numbas.parts.MultipleResponsePart.html#markingComment">Numbas.parts.MultipleResponsePart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingFeedback"><a href="Numbas.parts.MultipleResponsePart.html#markingFeedback">Numbas.parts.MultipleResponsePart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#markingScript"><a href="Numbas.parts.MultipleResponsePart.html#markingScript">Numbas.parts.MultipleResponsePart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#marks"><a href="Numbas.parts.MultipleResponsePart.html#marks">Numbas.parts.MultipleResponsePart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#multCredit"><a href="Numbas.parts.MultipleResponsePart.html#multCredit">Numbas.parts.MultipleResponsePart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#name"><a href="Numbas.parts.MultipleResponsePart.html#name">Numbas.parts.MultipleResponsePart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#numAnswers"><a href="Numbas.parts.MultipleResponsePart.html#numAnswers">Numbas.parts.MultipleResponsePart#numAnswers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#numChoices"><a href="Numbas.parts.MultipleResponsePart.html#numChoices">Numbas.parts.MultipleResponsePart#numChoices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#openSteps"><a href="Numbas.parts.MultipleResponsePart.html#openSteps">Numbas.parts.MultipleResponsePart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#parentPart"><a href="Numbas.parts.MultipleResponsePart.html#parentPart">Numbas.parts.MultipleResponsePart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#path"><a href="Numbas.parts.MultipleResponsePart.html#path">Numbas.parts.MultipleResponsePart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#pleaseResubmit"><a href="Numbas.parts.MultipleResponsePart.html#pleaseResubmit">Numbas.parts.MultipleResponsePart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#question"><a href="Numbas.parts.MultipleResponsePart.html#question">Numbas.parts.MultipleResponsePart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#rawStudentAnswerAsJME"><a href="Numbas.parts.MultipleResponsePart.html#rawStudentAnswerAsJME">Numbas.parts.MultipleResponsePart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#removeWarnings"><a href="Numbas.parts.MultipleResponsePart.html#removeWarnings">Numbas.parts.MultipleResponsePart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#resume"><a href="Numbas.parts.MultipleResponsePart.html#resume">Numbas.parts.MultipleResponsePart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#revealAnswer"><a href="Numbas.parts.MultipleResponsePart.html#revealAnswer">Numbas.parts.MultipleResponsePart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#score"><a href="Numbas.parts.MultipleResponsePart.html#score">Numbas.parts.MultipleResponsePart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setCredit"><a href="Numbas.parts.MultipleResponsePart.html#setCredit">Numbas.parts.MultipleResponsePart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setDirty"><a href="Numbas.parts.MultipleResponsePart.html#setDirty">Numbas.parts.MultipleResponsePart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setMarkingScript"><a href="Numbas.parts.MultipleResponsePart.html#setMarkingScript">Numbas.parts.MultipleResponsePart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setScript"><a href="Numbas.parts.MultipleResponsePart.html#setScript">Numbas.parts.MultipleResponsePart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setStudentAnswer"><a href="Numbas.parts.MultipleResponsePart.html#setStudentAnswer">Numbas.parts.MultipleResponsePart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#settings"><a href="Numbas.parts.MultipleResponsePart.html#settings">Numbas.parts.MultipleResponsePart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#setWarnings"><a href="Numbas.parts.MultipleResponsePart.html#setWarnings">Numbas.parts.MultipleResponsePart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#shouldResubmit"><a href="Numbas.parts.MultipleResponsePart.html#shouldResubmit">Numbas.parts.MultipleResponsePart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#showSteps"><a href="Numbas.parts.MultipleResponsePart.html#showSteps">Numbas.parts.MultipleResponsePart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stagedAnswer"><a href="Numbas.parts.MultipleResponsePart.html#stagedAnswer">Numbas.parts.MultipleResponsePart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#steps"><a href="Numbas.parts.MultipleResponsePart.html#steps">Numbas.parts.MultipleResponsePart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsMarks"><a href="Numbas.parts.MultipleResponsePart.html#stepsMarks">Numbas.parts.MultipleResponsePart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsOpen"><a href="Numbas.parts.MultipleResponsePart.html#stepsOpen">Numbas.parts.MultipleResponsePart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#stepsShown"><a href="Numbas.parts.MultipleResponsePart.html#stepsShown">Numbas.parts.MultipleResponsePart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#store"><a href="Numbas.parts.MultipleResponsePart.html#store">Numbas.parts.MultipleResponsePart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#storeAnswer"><a href="Numbas.parts.MultipleResponsePart.html#storeAnswer">Numbas.parts.MultipleResponsePart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#storeTick"><a href="Numbas.parts.MultipleResponsePart.html#storeTick">Numbas.parts.MultipleResponsePart#storeTick</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#studentAnswerAsJME"><a href="Numbas.parts.MultipleResponsePart.html#studentAnswerAsJME">Numbas.parts.MultipleResponsePart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#subCredit"><a href="Numbas.parts.MultipleResponsePart.html#subCredit">Numbas.parts.MultipleResponsePart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#submit"><a href="Numbas.parts.MultipleResponsePart.html#submit">Numbas.parts.MultipleResponsePart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#ticks"><a href="Numbas.parts.MultipleResponsePart.html#ticks">Numbas.parts.MultipleResponsePart#ticks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#type"><a href="Numbas.parts.MultipleResponsePart.html#type">Numbas.parts.MultipleResponsePart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#useCustomName"><a href="Numbas.parts.MultipleResponsePart.html#useCustomName">Numbas.parts.MultipleResponsePart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#warnings"><a href="Numbas.parts.MultipleResponsePart.html#warnings">Numbas.parts.MultipleResponsePart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.MultipleResponsePart#xml"><a href="Numbas.parts.MultipleResponsePart.html#xml">Numbas.parts.MultipleResponsePart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart"><a href="Numbas.parts.NumberEntryPart.html">Numbas.parts.NumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addCredit"><a href="Numbas.parts.NumberEntryPart.html#addCredit">Numbas.parts.NumberEntryPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addStep"><a href="Numbas.parts.NumberEntryPart.html#addStep">Numbas.parts.NumberEntryPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#addVariableReplacement"><a href="Numbas.parts.NumberEntryPart.html#addVariableReplacement">Numbas.parts.NumberEntryPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#answered"><a href="Numbas.parts.NumberEntryPart.html#answered">Numbas.parts.NumberEntryPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#apply_feedback"><a href="Numbas.parts.NumberEntryPart.html#apply_feedback">Numbas.parts.NumberEntryPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#applyScoreLimits"><a href="Numbas.parts.NumberEntryPart.html#applyScoreLimits">Numbas.parts.NumberEntryPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#assignName"><a href="Numbas.parts.NumberEntryPart.html#assignName">Numbas.parts.NumberEntryPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#baseMarkingScript"><a href="Numbas.parts.NumberEntryPart.html#baseMarkingScript">Numbas.parts.NumberEntryPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#calculateScore"><a href="Numbas.parts.NumberEntryPart.html#calculateScore">Numbas.parts.NumberEntryPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#cleanAnswer"><a href="Numbas.parts.NumberEntryPart.html#cleanAnswer">Numbas.parts.NumberEntryPart#cleanAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#creditFraction"><a href="Numbas.parts.NumberEntryPart.html#creditFraction">Numbas.parts.NumberEntryPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#customName"><a href="Numbas.parts.NumberEntryPart.html#customName">Numbas.parts.NumberEntryPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#display"><a href="Numbas.parts.NumberEntryPart.html#display">Numbas.parts.NumberEntryPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#doesMarking"><a href="Numbas.parts.NumberEntryPart.html#doesMarking">Numbas.parts.NumberEntryPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#error"><a href="Numbas.parts.NumberEntryPart.html#error">Numbas.parts.NumberEntryPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#errorCarriedForwardScope"><a href="Numbas.parts.NumberEntryPart.html#errorCarriedForwardScope">Numbas.parts.NumberEntryPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#finalised_result"><a href="Numbas.parts.NumberEntryPart.html#finalised_result">Numbas.parts.NumberEntryPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#finaliseLoad"><a href="Numbas.parts.NumberEntryPart.html#finaliseLoad">Numbas.parts.NumberEntryPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#gaps"><a href="Numbas.parts.NumberEntryPart.html#gaps">Numbas.parts.NumberEntryPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#getCorrectAnswer"><a href="Numbas.parts.NumberEntryPart.html#getCorrectAnswer">Numbas.parts.NumberEntryPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#getScope"><a href="Numbas.parts.NumberEntryPart.html#getScope">Numbas.parts.NumberEntryPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#giveWarning"><a href="Numbas.parts.NumberEntryPart.html#giveWarning">Numbas.parts.NumberEntryPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#hasStagedAnswer"><a href="Numbas.parts.NumberEntryPart.html#hasStagedAnswer">Numbas.parts.NumberEntryPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#hideSteps"><a href="Numbas.parts.NumberEntryPart.html#hideSteps">Numbas.parts.NumberEntryPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#input_options"><a href="Numbas.parts.NumberEntryPart.html#input_options">Numbas.parts.NumberEntryPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#input_widget"><a href="Numbas.parts.NumberEntryPart.html#input_widget">Numbas.parts.NumberEntryPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#isDirty"><a href="Numbas.parts.NumberEntryPart.html#isDirty">Numbas.parts.NumberEntryPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#loadFromJSON"><a href="Numbas.parts.NumberEntryPart.html#loadFromJSON">Numbas.parts.NumberEntryPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#loadFromXML"><a href="Numbas.parts.NumberEntryPart.html#loadFromXML">Numbas.parts.NumberEntryPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#mark"><a href="Numbas.parts.NumberEntryPart.html#mark">Numbas.parts.NumberEntryPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#mark_answer"><a href="Numbas.parts.NumberEntryPart.html#mark_answer">Numbas.parts.NumberEntryPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markAgainstScope"><a href="Numbas.parts.NumberEntryPart.html#markAgainstScope">Numbas.parts.NumberEntryPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingComment"><a href="Numbas.parts.NumberEntryPart.html#markingComment">Numbas.parts.NumberEntryPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingFeedback"><a href="Numbas.parts.NumberEntryPart.html#markingFeedback">Numbas.parts.NumberEntryPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#markingScript"><a href="Numbas.parts.NumberEntryPart.html#markingScript">Numbas.parts.NumberEntryPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#marks"><a href="Numbas.parts.NumberEntryPart.html#marks">Numbas.parts.NumberEntryPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#multCredit"><a href="Numbas.parts.NumberEntryPart.html#multCredit">Numbas.parts.NumberEntryPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#name"><a href="Numbas.parts.NumberEntryPart.html#name">Numbas.parts.NumberEntryPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#openSteps"><a href="Numbas.parts.NumberEntryPart.html#openSteps">Numbas.parts.NumberEntryPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#parentPart"><a href="Numbas.parts.NumberEntryPart.html#parentPart">Numbas.parts.NumberEntryPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#path"><a href="Numbas.parts.NumberEntryPart.html#path">Numbas.parts.NumberEntryPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#pleaseResubmit"><a href="Numbas.parts.NumberEntryPart.html#pleaseResubmit">Numbas.parts.NumberEntryPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#question"><a href="Numbas.parts.NumberEntryPart.html#question">Numbas.parts.NumberEntryPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#rawStudentAnswerAsJME"><a href="Numbas.parts.NumberEntryPart.html#rawStudentAnswerAsJME">Numbas.parts.NumberEntryPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#removeWarnings"><a href="Numbas.parts.NumberEntryPart.html#removeWarnings">Numbas.parts.NumberEntryPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#resume"><a href="Numbas.parts.NumberEntryPart.html#resume">Numbas.parts.NumberEntryPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#revealAnswer"><a href="Numbas.parts.NumberEntryPart.html#revealAnswer">Numbas.parts.NumberEntryPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#score"><a href="Numbas.parts.NumberEntryPart.html#score">Numbas.parts.NumberEntryPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setCredit"><a href="Numbas.parts.NumberEntryPart.html#setCredit">Numbas.parts.NumberEntryPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setDirty"><a href="Numbas.parts.NumberEntryPart.html#setDirty">Numbas.parts.NumberEntryPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setMarkingScript"><a href="Numbas.parts.NumberEntryPart.html#setMarkingScript">Numbas.parts.NumberEntryPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setScript"><a href="Numbas.parts.NumberEntryPart.html#setScript">Numbas.parts.NumberEntryPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setStudentAnswer"><a href="Numbas.parts.NumberEntryPart.html#setStudentAnswer">Numbas.parts.NumberEntryPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#settings"><a href="Numbas.parts.NumberEntryPart.html#settings">Numbas.parts.NumberEntryPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#setWarnings"><a href="Numbas.parts.NumberEntryPart.html#setWarnings">Numbas.parts.NumberEntryPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#shouldResubmit"><a href="Numbas.parts.NumberEntryPart.html#shouldResubmit">Numbas.parts.NumberEntryPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#showSteps"><a href="Numbas.parts.NumberEntryPart.html#showSteps">Numbas.parts.NumberEntryPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stagedAnswer"><a href="Numbas.parts.NumberEntryPart.html#stagedAnswer">Numbas.parts.NumberEntryPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#steps"><a href="Numbas.parts.NumberEntryPart.html#steps">Numbas.parts.NumberEntryPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsMarks"><a href="Numbas.parts.NumberEntryPart.html#stepsMarks">Numbas.parts.NumberEntryPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsOpen"><a href="Numbas.parts.NumberEntryPart.html#stepsOpen">Numbas.parts.NumberEntryPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#stepsShown"><a href="Numbas.parts.NumberEntryPart.html#stepsShown">Numbas.parts.NumberEntryPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#store"><a href="Numbas.parts.NumberEntryPart.html#store">Numbas.parts.NumberEntryPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#storeAnswer"><a href="Numbas.parts.NumberEntryPart.html#storeAnswer">Numbas.parts.NumberEntryPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#studentAnswer"><a href="Numbas.parts.NumberEntryPart.html#studentAnswer">Numbas.parts.NumberEntryPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#studentAnswerAsJME"><a href="Numbas.parts.NumberEntryPart.html#studentAnswerAsJME">Numbas.parts.NumberEntryPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#subCredit"><a href="Numbas.parts.NumberEntryPart.html#subCredit">Numbas.parts.NumberEntryPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#submit"><a href="Numbas.parts.NumberEntryPart.html#submit">Numbas.parts.NumberEntryPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#type"><a href="Numbas.parts.NumberEntryPart.html#type">Numbas.parts.NumberEntryPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#useCustomName"><a href="Numbas.parts.NumberEntryPart.html#useCustomName">Numbas.parts.NumberEntryPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#warnings"><a href="Numbas.parts.NumberEntryPart.html#warnings">Numbas.parts.NumberEntryPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.NumberEntryPart#xml"><a href="Numbas.parts.NumberEntryPart.html#xml">Numbas.parts.NumberEntryPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part"><a href="Numbas.parts.Part_.html">Numbas.parts.Part</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addCredit"><a href="Numbas.parts.Part.html#addCredit">Numbas.parts.Part#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addStep"><a href="Numbas.parts.Part.html#addStep">Numbas.parts.Part#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#addVariableReplacement"><a href="Numbas.parts.Part.html#addVariableReplacement">Numbas.parts.Part#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#answered"><a href="Numbas.parts.Part.html#answered">Numbas.parts.Part#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#apply_feedback"><a href="Numbas.parts.Part.html#apply_feedback">Numbas.parts.Part#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#applyScoreLimits"><a href="Numbas.parts.Part.html#applyScoreLimits">Numbas.parts.Part#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#applyScripts"><a href="Numbas.parts.Part_applyScripts.html">Numbas.parts.Part#applyScripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#assignName"><a href="Numbas.parts.Part.html#assignName">Numbas.parts.Part#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#baseMarkingScript"><a href="Numbas.parts.Part.html#baseMarkingScript">Numbas.parts.Part#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#calculateScore"><a href="Numbas.parts.Part.html#calculateScore">Numbas.parts.Part#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#creditFraction"><a href="Numbas.parts.Part.html#creditFraction">Numbas.parts.Part#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#customName"><a href="Numbas.parts.Part.html#customName">Numbas.parts.Part#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#display"><a href="Numbas.parts.Part.html#display">Numbas.parts.Part#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#doesMarking"><a href="Numbas.parts.Part.html#doesMarking">Numbas.parts.Part#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#error"><a href="Numbas.parts.Part.html#error">Numbas.parts.Part#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#errorCarriedForwardScope"><a href="Numbas.parts.Part.html#errorCarriedForwardScope">Numbas.parts.Part#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#finalised_result"><a href="Numbas.parts.Part.html#finalised_result">Numbas.parts.Part#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#finaliseLoad"><a href="Numbas.parts.Part.html#finaliseLoad">Numbas.parts.Part#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#gaps"><a href="Numbas.parts.Part.html#gaps">Numbas.parts.Part#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#getCorrectAnswer"><a href="Numbas.parts.Part.html#getCorrectAnswer">Numbas.parts.Part#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#getScope"><a href="Numbas.parts.Part.html#getScope">Numbas.parts.Part#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#giveWarning"><a href="Numbas.parts.Part.html#giveWarning">Numbas.parts.Part#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#hasStagedAnswer"><a href="Numbas.parts.Part.html#hasStagedAnswer">Numbas.parts.Part#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#hideSteps"><a href="Numbas.parts.Part.html#hideSteps">Numbas.parts.Part#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#input_options"><a href="Numbas.parts.Part.html#input_options">Numbas.parts.Part#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#input_widget"><a href="Numbas.parts.Part.html#input_widget">Numbas.parts.Part#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#isDirty"><a href="Numbas.parts.Part.html#isDirty">Numbas.parts.Part#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#loadFromJSON"><a href="Numbas.parts.Part.html#loadFromJSON">Numbas.parts.Part#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#loadFromXML"><a href="Numbas.parts.Part.html#loadFromXML">Numbas.parts.Part#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#mark"><a href="Numbas.parts.Part.html#mark">Numbas.parts.Part#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#mark_answer"><a href="Numbas.parts.Part.html#mark_answer">Numbas.parts.Part#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markAgainstScope"><a href="Numbas.parts.Part.html#markAgainstScope">Numbas.parts.Part#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingComment"><a href="Numbas.parts.Part.html#markingComment">Numbas.parts.Part#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingFeedback"><a href="Numbas.parts.Part.html#markingFeedback">Numbas.parts.Part#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#markingScript"><a href="Numbas.parts.Part.html#markingScript">Numbas.parts.Part#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#marks"><a href="Numbas.parts.Part.html#marks">Numbas.parts.Part#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#multCredit"><a href="Numbas.parts.Part.html#multCredit">Numbas.parts.Part#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#name"><a href="Numbas.parts.Part.html#name">Numbas.parts.Part#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#openSteps"><a href="Numbas.parts.Part.html#openSteps">Numbas.parts.Part#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#parentPart"><a href="Numbas.parts.Part.html#parentPart">Numbas.parts.Part#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#path"><a href="Numbas.parts.Part.html#path">Numbas.parts.Part#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#pleaseResubmit"><a href="Numbas.parts.Part.html#pleaseResubmit">Numbas.parts.Part#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#question"><a href="Numbas.parts.Part_.html#question">Numbas.parts.Part#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#rawStudentAnswerAsJME"><a href="Numbas.parts.Part_.html#rawStudentAnswerAsJME">Numbas.parts.Part#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#removeWarnings"><a href="Numbas.parts.Part_.html#removeWarnings">Numbas.parts.Part#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#resume"><a href="Numbas.parts.Part_.html#resume">Numbas.parts.Part#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#revealAnswer"><a href="Numbas.parts.Part_.html#revealAnswer">Numbas.parts.Part#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#score"><a href="Numbas.parts.Part_.html#score">Numbas.parts.Part#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setCredit"><a href="Numbas.parts.Part_.html#setCredit">Numbas.parts.Part#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setDirty"><a href="Numbas.parts.Part_.html#setDirty">Numbas.parts.Part#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setMarkingScript"><a href="Numbas.parts.Part_.html#setMarkingScript">Numbas.parts.Part#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setScript"><a href="Numbas.parts.Part_.html#setScript">Numbas.parts.Part#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setStudentAnswer"><a href="Numbas.parts.Part_.html#setStudentAnswer">Numbas.parts.Part#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#settings"><a href="Numbas.parts.Part_.html#settings">Numbas.parts.Part#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#setWarnings"><a href="Numbas.parts.Part_.html#setWarnings">Numbas.parts.Part#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#shouldResubmit"><a href="Numbas.parts.Part_.html#shouldResubmit">Numbas.parts.Part#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#showSteps"><a href="Numbas.parts.Part_.html#showSteps">Numbas.parts.Part#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stagedAnswer"><a href="Numbas.parts.Part_.html#stagedAnswer">Numbas.parts.Part#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#steps"><a href="Numbas.parts.Part_.html#steps">Numbas.parts.Part#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsMarks"><a href="Numbas.parts.Part_.html#stepsMarks">Numbas.parts.Part#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsOpen"><a href="Numbas.parts.Part_.html#stepsOpen">Numbas.parts.Part#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#stepsShown"><a href="Numbas.parts.Part_.html#stepsShown">Numbas.parts.Part#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#store"><a href="Numbas.parts.Part_.html#store">Numbas.parts.Part#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#storeAnswer"><a href="Numbas.parts.Part_.html#storeAnswer">Numbas.parts.Part#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#studentAnswerAsJME"><a href="Numbas.parts.Part_.html#studentAnswerAsJME">Numbas.parts.Part#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#subCredit"><a href="Numbas.parts.Part_.html#subCredit">Numbas.parts.Part#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#submit"><a href="Numbas.parts.Part_.html#submit">Numbas.parts.Part#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#type"><a href="Numbas.parts.Part_.html#type">Numbas.parts.Part#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#useCustomName"><a href="Numbas.parts.Part_.html#useCustomName">Numbas.parts.Part#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#warnings"><a href="Numbas.parts.Part_.html#warnings">Numbas.parts.Part#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.Part#xml"><a href="Numbas.parts.Part_.html#xml">Numbas.parts.Part#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.partpath"><a href="Numbas.parts.html#.partpath">Numbas.parts.partpath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart"><a href="Numbas.parts.PatternMatchPart.html">Numbas.parts.PatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addCredit"><a href="Numbas.parts.PatternMatchPart.html#addCredit">Numbas.parts.PatternMatchPart#addCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addStep"><a href="Numbas.parts.PatternMatchPart.html#addStep">Numbas.parts.PatternMatchPart#addStep</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#addVariableReplacement"><a href="Numbas.parts.PatternMatchPart.html#addVariableReplacement">Numbas.parts.PatternMatchPart#addVariableReplacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#answered"><a href="Numbas.parts.PatternMatchPart.html#answered">Numbas.parts.PatternMatchPart#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#apply_feedback"><a href="Numbas.parts.PatternMatchPart.html#apply_feedback">Numbas.parts.PatternMatchPart#apply_feedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#applyScoreLimits"><a href="Numbas.parts.PatternMatchPart.html#applyScoreLimits">Numbas.parts.PatternMatchPart#applyScoreLimits</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#assignName"><a href="Numbas.parts.PatternMatchPart.html#assignName">Numbas.parts.PatternMatchPart#assignName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#baseMarkingScript"><a href="Numbas.parts.PatternMatchPart.html#baseMarkingScript">Numbas.parts.PatternMatchPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#calculateScore"><a href="Numbas.parts.PatternMatchPart.html#calculateScore">Numbas.parts.PatternMatchPart#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#creditFraction"><a href="Numbas.parts.PatternMatchPart.html#creditFraction">Numbas.parts.PatternMatchPart#creditFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#customName"><a href="Numbas.parts.PatternMatchPart.html#customName">Numbas.parts.PatternMatchPart#customName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#display"><a href="Numbas.parts.PatternMatchPart.html#display">Numbas.parts.PatternMatchPart#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#doesMarking"><a href="Numbas.parts.PatternMatchPart.html#doesMarking">Numbas.parts.PatternMatchPart#doesMarking</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#error"><a href="Numbas.parts.PatternMatchPart.html#error">Numbas.parts.PatternMatchPart#error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#errorCarriedForwardScope"><a href="Numbas.parts.PatternMatchPart.html#errorCarriedForwardScope">Numbas.parts.PatternMatchPart#errorCarriedForwardScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#finalised_result"><a href="Numbas.parts.PatternMatchPart.html#finalised_result">Numbas.parts.PatternMatchPart#finalised_result</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#finaliseLoad"><a href="Numbas.parts.PatternMatchPart.html#finaliseLoad">Numbas.parts.PatternMatchPart#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#gaps"><a href="Numbas.parts.PatternMatchPart.html#gaps">Numbas.parts.PatternMatchPart#gaps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#getCorrectAnswer"><a href="Numbas.parts.PatternMatchPart.html#getCorrectAnswer">Numbas.parts.PatternMatchPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#getScope"><a href="Numbas.parts.PatternMatchPart.html#getScope">Numbas.parts.PatternMatchPart#getScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#giveWarning"><a href="Numbas.parts.PatternMatchPart.html#giveWarning">Numbas.parts.PatternMatchPart#giveWarning</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#hasStagedAnswer"><a href="Numbas.parts.PatternMatchPart.html#hasStagedAnswer">Numbas.parts.PatternMatchPart#hasStagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#hideSteps"><a href="Numbas.parts.PatternMatchPart.html#hideSteps">Numbas.parts.PatternMatchPart#hideSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#input_options"><a href="Numbas.parts.PatternMatchPart.html#input_options">Numbas.parts.PatternMatchPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#input_widget"><a href="Numbas.parts.PatternMatchPart.html#input_widget">Numbas.parts.PatternMatchPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#isDirty"><a href="Numbas.parts.PatternMatchPart.html#isDirty">Numbas.parts.PatternMatchPart#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#loadFromJSON"><a href="Numbas.parts.PatternMatchPart.html#loadFromJSON">Numbas.parts.PatternMatchPart#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#loadFromXML"><a href="Numbas.parts.PatternMatchPart.html#loadFromXML">Numbas.parts.PatternMatchPart#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#mark"><a href="Numbas.parts.PatternMatchPart.html#mark">Numbas.parts.PatternMatchPart#mark</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#mark_answer"><a href="Numbas.parts.PatternMatchPart.html#mark_answer">Numbas.parts.PatternMatchPart#mark_answer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markAgainstScope"><a href="Numbas.parts.PatternMatchPart.html#markAgainstScope">Numbas.parts.PatternMatchPart#markAgainstScope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingComment"><a href="Numbas.parts.PatternMatchPart.html#markingComment">Numbas.parts.PatternMatchPart#markingComment</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingFeedback"><a href="Numbas.parts.PatternMatchPart.html#markingFeedback">Numbas.parts.PatternMatchPart#markingFeedback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#markingScript"><a href="Numbas.parts.PatternMatchPart.html#markingScript">Numbas.parts.PatternMatchPart#markingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#marks"><a href="Numbas.parts.PatternMatchPart.html#marks">Numbas.parts.PatternMatchPart#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#multCredit"><a href="Numbas.parts.PatternMatchPart.html#multCredit">Numbas.parts.PatternMatchPart#multCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#name"><a href="Numbas.parts.PatternMatchPart.html#name">Numbas.parts.PatternMatchPart#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#openSteps"><a href="Numbas.parts.PatternMatchPart.html#openSteps">Numbas.parts.PatternMatchPart#openSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#parentPart"><a href="Numbas.parts.PatternMatchPart.html#parentPart">Numbas.parts.PatternMatchPart#parentPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#path"><a href="Numbas.parts.PatternMatchPart.html#path">Numbas.parts.PatternMatchPart#path</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#pleaseResubmit"><a href="Numbas.parts.PatternMatchPart.html#pleaseResubmit">Numbas.parts.PatternMatchPart#pleaseResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#question"><a href="Numbas.parts.PatternMatchPart.html#question">Numbas.parts.PatternMatchPart#question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#rawStudentAnswerAsJME"><a href="Numbas.parts.PatternMatchPart.html#rawStudentAnswerAsJME">Numbas.parts.PatternMatchPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#removeWarnings"><a href="Numbas.parts.PatternMatchPart.html#removeWarnings">Numbas.parts.PatternMatchPart#removeWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#resume"><a href="Numbas.parts.PatternMatchPart.html#resume">Numbas.parts.PatternMatchPart#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#revealAnswer"><a href="Numbas.parts.PatternMatchPart.html#revealAnswer">Numbas.parts.PatternMatchPart#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#score"><a href="Numbas.parts.PatternMatchPart.html#score">Numbas.parts.PatternMatchPart#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setCredit"><a href="Numbas.parts.PatternMatchPart.html#setCredit">Numbas.parts.PatternMatchPart#setCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setDirty"><a href="Numbas.parts.PatternMatchPart.html#setDirty">Numbas.parts.PatternMatchPart#setDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setMarkingScript"><a href="Numbas.parts.PatternMatchPart.html#setMarkingScript">Numbas.parts.PatternMatchPart#setMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setScript"><a href="Numbas.parts.PatternMatchPart.html#setScript">Numbas.parts.PatternMatchPart#setScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setStudentAnswer"><a href="Numbas.parts.PatternMatchPart.html#setStudentAnswer">Numbas.parts.PatternMatchPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#settings"><a href="Numbas.parts.PatternMatchPart.html#settings">Numbas.parts.PatternMatchPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#setWarnings"><a href="Numbas.parts.PatternMatchPart.html#setWarnings">Numbas.parts.PatternMatchPart#setWarnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#shouldResubmit"><a href="Numbas.parts.PatternMatchPart.html#shouldResubmit">Numbas.parts.PatternMatchPart#shouldResubmit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#showSteps"><a href="Numbas.parts.PatternMatchPart.html#showSteps">Numbas.parts.PatternMatchPart#showSteps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stagedAnswer"><a href="Numbas.parts.PatternMatchPart.html#stagedAnswer">Numbas.parts.PatternMatchPart#stagedAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#steps"><a href="Numbas.parts.PatternMatchPart.html#steps">Numbas.parts.PatternMatchPart#steps</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsMarks"><a href="Numbas.parts.PatternMatchPart.html#stepsMarks">Numbas.parts.PatternMatchPart#stepsMarks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsOpen"><a href="Numbas.parts.PatternMatchPart.html#stepsOpen">Numbas.parts.PatternMatchPart#stepsOpen</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#stepsShown"><a href="Numbas.parts.PatternMatchPart.html#stepsShown">Numbas.parts.PatternMatchPart#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#store"><a href="Numbas.parts.PatternMatchPart.html#store">Numbas.parts.PatternMatchPart#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#storeAnswer"><a href="Numbas.parts.PatternMatchPart.html#storeAnswer">Numbas.parts.PatternMatchPart#storeAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#studentAnswerAsJME"><a href="Numbas.parts.PatternMatchPart.html#studentAnswerAsJME">Numbas.parts.PatternMatchPart#studentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#subCredit"><a href="Numbas.parts.PatternMatchPart.html#subCredit">Numbas.parts.PatternMatchPart#subCredit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#submit"><a href="Numbas.parts.PatternMatchPart.html#submit">Numbas.parts.PatternMatchPart#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#type"><a href="Numbas.parts.PatternMatchPart.html#type">Numbas.parts.PatternMatchPart#type</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#useCustomName"><a href="Numbas.parts.PatternMatchPart.html#useCustomName">Numbas.parts.PatternMatchPart#useCustomName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#warnings"><a href="Numbas.parts.PatternMatchPart.html#warnings">Numbas.parts.PatternMatchPart#warnings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.parts.PatternMatchPart#xml"><a href="Numbas.parts.PatternMatchPart.html#xml">Numbas.parts.PatternMatchPart#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart"><a href="Numbas.PatternMatchPart.html">Numbas.PatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#baseMarkingScript"><a href="Numbas.PatternMatchPart.html#baseMarkingScript">Numbas.PatternMatchPart#baseMarkingScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#getCorrectAnswer"><a href="Numbas.PatternMatchPart.html#getCorrectAnswer">Numbas.PatternMatchPart#getCorrectAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#input_options"><a href="Numbas.PatternMatchPart.html#input_options">Numbas.PatternMatchPart#input_options</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#input_widget"><a href="Numbas.PatternMatchPart.html#input_widget">Numbas.PatternMatchPart#input_widget</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#rawStudentAnswerAsJME"><a href="Numbas.PatternMatchPart.html#rawStudentAnswerAsJME">Numbas.PatternMatchPart#rawStudentAnswerAsJME</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#setStudentAnswer"><a href="Numbas.PatternMatchPart.html#setStudentAnswer">Numbas.PatternMatchPart#setStudentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#settings"><a href="Numbas.PatternMatchPart.html#settings">Numbas.PatternMatchPart#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.PatternMatchPart#studentAnswer"><a href="Numbas.PatternMatchPart.html#studentAnswer">Numbas.PatternMatchPart#studentAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question"><a href="Numbas.Question.html">Numbas.Question</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#addPart"><a href="Numbas.Question.html#addPart">Numbas.Question#addPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#adviceDisplayed"><a href="Numbas.Question.html#adviceDisplayed">Numbas.Question#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#answered"><a href="Numbas.Question.html#answered">Numbas.Question#answered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#calculateScore"><a href="Numbas.Question.html#calculateScore">Numbas.Question#calculateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#callbacks"><a href="Numbas.Question.html#callbacks">Numbas.Question#callbacks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#display"><a href="Numbas.Question.html#display">Numbas.Question#display</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:functionsLoaded"><a href="Numbas.Question.html#event:functionsLoaded">Numbas.Question#event:functionsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:functionsMade"><a href="Numbas.Question.html#event:functionsMade">Numbas.Question#event:functionsMade</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:generateVariables"><a href="Numbas.Question.html#event:generateVariables">Numbas.Question#event:generateVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:HTMLAttached"><a href="Numbas.Question.html#event:HTMLAttached">Numbas.Question#event:HTMLAttached</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:partsGenerated"><a href="Numbas.Question.html#event:partsGenerated">Numbas.Question#event:partsGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:partsResumed"><a href="Numbas.Question.html#event:partsResumed">Numbas.Question#event:partsResumed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:preambleLoaded"><a href="Numbas.Question.html#event:preambleLoaded">Numbas.Question#event:preambleLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:preambleRun"><a href="Numbas.Question.html#event:preambleRun">Numbas.Question#event:preambleRun</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:ready"><a href="Numbas.Question.html#event:ready">Numbas.Question#event:ready</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:rulesetsLoaded"><a href="Numbas.Question.html#event:rulesetsLoaded">Numbas.Question#event:rulesetsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:rulesetsMade"><a href="Numbas.Question.html#event:rulesetsMade">Numbas.Question#event:rulesetsMade</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variableDefinitionsLoaded"><a href="Numbas.Question.html#event:variableDefinitionsLoaded">Numbas.Question#event:variableDefinitionsLoaded</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variablesGenerated"><a href="Numbas.Question.html#event:variablesGenerated">Numbas.Question#event:variablesGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#event:variablesSet"><a href="Numbas.Question.html#event:variablesSet">Numbas.Question#event:variablesSet</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#finaliseLoad"><a href="Numbas.Question.html#finaliseLoad">Numbas.Question#finaliseLoad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#getAdvice"><a href="Numbas.Question.html#getAdvice">Numbas.Question#getAdvice</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#getPart"><a href="Numbas.Question.html#getPart">Numbas.Question#getPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#isDirty"><a href="Numbas.Question.html#isDirty">Numbas.Question#isDirty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#leave"><a href="Numbas.Question.html#leave">Numbas.Question#leave</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#leavingDirtyQuestion"><a href="Numbas.Question.html#leavingDirtyQuestion">Numbas.Question#leavingDirtyQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#loadFromJSON"><a href="Numbas.Question.html#loadFromJSON">Numbas.Question#loadFromJSON</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#loadFromXML"><a href="Numbas.Question.html#loadFromXML">Numbas.Question#loadFromXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#marks"><a href="Numbas.Question.html#marks">Numbas.Question#marks</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#name"><a href="Numbas.Question.html#name">Numbas.Question#name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#number"><a href="Numbas.Question.html#number">Numbas.Question#number</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#onHTMLAttached"><a href="Numbas.Question.html#onHTMLAttached">Numbas.Question#onHTMLAttached</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#onVariablesGenerated"><a href="Numbas.Question.html#onVariablesGenerated">Numbas.Question#onVariablesGenerated</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#partDictionary"><a href="Numbas.Question.html#partDictionary">Numbas.Question#partDictionary</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#parts"><a href="Numbas.Question.html#parts">Numbas.Question#parts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#resume"><a href="Numbas.Question.html#resume">Numbas.Question#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#revealAnswer"><a href="Numbas.Question.html#revealAnswer">Numbas.Question#revealAnswer</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#revealed"><a href="Numbas.Question.html#revealed">Numbas.Question#revealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#runPreamble"><a href="Numbas.Question.html#runPreamble">Numbas.Question#runPreamble</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#scope"><a href="Numbas.Question.html#scope">Numbas.Question#scope</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#score"><a href="Numbas.Question.html#score">Numbas.Question#score</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#signals"><a href="Numbas.Question.html#signals">Numbas.Question#signals</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#store"><a href="Numbas.Question.html#store">Numbas.Question#store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#submit"><a href="Numbas.Question.html#submit">Numbas.Question#submit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#submitted"><a href="Numbas.Question.html#submitted">Numbas.Question#submitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#updateScore"><a href="Numbas.Question.html#updateScore">Numbas.Question#updateScore</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#validate"><a href="Numbas.Question.html#validate">Numbas.Question#validate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#visited"><a href="Numbas.Question.html#visited">Numbas.Question#visited</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.Question#xml"><a href="Numbas.Question.html#xml">Numbas.Question#xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup"><a href="Numbas.QuestionGroup.html">Numbas.QuestionGroup</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup#chooseQuestionSubset"><a href="Numbas.QuestionGroup.html#chooseQuestionSubset">Numbas.QuestionGroup#chooseQuestionSubset</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.QuestionGroup#settings"><a href="Numbas.QuestionGroup.html#settings">Numbas.QuestionGroup#settings</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.queueScript"><a href="Numbas.html#.queueScript">Numbas.queueScript</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.raw_marking_scripts"><a href="Numbas.html#.raw_marking_scripts">Numbas.raw_marking_scripts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.rawxml"><a href="Numbas.html#.rawxml">Numbas.rawxml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule"><a href="Numbas.schedule.html">Numbas.schedule</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.add"><a href="Numbas.schedule.html#.add">Numbas.schedule.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.callback"><a href="Numbas.schedule.html#.callback">Numbas.schedule.callback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.calls"><a href="Numbas.schedule.html#.calls">Numbas.schedule.calls</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.completed"><a href="Numbas.schedule.html#.completed">Numbas.schedule.completed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.drop"><a href="Numbas.schedule.html#.drop">Numbas.schedule.drop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halt"><a href="Numbas.schedule.html#.halt">Numbas.schedule.halt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halt_error"><a href="Numbas.schedule.html#.halt_error">Numbas.schedule.halt_error</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.halted"><a href="Numbas.schedule.html#.halted">Numbas.schedule.halted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.lift"><a href="Numbas.schedule.html#.lift">Numbas.schedule.lift</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.lifts"><a href="Numbas.schedule.html#.lifts">Numbas.schedule.lifts</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.pop"><a href="Numbas.schedule.html#.pop">Numbas.schedule.pop</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox"><a href="Numbas.schedule.SignalBox.html">Numbas.schedule.SignalBox</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#getCallback"><a href="Numbas.schedule.SignalBox.html#getCallback">Numbas.schedule.SignalBox#getCallback</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#on"><a href="Numbas.schedule.SignalBox.html#on">Numbas.schedule.SignalBox#on</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.SignalBox#trigger"><a href="Numbas.schedule.SignalBox.html#trigger">Numbas.schedule.SignalBox#trigger</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.task_object"><a href="Numbas.schedule.html#.task_object">Numbas.schedule.task_object</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.schedule.total"><a href="Numbas.schedule.html#.total">Numbas.schedule.total</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath"><a href="Numbas.setmath.html">Numbas.setmath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.contains"><a href="Numbas.setmath.html#.contains">Numbas.setmath.contains</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.eq"><a href="Numbas.setmath.html#.eq">Numbas.setmath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.intersection"><a href="Numbas.setmath.html#.intersection">Numbas.setmath.intersection</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.minus"><a href="Numbas.setmath.html#.minus">Numbas.setmath.minus</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.size"><a href="Numbas.setmath.html#.size">Numbas.setmath.size</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.setmath.union"><a href="Numbas.setmath.html#.union">Numbas.setmath.union</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.showError"><a href="Numbas.html#.showError">Numbas.showError</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage"><a href="Numbas.storage.html">Numbas.storage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage"><a href="Numbas.storage.BlankStorage.html">Numbas.storage.BlankStorage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#adviceDisplayed"><a href="Numbas.storage.BlankStorage.html#adviceDisplayed">Numbas.storage.BlankStorage#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#answerRevealed"><a href="Numbas.storage.BlankStorage.html#answerRevealed">Numbas.storage.BlankStorage#answerRevealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#changeQuestion"><a href="Numbas.storage.BlankStorage.html#changeQuestion">Numbas.storage.BlankStorage#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#end"><a href="Numbas.storage.BlankStorage.html#end">Numbas.storage.BlankStorage#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getEntry"><a href="Numbas.storage.BlankStorage.html#getEntry">Numbas.storage.BlankStorage#getEntry</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getMode"><a href="Numbas.storage.BlankStorage.html#getMode">Numbas.storage.BlankStorage#getMode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#getStudentID"><a href="Numbas.storage.BlankStorage.html#getStudentID">Numbas.storage.BlankStorage#getStudentID</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#init"><a href="Numbas.storage.BlankStorage.html#init">Numbas.storage.BlankStorage#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#load"><a href="Numbas.storage.BlankStorage.html#load">Numbas.storage.BlankStorage#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadExtensionPart"><a href="Numbas.storage.BlankStorage.html#loadExtensionPart">Numbas.storage.BlankStorage#loadExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadJMEPart"><a href="Numbas.storage.BlankStorage.html#loadJMEPart">Numbas.storage.BlankStorage#loadJMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadMatrixEntryPart"><a href="Numbas.storage.BlankStorage.html#loadMatrixEntryPart">Numbas.storage.BlankStorage#loadMatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadMultipleResponsePart"><a href="Numbas.storage.BlankStorage.html#loadMultipleResponsePart">Numbas.storage.BlankStorage#loadMultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadNumberEntryPart"><a href="Numbas.storage.BlankStorage.html#loadNumberEntryPart">Numbas.storage.BlankStorage#loadNumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadPart"><a href="Numbas.storage.BlankStorage.html#loadPart">Numbas.storage.BlankStorage#loadPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadPatternMatchPart"><a href="Numbas.storage.BlankStorage.html#loadPatternMatchPart">Numbas.storage.BlankStorage#loadPatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#loadQuestion"><a href="Numbas.storage.BlankStorage.html#loadQuestion">Numbas.storage.BlankStorage#loadQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#partAnswered"><a href="Numbas.storage.BlankStorage.html#partAnswered">Numbas.storage.BlankStorage#partAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#pause"><a href="Numbas.storage.BlankStorage.html#pause">Numbas.storage.BlankStorage#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#questionSubmitted"><a href="Numbas.storage.BlankStorage.html#questionSubmitted">Numbas.storage.BlankStorage#questionSubmitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#resume"><a href="Numbas.storage.BlankStorage.html#resume">Numbas.storage.BlankStorage#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#save"><a href="Numbas.storage.BlankStorage.html#save">Numbas.storage.BlankStorage#save</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#saveExam"><a href="Numbas.storage.BlankStorage.html#saveExam">Numbas.storage.BlankStorage#saveExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#start"><a href="Numbas.storage.BlankStorage.html#start">Numbas.storage.BlankStorage#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#stepsHidden"><a href="Numbas.storage.BlankStorage.html#stepsHidden">Numbas.storage.BlankStorage#stepsHidden</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.BlankStorage#stepsShown"><a href="Numbas.storage.BlankStorage.html#stepsShown">Numbas.storage.BlankStorage#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.exam_suspend_data"><a href="Numbas.storage.html#.exam_suspend_data">Numbas.storage.exam_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.part_suspend_data"><a href="Numbas.storage.html#.part_suspend_data">Numbas.storage.part_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.question_suspend_data"><a href="Numbas.storage.html#.question_suspend_data">Numbas.storage.question_suspend_data</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage"><a href="Numbas.storage.SCORMStorage.html">Numbas.storage.SCORMStorage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#adviceDisplayed"><a href="Numbas.storage.SCORMStorage.html#adviceDisplayed">Numbas.storage.SCORMStorage#adviceDisplayed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#answerRevealed"><a href="Numbas.storage.SCORMStorage.html#answerRevealed">Numbas.storage.SCORMStorage#answerRevealed</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#changeQuestion"><a href="Numbas.storage.SCORMStorage.html#changeQuestion">Numbas.storage.SCORMStorage#changeQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#end"><a href="Numbas.storage.SCORMStorage.html#end">Numbas.storage.SCORMStorage#end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#exam"><a href="Numbas.storage.SCORMStorage.html#exam">Numbas.storage.SCORMStorage#exam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#get"><a href="Numbas.storage.SCORMStorage.html#get">Numbas.storage.SCORMStorage#get</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#get_student_name"><a href="Numbas.storage.SCORMStorage.html#get_student_name">Numbas.storage.SCORMStorage#get_student_name</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getEntry"><a href="Numbas.storage.SCORMStorage.html#getEntry">Numbas.storage.SCORMStorage#getEntry</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getMode"><a href="Numbas.storage.SCORMStorage.html#getMode">Numbas.storage.SCORMStorage#getMode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getPartId"><a href="Numbas.storage.SCORMStorage.html#getPartId">Numbas.storage.SCORMStorage#getPartId</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getQuestionId"><a href="Numbas.storage.SCORMStorage.html#getQuestionId">Numbas.storage.SCORMStorage#getQuestionId</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getStudentID"><a href="Numbas.storage.SCORMStorage.html#getStudentID">Numbas.storage.SCORMStorage#getStudentID</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#getSuspendData"><a href="Numbas.storage.SCORMStorage.html#getSuspendData">Numbas.storage.SCORMStorage#getSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#init"><a href="Numbas.storage.SCORMStorage.html#init">Numbas.storage.SCORMStorage#init</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#initPart"><a href="Numbas.storage.SCORMStorage.html#initPart">Numbas.storage.SCORMStorage#initPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#initQuestion"><a href="Numbas.storage.SCORMStorage.html#initQuestion">Numbas.storage.SCORMStorage#initQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#lmsConnected"><a href="Numbas.storage.SCORMStorage.html#lmsConnected">Numbas.storage.SCORMStorage#lmsConnected</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#load"><a href="Numbas.storage.SCORMStorage.html#load">Numbas.storage.SCORMStorage#load</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadExtensionPart"><a href="Numbas.storage.SCORMStorage.html#loadExtensionPart">Numbas.storage.SCORMStorage#loadExtensionPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadJMEPart"><a href="Numbas.storage.SCORMStorage.html#loadJMEPart">Numbas.storage.SCORMStorage#loadJMEPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadMatrixEntryPart"><a href="Numbas.storage.SCORMStorage.html#loadMatrixEntryPart">Numbas.storage.SCORMStorage#loadMatrixEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadMultipleResponsePart"><a href="Numbas.storage.SCORMStorage.html#loadMultipleResponsePart">Numbas.storage.SCORMStorage#loadMultipleResponsePart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadNumberEntryPart"><a href="Numbas.storage.SCORMStorage.html#loadNumberEntryPart">Numbas.storage.SCORMStorage#loadNumberEntryPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadPart"><a href="Numbas.storage.SCORMStorage.html#loadPart">Numbas.storage.SCORMStorage#loadPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadPatternMatchPart"><a href="Numbas.storage.SCORMStorage.html#loadPatternMatchPart">Numbas.storage.SCORMStorage#loadPatternMatchPart</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#loadQuestion"><a href="Numbas.storage.SCORMStorage.html#loadQuestion">Numbas.storage.SCORMStorage#loadQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#mode"><a href="Numbas.storage.SCORMStorage.html#mode">Numbas.storage.SCORMStorage#mode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partAnswered"><a href="Numbas.storage.SCORMStorage.html#partAnswered">Numbas.storage.SCORMStorage#partAnswered</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partIndices"><a href="Numbas.storage.SCORMStorage.html#partIndices">Numbas.storage.SCORMStorage#partIndices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#partSuspendData"><a href="Numbas.storage.SCORMStorage.html#partSuspendData">Numbas.storage.SCORMStorage#partSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#pause"><a href="Numbas.storage.SCORMStorage.html#pause">Numbas.storage.SCORMStorage#pause</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionIndices"><a href="Numbas.storage.SCORMStorage.html#questionIndices">Numbas.storage.SCORMStorage#questionIndices</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionSubmitted"><a href="Numbas.storage.SCORMStorage.html#questionSubmitted">Numbas.storage.SCORMStorage#questionSubmitted</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#questionSuspendData"><a href="Numbas.storage.SCORMStorage.html#questionSuspendData">Numbas.storage.SCORMStorage#questionSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#resume"><a href="Numbas.storage.SCORMStorage.html#resume">Numbas.storage.SCORMStorage#resume</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#save"><a href="Numbas.storage.SCORMStorage.html#save">Numbas.storage.SCORMStorage#save</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#saveExam"><a href="Numbas.storage.SCORMStorage.html#saveExam">Numbas.storage.SCORMStorage#saveExam</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#saveQuestion"><a href="Numbas.storage.SCORMStorage.html#saveQuestion">Numbas.storage.SCORMStorage#saveQuestion</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#set"><a href="Numbas.storage.SCORMStorage.html#set">Numbas.storage.SCORMStorage#set</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#setSessionTime"><a href="Numbas.storage.SCORMStorage.html#setSessionTime">Numbas.storage.SCORMStorage#setSessionTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#setSuspendData"><a href="Numbas.storage.SCORMStorage.html#setSuspendData">Numbas.storage.SCORMStorage#setSuspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#start"><a href="Numbas.storage.SCORMStorage.html#start">Numbas.storage.SCORMStorage#start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#stepsHidden"><a href="Numbas.storage.SCORMStorage.html#stepsHidden">Numbas.storage.SCORMStorage#stepsHidden</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#stepsShown"><a href="Numbas.storage.SCORMStorage.html#stepsShown">Numbas.storage.SCORMStorage#stepsShown</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.storage.SCORMStorage#suspendData"><a href="Numbas.storage.SCORMStorage.html#suspendData">Numbas.storage.SCORMStorage#suspendData</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.store"><a href="Numbas.html#.store">Numbas.store</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing"><a href="Numbas.timing.html">Numbas.timing</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.accs"><a href="Numbas.timing.html#.accs">Numbas.timing.accs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.displayDate"><a href="Numbas.timing.html#.displayDate">Numbas.timing.displayDate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.end"><a href="Numbas.timing.html#.end">Numbas.timing.end</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.endacc"><a href="Numbas.timing.html#.endacc">Numbas.timing.endacc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.messages"><a href="Numbas.timing.html#.messages">Numbas.timing.messages</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.secsToDisplayTime"><a href="Numbas.timing.html#.secsToDisplayTime">Numbas.timing.secsToDisplayTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.show"><a href="Numbas.timing.html#.show">Numbas.timing.show</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.start"><a href="Numbas.timing.html#.start">Numbas.timing.start</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.startacc"><a href="Numbas.timing.html#.startacc">Numbas.timing.startacc</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.stress"><a href="Numbas.timing.html#.stress">Numbas.timing.stress</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.timing.timers"><a href="Numbas.timing.html#.timers">Numbas.timing.timers</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.tryInit"><a href="Numbas.html#.tryInit">Numbas.tryInit</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util"><a href="Numbas.util.html">Numbas.util</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.arraysEqual"><a href="Numbas.util.html#.arraysEqual">Numbas.util.arraysEqual</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.capitalise"><a href="Numbas.util.html#.capitalise">Numbas.util.capitalise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.cartesian_power"><a href="Numbas.util.html#.cartesian_power">Numbas.util.cartesian_power</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.cleanNumber"><a href="Numbas.util.html#.cleanNumber">Numbas.util.cleanNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.combinations"><a href="Numbas.util.html#.combinations">Numbas.util.combinations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.combinations_with_replacement"><a href="Numbas.util.html#.combinations_with_replacement">Numbas.util.combinations_with_replacement</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.contains"><a href="Numbas.util.html#.contains">Numbas.util.contains</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.contentsplitbrackets"><a href="Numbas.util.html#.contentsplitbrackets">Numbas.util.contentsplitbrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyarray"><a href="Numbas.util.html#.copyarray">Numbas.util.copyarray</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyinto"><a href="Numbas.util.html#.copyinto">Numbas.util.copyinto</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.copyobj"><a href="Numbas.util.html#.copyobj">Numbas.util.copyobj</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.currency"><a href="Numbas.util.html#.currency">Numbas.util.currency</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.distinct"><a href="Numbas.util.html#.distinct">Numbas.util.distinct</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.eq"><a href="Numbas.util.html#.eq">Numbas.util.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.equalityTests"><a href="Numbas.util.html#.equalityTests">Numbas.util.equalityTests</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.escapeHTML"><a href="Numbas.util.html#.escapeHTML">Numbas.util.escapeHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.except"><a href="Numbas.util.html#.except">Numbas.util.except</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.extend"><a href="Numbas.util.html#.extend">Numbas.util.extend</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.extend_object"><a href="Numbas.util.html#.extend_object">Numbas.util.extend_object</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.formatString"><a href="Numbas.util.html#.formatString">Numbas.util.formatString</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.formatTime"><a href="Numbas.util.html#.formatTime">Numbas.util.formatTime</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.hashCode"><a href="Numbas.util.html#.hashCode">Numbas.util.hashCode</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isBool"><a href="Numbas.util.html#.isBool">Numbas.util.isBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isFloat"><a href="Numbas.util.html#.isFloat">Numbas.util.isFloat</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isFraction"><a href="Numbas.util.html#.isFraction">Numbas.util.isFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isInt"><a href="Numbas.util.html#.isInt">Numbas.util.isInt</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isNonemptyHTML"><a href="Numbas.util.html#.isNonemptyHTML">Numbas.util.isNonemptyHTML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.isNumber"><a href="Numbas.util.html#.isNumber">Numbas.util.isNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.letterOrdinal"><a href="Numbas.util.html#.letterOrdinal">Numbas.util.letterOrdinal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.lpad"><a href="Numbas.util.html#.lpad">Numbas.util.lpad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.matchNotationStyle"><a href="Numbas.util.html#.matchNotationStyle">Numbas.util.matchNotationStyle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.neq"><a href="Numbas.util.html#.neq">Numbas.util.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.nicePartName"><a href="Numbas.util.html#.nicePartName">Numbas.util.nicePartName</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.numberNotationStyles"><a href="Numbas.util.html#.numberNotationStyles">Numbas.util.numberNotationStyles</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.objects_equal"><a href="Numbas.util.html#.objects_equal">Numbas.util.objects_equal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseBool"><a href="Numbas.util.html#.parseBool">Numbas.util.parseBool</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseDecimal"><a href="Numbas.util.html#.parseDecimal">Numbas.util.parseDecimal</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseFraction"><a href="Numbas.util.html#.parseFraction">Numbas.util.parseFraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.parseNumber"><a href="Numbas.util.html#.parseNumber">Numbas.util.parseNumber</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.permutations"><a href="Numbas.util.html#.permutations">Numbas.util.permutations</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.pluralise"><a href="Numbas.util.html#.pluralise">Numbas.util.pluralise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.product"><a href="Numbas.util.html#.product">Numbas.util.product</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.re_fraction"><a href="Numbas.util.html#.re_fraction">Numbas.util.re_fraction</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.rpad"><a href="Numbas.util.html#.rpad">Numbas.util.rpad</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.separateThousands"><a href="Numbas.util.html#.separateThousands">Numbas.util.separateThousands</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.sortBy"><a href="Numbas.util.html#.sortBy">Numbas.util.sortBy</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.splitbrackets"><a href="Numbas.util.html#.splitbrackets">Numbas.util.splitbrackets</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.standardNumberFormatter"><a href="Numbas.util.html#.standardNumberFormatter">Numbas.util.standardNumberFormatter</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.unPercent"><a href="Numbas.util.html#.unPercent">Numbas.util.unPercent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.wrapListIndex"><a href="Numbas.util.html#.wrapListIndex">Numbas.util.wrapListIndex</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.util.zip"><a href="Numbas.util.html#.zip">Numbas.util.zip</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath"><a href="Numbas.vectormath.html">Numbas.vectormath</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.abs"><a href="Numbas.vectormath.html#.abs">Numbas.vectormath.abs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.abs_squared"><a href="Numbas.vectormath.html#.abs_squared">Numbas.vectormath.abs_squared</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.add"><a href="Numbas.vectormath.html#.add">Numbas.vectormath.add</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.angle"><a href="Numbas.vectormath.html#.angle">Numbas.vectormath.angle</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.cross"><a href="Numbas.vectormath.html#.cross">Numbas.vectormath.cross</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.div"><a href="Numbas.vectormath.html#.div">Numbas.vectormath.div</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.dot"><a href="Numbas.vectormath.html#.dot">Numbas.vectormath.dot</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.eq"><a href="Numbas.vectormath.html#.eq">Numbas.vectormath.eq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.is_zero"><a href="Numbas.vectormath.html#.is_zero">Numbas.vectormath.is_zero</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.map"><a href="Numbas.vectormath.html#.map">Numbas.vectormath.map</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.matrixmul"><a href="Numbas.vectormath.html#.matrixmul">Numbas.vectormath.matrixmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.mul"><a href="Numbas.vectormath.html#.mul">Numbas.vectormath.mul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.negate"><a href="Numbas.vectormath.html#.negate">Numbas.vectormath.negate</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.neq"><a href="Numbas.vectormath.html#.neq">Numbas.vectormath.neq</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.precround"><a href="Numbas.vectormath.html#.precround">Numbas.vectormath.precround</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.siground"><a href="Numbas.vectormath.html#.siground">Numbas.vectormath.siground</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.sub"><a href="Numbas.vectormath.html#.sub">Numbas.vectormath.sub</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.toMatrix"><a href="Numbas.vectormath.html#.toMatrix">Numbas.vectormath.toMatrix</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.transpose"><a href="Numbas.vectormath.html#.transpose">Numbas.vectormath.transpose</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.vectormath.vectormatrixmul"><a href="Numbas.vectormath.html#.vectormatrixmul">Numbas.vectormath.vectormatrixmul</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml"><a href="Numbas.xml.html">Numbas.xml</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.examXML"><a href="Numbas.xml.html#.examXML">Numbas.xml.examXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.getTextContent"><a href="Numbas.xml.html#.getTextContent">Numbas.xml.getTextContent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.isEmpty"><a href="Numbas.xml.html#.isEmpty">Numbas.xml.isEmpty</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadFunctions"><a href="Numbas.xml.html#.loadFunctions">Numbas.xml.loadFunctions</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadVariables"><a href="Numbas.xml.html#.loadVariables">Numbas.xml.loadVariables</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadXML"><a href="Numbas.xml.html#.loadXML">Numbas.xml.loadXML</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.loadXMLDocs"><a href="Numbas.xml.html#.loadXMLDocs">Numbas.xml.loadXMLDocs</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.localise"><a href="Numbas.xml.html#.localise">Numbas.xml.localise</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.serializeMessage"><a href="Numbas.xml.html#.serializeMessage">Numbas.xml.serializeMessage</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.setTextContent"><a href="Numbas.xml.html#.setTextContent">Numbas.xml.setTextContent</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.templates"><a href="Numbas.xml.html#.templates">Numbas.xml.templates</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.tryGetAttribute"><a href="Numbas.xml.html#.tryGetAttribute">Numbas.xml.tryGetAttribute</a></li>
-		
+
 			<li class="search-result" data-longname="Numbas.xml.tryGetAttribute_options"><a href="Numbas.xml.html#.tryGetAttribute_options">Numbas.xml.tryGetAttribute_options</a></li>
-		
+
 			<li class="search-result" data-longname="package:undefined"><a href="global.html#package:">package:undefined</a></li>
-		
+
 			<li class="search-result" data-longname="range"><a href="global.html#range">range</a></li>
-		
+
 			<li class="search-result" data-longname="RequireScript"><a href="RequireScript.html">RequireScript</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/controls.js"><a href="global.html#runtime/scripts/controls.js">runtime/scripts/controls.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/exam.js"><a href="global.html#runtime/scripts/exam.js">runtime/scripts/exam.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme.js"><a href="global.html#runtime/scripts/jme.js">runtime/scripts/jme.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-builtins.js"><a href="global.html#runtime/scripts/jme-builtins.js">runtime/scripts/jme-builtins.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-display.js"><a href="global.html#runtime/scripts/jme-display.js">runtime/scripts/jme-display.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-rules.js"><a href="global.html#runtime/scripts/jme-rules.js">runtime/scripts/jme-rules.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/jme-variables.js"><a href="global.html#runtime/scripts/jme-variables.js">runtime/scripts/jme-variables.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/json.js"><a href="global.html#runtime/scripts/json.js">runtime/scripts/json.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/math.js"><a href="global.html#runtime/scripts/math.js">runtime/scripts/math.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/numbas.js"><a href="global.html#runtime/scripts/numbas.js">runtime/scripts/numbas.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/part.js"><a href="global.html#runtime/scripts/part.js">runtime/scripts/part.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/custom_part_type.js"><a href="global.html#runtime/scripts/parts/custom_part_type.js">runtime/scripts/parts/custom_part_type.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/extension.js"><a href="global.html#runtime/scripts/parts/extension.js">runtime/scripts/parts/extension.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/gapfill.js"><a href="global.html#runtime/scripts/parts/gapfill.js">runtime/scripts/parts/gapfill.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/information.js"><a href="global.html#runtime/scripts/parts/information.js">runtime/scripts/parts/information.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/jme.js"><a href="global.html#runtime/scripts/parts/jme.js">runtime/scripts/parts/jme.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/matrixentry.js"><a href="global.html#runtime/scripts/parts/matrixentry.js">runtime/scripts/parts/matrixentry.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/multipleresponse.js"><a href="global.html#runtime/scripts/parts/multipleresponse.js">runtime/scripts/parts/multipleresponse.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/numberentry.js"><a href="global.html#runtime/scripts/parts/numberentry.js">runtime/scripts/parts/numberentry.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/parts/patternmatch.js"><a href="global.html#runtime/scripts/parts/patternmatch.js">runtime/scripts/parts/patternmatch.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/question.js"><a href="global.html#runtime/scripts/question.js">runtime/scripts/question.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/schedule.js"><a href="global.html#runtime/scripts/schedule.js">runtime/scripts/schedule.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/scorm-storage.js"><a href="global.html#runtime/scripts/scorm-storage.js">runtime/scripts/scorm-storage.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/start-exam.js"><a href="global.html#runtime/scripts/start-exam.js">runtime/scripts/start-exam.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/timing.js"><a href="global.html#runtime/scripts/timing.js">runtime/scripts/timing.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/util.js"><a href="global.html#runtime/scripts/util.js">runtime/scripts/util.js</a></li>
-		
+
 			<li class="search-result" data-longname="runtime/scripts/xml.js"><a href="global.html#runtime/scripts/xml.js">runtime/scripts/xml.js</a></li>
-		
+
 			<li class="search-result" data-longname="set"><a href="global.html#set">set</a></li>
-		
+
 			<li class="search-result" data-longname="TeX"><a href="global.html#TeX">TeX</a></li>
-		
+
 			<li class="search-result" data-longname="themes/default/files/scripts/display.js"><a href="global.html#themes/default/files/scripts/display.js">themes/default/files/scripts/display.js</a></li>
-		
+
 			<li class="search-result" data-longname="vector"><a href="global.html#vector">vector</a></li>
-		
+
 			<li class="search-result" data-longname="viewModel"><a href="viewModel.html">viewModel</a></li>
-		
+
 			<li class="search-result" data-longname="Number"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></li>
-		
+
 			<li class="search-result" data-longname="String"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></li>
-		
+
 			<li class="search-result" data-longname="RegExp"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a></li>
-		
+
 			<li class="search-result" data-longname="Date"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a></li>
-		
+
 			<li class="search-result" data-longname="Element"><a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a></li>
-		
+
 			<li class="search-result" data-longname="observable"><a href="http://knockoutjs.com/documentation/observables.html">observable</a></li>
-		
+
 			<li class="search-result" data-longname="jQuery"><a href="http://api.jquery.com/Types/#jQuery">jQuery</a></li>
-		
+
 			<li class="search-result" data-longname="Error"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a></li>
-		
+
 			<li class="search-result" data-longname="Boolean"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></li>
-		
+
 			<li class="search-result" data-longname="Array"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></li>
-		
+
 			<li class="search-result" data-longname="function"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">function</a></li>
-		
+
 			<li class="search-result" data-longname="XMLDocument"><a href="https://developer.mozilla.org/en/docs/Web/API/XMLDocument">XMLDocument</a></li>
-		
+
 			<li class="search-result" data-longname="Object"><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></li>
-		
+
 	</ul>
 </div>
 <div class="main-nav-item"><h3>Namespaces</h3><ul><li><a href="Numbas.html">Numbas</a></li><li><a href="Numbas.controls.html">Numbas.controls</a></li><li><a href="Numbas.display.html">Numbas.display</a></li><li><a href="Numbas.jme.html">Numbas.jme</a></li><li><a href="Numbas.jme.display.html">Numbas.jme.display</a></li><li><a href="Numbas.jme.rules.html">Numbas.jme.rules</a></li><li><a href="Numbas.jme.types.html">Numbas.jme.types</a></li><li><a href="Numbas.jme.variables.html">Numbas.jme.variables</a></li><li><a href="Numbas.json.html">Numbas.json</a></li><li><a href="Numbas.marking.html">Numbas.marking</a></li><li><a href="Numbas.math.html">Numbas.math</a></li><li><a href="Numbas.matrixmath.html">Numbas.matrixmath</a></li><li><a href="Numbas.parts.html">Numbas.parts</a></li><li><a href="Numbas.schedule.html">Numbas.schedule</a></li><li><a href="Numbas.setmath.html">Numbas.setmath</a></li><li><a href="Numbas.storage.html">Numbas.storage</a></li><li><a href="Numbas.timing.html">Numbas.timing</a></li><li><a href="Numbas.util.html">Numbas.util</a></li><li><a href="Numbas.vectormath.html">Numbas.vectormath</a></li><li><a href="Numbas.xml.html">Numbas.xml</a></li></ul></div><div class="main-nav-item"><h3>Classes</h3><ul><li><a href="Numbas.storage.BlankStorage.html">BlankStorage</a></li><li><a href="Numbas.math.ComplexDecimal.html">ComplexDecimal</a></li><li><a href="Numbas.parts.CustomPart.html">CustomPart</a></li><li><a href="Numbas.jme.variables.DOMcontentsubber.html">DOMcontentsubber</a></li><li><a href="Numbas.Error.html">Error</a></li><li><a href="Numbas.Exam.html">Exam</a></li><li><a href="Numbas.display.ExamDisplay.html">ExamDisplay</a></li><li><a href="Numbas.ExamEvent.html">ExamEvent</a></li><li><a href="Numbas.parts.ExtensionPart.html">ExtensionPart</a></li><li><a href="Numbas.math.Fraction.html">Fraction</a></li><li><a href="Numbas.jme.funcObj.html">funcObj</a></li><li><a href="Numbas.parts.GapFillPart.html">GapFillPart</a></li><li><a href="Numbas.parts.InformationPart.html">InformationPart</a></li><li><a href="Numbas.parts.JMEPart.html">JMEPart</a></li><li><a href="Numbas.marking.MarkingNote.html">MarkingNote</a></li><li><a href="Numbas.marking.MarkingScript.html">MarkingScript</a></li><li><a href="Numbas.parts.MatrixEntryPart.html">MatrixEntryPart</a></li><li><a href="Numbas.parts.MultipleResponsePart.html">MultipleResponsePart</a></li><li><a href="Numbas.parts.NumberEntryPart.html">NumberEntryPart</a></li><li><a href="Numbas.jme.Parser.html">Parser</a></li><li><a href="Numbas.parts.Part_.html">Part</a></li><li><a href="Numbas.display.PartDisplay.html">PartDisplay</a></li><li><a href="Numbas.parts.PatternMatchPart.html">PatternMatchPart</a></li><li><a href="Numbas.Question.html">Question</a></li><li><a href="Numbas.display.QuestionDisplay.html">QuestionDisplay</a></li><li><a href="Numbas.QuestionGroup.html">QuestionGroup</a></li><li><a href="RequireScript.html">RequireScript</a></li><li><a href="Numbas.jme.rules.Rule.html">Rule</a></li><li><a href="Numbas.jme.rules.Ruleset.html">Ruleset</a></li><li><a href="Numbas.jme.Scope.html">Scope</a></li><li><a href="Numbas.storage.SCORMStorage.html">SCORMStorage</a></li><li><a href="Numbas.schedule.SignalBox.html">SignalBox</a></li><li><a href="Numbas.marking.StatefulScope.html">StatefulScope</a></li><li><a href="Numbas.jme.types.TBool.html">TBool</a></li><li><a href="Numbas.jme.types.TDict.html">TDict</a></li><li><a href="Numbas.jme.types.TExpression.html">TExpression</a></li><li><a href="Numbas.jme.types.TFunc.html">TFunc</a></li><li><a href="Numbas.jme.types.THTML.html">THTML</a></li><li><a href="Numbas.jme.types.TKeyPair.html">TKeyPair</a></li><li><a href="Numbas.jme.types.TList.html">TList</a></li><li><a href="Numbas.jme.types.TMatrix.html">TMatrix</a></li><li><a href="Numbas.jme.types.TName.html">TName</a></li><li><a href="Numbas.jme.types.TNothing.html">TNothing</a></li><li><a href="Numbas.jme.types.TNum.html">TNum</a></li><li><a href="Numbas.jme.types.TOp.html">TOp</a></li><li><a href="Numbas.jme.types.TPunc.html">TPunc</a></li><li><a href="Numbas.jme.types.TRange.html">TRange</a></li><li><a href="Numbas.jme.types.TSet.html">TSet</a></li><li><a href="Numbas.jme.types.TString.html">TString</a></li><li><a href="Numbas.jme.types.TVector.html">TVector</a></li></ul></div><div class="main-nav-item"><h3>Events</h3><ul><li><a href="Numbas.Question.html#event:functionsLoaded">functionsLoaded</a></li><li><a href="Numbas.Question.html#event:functionsMade">functionsMade</a></li><li><a href="Numbas.Question.html#event:generateVariables">generateVariables</a></li><li><a href="Numbas.Question.html#event:HTMLAttached">HTMLAttached</a></li><li><a href="Numbas.Question.html#event:partsGenerated">partsGenerated</a></li><li><a href="Numbas.Question.html#event:partsResumed">partsResumed</a></li><li><a href="Numbas.Question.html#event:preambleLoaded">preambleLoaded</a></li><li><a href="Numbas.Question.html#event:preambleRun">preambleRun</a></li><li><a href="Numbas.Exam.html#event:questionlistinitialised">question list initialised</a></li><li><a href="Numbas.Exam.html#event:ready">ready</a></li><li><a href="Numbas.Question.html#event:ready">ready</a></li><li><a href="Numbas.Question.html#event:rulesetsLoaded">rulesetsLoaded</a></li><li><a href="Numbas.Question.html#event:rulesetsMade">rulesetsMade</a></li><li><a href="Numbas.Question.html#event:variableDefinitionsLoaded">variableDefinitionsLoaded</a></li><li><a href="Numbas.Question.html#event:variablesGenerated">variablesGenerated</a></li><li><a href="Numbas.Question.html#event:variablesSet">variablesSet</a></li></ul></div><h3>Global variables</h3><ul><li><a href="global.html#get">get</a></li><li><a href="global.html#hasWarnings">hasWarnings</a></li></ul>

--- a/runtime/scripts/jme-display.js
+++ b/runtime/scripts/jme-display.js
@@ -592,7 +592,7 @@ var texSpecialNumber = jme.display.texSpecialNumber = function(value) {
         }
     }
 }
-/** Convert a number to TeX, displaying it as a fractionm using {@link Numbas.math.rationalApproximation}
+/** Convert a number to TeX, displaying it as a fraction using {@link Numbas.math.rationalApproximation}
  * @memberof Numbas.jme.display
  * @private
  *

--- a/runtime/scripts/jme-display.js
+++ b/runtime/scripts/jme-display.js
@@ -313,12 +313,7 @@ var texOps = jme.display.texOps = {
     }),
     '/': (function(thing,texArgs,settings) {
         if (settings.flatfractions) {
-            for (var i=0; i<2; i++) {
-                // identifying if the numerator and denominator need brackets around them by
-                // checking whether they contain whitespaces
-                if (texArgs[i].includes(' ')) texArgs[i] = '(' + texArgs[i] + ')'
-            }
-            return ('\\left. '+texArgs[0]+' \\middle/ '+texArgs[1]+' \\right.');
+            return '\\left. ' + texifyOpArg(thing,texArgs,0) + ' \\middle/ ' + texifyOpArg(thing,texArgs,1) + ' \\right.'
         } else {
             return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }');
         }

--- a/runtime/scripts/jme-display.js
+++ b/runtime/scripts/jme-display.js
@@ -1225,7 +1225,7 @@ var jmeRealNumber = jme.display.jmeRealNumber = function(n,settings)
         im += im.match(/\d$/) ? 'i' : '*i';
         if(Math.abs(n.im)<1e-15) {
             return re;
-        } 
+        }
         else if(n.re==0)
         {
             if(n.im==1)
@@ -1309,7 +1309,7 @@ var jmeDecimal = jme.display.jmeDecimal = function(n,settings)
         var re = jmeDecimal(n.re);
         if(n.isReal()) {
             return re;
-        } 
+        }
         var im = jmeDecimal(n.im)+'*i';
         if(n.re.isZero()) {
             if(n.im.eq(1))
@@ -1647,7 +1647,7 @@ var align_text_blocks = jme.display.align_text_blocks = function(header,items) {
         }
         return line;
     }
-    
+
     var item_lines = items.map(function(item){return item.split('\n')});
     var item_widths = item_lines.map(function(lines) {return lines.reduce(function(m,l){return Math.max(l.length,m)},0)});
     var num_lines = item_lines.reduce(function(t,ls){return Math.max(ls.length,t)},0);

--- a/runtime/scripts/jme-display.js
+++ b/runtime/scripts/jme-display.js
@@ -311,7 +311,18 @@ var texOps = jme.display.texOps = {
         }
         return s;
     }),
-    '/': (function(thing,texArgs) { return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }'); }),
+    '/': (function(thing,texArgs,settings) {
+        if (settings.flatfractions) {
+            for (var i=0; i<2; i++) {
+                // identifying if the numerator and denominator need brackets around them by
+                // checking whether they contain whitespaces
+                if (texArgs[i].includes(' ')) texArgs[i] = '(' + texArgs[i] + ')'
+            }
+            return ('\\left. '+texArgs[0]+' \\middle/ '+texArgs[1]+' \\right.');
+        } else {
+            return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }');
+        }
+    }),
     '+': (function(thing,texArgs,settings) {
         var a = thing.args[0];
         var b = thing.args[1];

--- a/runtime/scripts/jme-display.js
+++ b/runtime/scripts/jme-display.js
@@ -399,25 +399,39 @@ var texOps = jme.display.texOps = {
     'floor': (function(thing,texArgs) { return '\\left \\lfloor '+texArgs[0]+' \\right \\rfloor';}),
     'int': (function(thing,texArgs) { return ('\\int \\! '+texArgs[0]+' \\, \\mathrm{d}'+texArgs[1]); }),
     'defint': (function(thing,texArgs) { return ('\\int_{'+texArgs[2]+'}^{'+texArgs[3]+'} \\! '+texArgs[0]+' \\, \\mathrm{d}'+texArgs[1]); }),
-    'diff': (function(thing,texArgs)
+    'diff': (function(thing,texArgs,settings)
             {
                 var degree = (jme.isType(thing.args[2].tok,'number') && jme.castToType(thing.args[2].tok,'number').value==1) ? '' : '^{'+texArgs[2]+'}';
                 if(thing.args[0].tok.type=='name') {
-                    return ('\\frac{\\mathrm{d}'+degree+texArgs[0]+'}{\\mathrm{d}'+texArgs[1]+degree+'}');
+                    if (settings.flatfractions) {
+                        return ('\\left. \\mathrm{d}'+degree+texifyOpArg(thing, texArgs, 0)+' \\middle/ \\mathrm{d}'+texifyOpArg(thing, texArgs, 1)+'\\right.')
+                    } else {
+                        return ('\\frac{\\mathrm{d}'+degree+texArgs[0]+'}{\\mathrm{d}'+texArgs[1]+degree+'}');
+                    }
                 } else {
-                    return ('\\frac{\\mathrm{d}'+degree+'}{\\mathrm{d}'+texArgs[1]+degree+'} \\left ('+texArgs[0]+' \\right )');
+                    if (settings.flatfractions) {
+                        return ('\\left. \\mathrm{d}'+degree+'('+texArgs[0]+') \\middle/ \\mathrm{d}'+texifyOpArg(thing, texArgs, 1)+'\\right.')
+                    } else {
+                        return ('\\frac{\\mathrm{d}'+degree+'}{\\mathrm{d}'+texArgs[1]+degree+'} \\left ('+texArgs[0]+' \\right )');
+                    }
                 }
             }),
-    'partialdiff': (function(thing,texArgs)
+    'partialdiff': (function(thing,texArgs,settings)
             {
                 var degree = (jme.isType(thing.args[2].tok,'number') && jme.castToType(thing.args[2].tok,'number').value==1) ? '' : '^{'+texArgs[2]+'}';
                 if(thing.args[0].tok.type=='name')
-                {
-                    return ('\\frac{\\partial '+degree+texArgs[0]+'}{\\partial '+texArgs[1]+degree+'}');
-                }
+                    if (settings.flatfractions) {
+                        return ('\\left. \\partial '+degree+texifyOpArg(thing, texArgs, 0)+' \\middle/ \\partial '+texifyOpArg(thing, texArgs, 1)+'\\right.')
+                    } else {
+                        return ('\\frac{\\partial '+degree+texArgs[0]+'}{\\partial '+texArgs[1]+degree+'}');
+                    }
                 else
                 {
-                    return ('\\frac{\\partial '+degree+'}{\\partial '+texArgs[1]+degree+'} \\left ('+texArgs[0]+' \\right )');
+                    if (settings.flatfractions) {
+                        return ('\\left. \\partial '+degree+'('+texArgs[0]+') \\middle/ \\partial '+texifyOpArg(thing, texArgs, 1)+'\\right.')
+                    } else {
+                        return ('\\frac{\\partial '+degree+'}{\\partial '+texArgs[1]+degree+'} \\left ('+texArgs[0]+' \\right )');
+                    }
                 }
             }),
     'sub': (function(thing,texArgs) {
@@ -644,10 +658,19 @@ var texRationalNumber = jme.display.texRationalNumber = function(n, settings)
             if(settings.mixedfractions && f[0] > f[1]) {
                 var properNumerator = math.mod(f[0], f[1]);
                 var mixedInteger = (f[0]-properNumerator)/f[1];
-                out = mixedInteger+' \\frac{'+properNumerator+'}{'+f[1]+'}';
+                if (settings.flatfractions) {
+                    out = mixedInteger+' (\\left. '+properNumerator+' \\middle/ '+f[1]+' \\right.)';
+                } else {
+                    out = mixedInteger+' \\frac{'+properNumerator+'}{'+f[1]+'}';
+                }
             }
             else {
-                out = '\\frac{'+f[0]+'}{'+f[1]+'}';
+                if (settings.flatfractions) {
+                    out = '\\left. '+f[0]+' \\middle/ '+f[1]+' \\right.'
+                }
+                else {
+                    out = '\\frac{'+f[0]+'}{'+f[1]+'}';
+                }
             }
         }
         if(n<0)

--- a/runtime/scripts/jme-rules.js
+++ b/runtime/scripts/jme-rules.js
@@ -247,7 +247,7 @@ var Term = Numbas.jme.rules.Term = function(tree) {
 }
 
 /** Replacements to make when identifying terms in a sequence of applications of a given op.
- * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`. 
+ * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`.
  * A tree `A op B` should be replaced with `replacement(tree)`.
  * For example, `x-y` should be rewritten to `x+(-y)`.
  */
@@ -257,7 +257,7 @@ var nonStrictReplacements = {
             return {tok: new jme.types.TOp('+',false,false,2,true,true), args: [tree.args[0],insertUnaryMinus(tree.args[1])]};
         }
     },
-    '*': { 
+    '*': {
         '/': function(tree) {
             tree = {tok: new jme.types.TOp('*',false,false,2,true,true), args: [tree.args[0],{tok:new jme.types.TOp('/u',false,true,1,false,false),args:[tree.args[1]]}]};
             return tree;
@@ -326,12 +326,12 @@ var getTerms = Numbas.jme.rules.getTerms = function(tree,op,options,calculate_mi
     function add_existing_names(items,existing_names,existing_equal_names) {
         return existing_names.length==0 && existing_equal_names.length==0 ? items : items.map(function(item) {
             return {
-                term: item.term, 
+                term: item.term,
                 names: existing_names.concat(item.names),
                 inside_equalnames: item.inside_equalnames,
                 outside_equalnames: existing_equal_names.concat(item.outside_equalnames),
-                quantifier: item.quantifier, 
-                min: item.min, 
+                quantifier: item.quantifier,
+                min: item.min,
                 max: item.max,
                 defaultValue: item.defaultValue,
             };
@@ -708,7 +708,7 @@ function matchFunction(ruleTree,exprTree,options) {
     }
     if(ruleTok.nameWithoutAnnotation in specialMatchFunctions) {
         return specialMatchFunctions[ruleTok.nameWithoutAnnotation](ruleTree,exprTree,options);
-    } else { 
+    } else {
         return matchOrdinaryFunction(ruleTree,exprTree,options);
     }
 }
@@ -1122,7 +1122,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * The indices of the input and rule terms are given so the result of the match can be cached
      * @param {Numbas.jme.rules.term} exprTerm - the input term
      * @param {Numbas.jme.rules.term} ruleTerm - the term in the pattern which must be matched
-     * @param {Number} ic - the index of the input term 
+     * @param {Number} ic - the index of the input term
      * @param {Number} pc - the index of the rule term
      * @returns {Boolean}
      */
@@ -1151,7 +1151,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
                 outside_equalnames: outside_equalnames
             }
         }
-        return matches[ic][pc].match!==false; 
+        return matches[ic][pc].match!==false;
     }
 
     /** Does the given assignment satisfy the constraints of the matching algorithm?
@@ -1222,7 +1222,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * @param {Numbas.jme.rules.term} ruleTerm
      * @param {Numbas.jme.tree} exprTree
      */
-    function matchTerm(ruleTerm,exprTree){ 
+    function matchTerm(ruleTerm,exprTree){
         ruleTerm.names.forEach(function(name) {
             var o = resolveName(name,exprTree);
             nameTerm(o.name,o.value,ruleTerm);
@@ -1324,8 +1324,8 @@ var findSequenceMatch = jme.rules.findSequenceMatch = function(pattern,input,opt
             capture.push(-1);
             increment_start();
             return;
-        } 
-        
+        }
+
         ic -= 1;
         while(ic>=start && (ic>=capture.length || capture[ic]>=pattern.length)) {
             ic -= 1;
@@ -1553,7 +1553,7 @@ function matchType(wantedType,exprTree) {
     }
 }
 
-/** Match all of the given patterns against the given expression. 
+/** Match all of the given patterns against the given expression.
  * Return `false` if any of the patterns don't match.
  * @param {Array.<Numbas.jme.tree>} patterns
  * @param {Numbas.jme.tree} exprTree
@@ -1674,7 +1674,7 @@ var transform = jme.rules.transform = function(ruleTree,resultTree,exprTree,opti
 var transformAll = jme.rules.transformAll = function(ruleTree,resultTree,exprTree,options) {
     var changed = false;
     if(exprTree.args) {
-        var args = exprTree.args.map(function(arg){ 
+        var args = exprTree.args.map(function(arg){
             var o = transformAll(ruleTree,resultTree,arg,options);
             changed = changed || o.changed;
             return  o.expression;
@@ -1705,7 +1705,7 @@ patternParser.addPostfixOperator('`?','`?',{precedence: 0.5});  // optional
 patternParser.addPostfixOperator('`*','`*',{precedence: 0.5}); // any number of times
 patternParser.addPostfixOperator('`+','`+',{precedence: 0.5}); // at least one time
 
-patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not 
+patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not
 patternParser.addPrefixOperator('`+-','`+-',{precedence: 0.5});  // unary plus or minus
 patternParser.addPrefixOperator('`*/','`*/',{precedence: 0.5});  // unary multiply or divide
 
@@ -1785,7 +1785,7 @@ Ruleset.prototype = /** @lends Numbas.jme.rules.Ruleset.prototype */ {
             return false;
     },
 
-    /** Apply this set's rules to the given expression until they don't change any more 
+    /** Apply this set's rules to the given expression until they don't change any more
      * @param {Numbas.jme.tree} exprTree
      * @param {Numbas.jme.Scope} scope
      * @see Numbas.jme.rules.transform

--- a/runtime/scripts/jme-rules.js
+++ b/runtime/scripts/jme-rules.js
@@ -1751,7 +1751,8 @@ var displayFlags = jme.rules.displayFlags = {
     fractionnumbers: undefined,
     rowvector: undefined,
     alwaystimes: undefined,
-    mixedfractions: undefined
+    mixedfractions: undefined,
+    flatfractions: undefined
 };
 /** Flags used in JME simplification rulesets
  * @type Object.<Boolean>
@@ -1759,6 +1760,7 @@ var displayFlags = jme.rules.displayFlags = {
  * @property {Boolean} fractionnumbers - Show all numbers as fractions?
  * @property {Boolean} rowvector - Display vectors as a horizontal list of components?
  * @property {Boolean} alwaystimes - Always show the multiplication symbol between multiplicands?
+ * @property {Boolean} flatfractions - Display fractions horizontally?
  * @see Numbas.jme.rules.Ruleset
  */
 /** Set of simplification rules

--- a/tests/jme-runtime.js
+++ b/tests/jme-runtime.js
@@ -115,7 +115,7 @@ RequireScript.prototype = {
     fdeps: [],
     callback: null,
 
-    
+
     /** Try to run this script. It will run if all of its dependencies have run.
      * Once it has run, every script which depends on it will try to run.
      */
@@ -748,7 +748,7 @@ var util = Numbas.util = /** @lends Numbas.util */ {
         b = b.toString().toLowerCase();
         return( b=='true' || b=='yes' );
     },
-    /** Regular expression recognising a fraction 
+    /** Regular expression recognising a fraction
      * @type RegExp
      */
     re_fraction: /^\s*(-?)\s*(\d+)\s*\/\s*(\d+)\s*/,
@@ -1727,8 +1727,8 @@ Copyright 2011-14 Newcastle University
  * Provides {@link Numbas.math}, {@link Numbas.vectormath} and {@link Numbas.matrixmath}
  */
 Numbas.queueScript('math',['base','decimal'],function() {
-    
-    Decimal.set({ 
+
+    Decimal.set({
         precision: 40,
         modulo: Decimal.EUCLID,
         toExpPos: 1000,
@@ -1751,7 +1751,7 @@ Numbas.queueScript('math',['base','decimal'],function() {
  * @see Numbas.math.defineRange
  */
 var math = Numbas.math = /** @lends Numbas.math */ {
-    /** Regex to match numbers in scientific notation 
+    /** Regex to match numbers in scientific notation
      * @type {RegExp}
      * @memberof Numbas.math
      */
@@ -4053,7 +4053,7 @@ var vectormath = Numbas.vectormath = {
  * @namespace Numbas.matrixmath
  */
 var matrixmath = Numbas.matrixmath = {
-    /** Negate a matrix - negate each of its elements 
+    /** Negate a matrix - negate each of its elements
      * @param {matrix} m
      * @returns {matrix}
      */
@@ -5409,7 +5409,7 @@ if (!Object.entries) {
         resArray = new Array(i); // preallocate the Array
     while (i--)
       resArray[i] = [ownProps[i], obj[ownProps[i]]];
-    
+
     return resArray;
   };
 }
@@ -9566,7 +9566,7 @@ var Term = Numbas.jme.rules.Term = function(tree) {
 }
 
 /** Replacements to make when identifying terms in a sequence of applications of a given op.
- * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`. 
+ * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`.
  * A tree `A op B` should be replaced with `replacement(tree)`.
  * For example, `x-y` should be rewritten to `x+(-y)`.
  */
@@ -9576,7 +9576,7 @@ var nonStrictReplacements = {
             return {tok: new jme.types.TOp('+',false,false,2,true,true), args: [tree.args[0],insertUnaryMinus(tree.args[1])]};
         }
     },
-    '*': { 
+    '*': {
         '/': function(tree) {
             tree = {tok: new jme.types.TOp('*',false,false,2,true,true), args: [tree.args[0],{tok:new jme.types.TOp('/u',false,true,1,false,false),args:[tree.args[1]]}]};
             return tree;
@@ -9645,12 +9645,12 @@ var getTerms = Numbas.jme.rules.getTerms = function(tree,op,options,calculate_mi
     function add_existing_names(items,existing_names,existing_equal_names) {
         return existing_names.length==0 && existing_equal_names.length==0 ? items : items.map(function(item) {
             return {
-                term: item.term, 
+                term: item.term,
                 names: existing_names.concat(item.names),
                 inside_equalnames: item.inside_equalnames,
                 outside_equalnames: existing_equal_names.concat(item.outside_equalnames),
-                quantifier: item.quantifier, 
-                min: item.min, 
+                quantifier: item.quantifier,
+                min: item.min,
                 max: item.max,
                 defaultValue: item.defaultValue,
             };
@@ -10027,7 +10027,7 @@ function matchFunction(ruleTree,exprTree,options) {
     }
     if(ruleTok.nameWithoutAnnotation in specialMatchFunctions) {
         return specialMatchFunctions[ruleTok.nameWithoutAnnotation](ruleTree,exprTree,options);
-    } else { 
+    } else {
         return matchOrdinaryFunction(ruleTree,exprTree,options);
     }
 }
@@ -10441,7 +10441,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * The indices of the input and rule terms are given so the result of the match can be cached
      * @param {Numbas.jme.rules.term} exprTerm - the input term
      * @param {Numbas.jme.rules.term} ruleTerm - the term in the pattern which must be matched
-     * @param {Number} ic - the index of the input term 
+     * @param {Number} ic - the index of the input term
      * @param {Number} pc - the index of the rule term
      * @returns {Boolean}
      */
@@ -10470,7 +10470,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
                 outside_equalnames: outside_equalnames
             }
         }
-        return matches[ic][pc].match!==false; 
+        return matches[ic][pc].match!==false;
     }
 
     /** Does the given assignment satisfy the constraints of the matching algorithm?
@@ -10541,7 +10541,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * @param {Numbas.jme.rules.term} ruleTerm
      * @param {Numbas.jme.tree} exprTree
      */
-    function matchTerm(ruleTerm,exprTree){ 
+    function matchTerm(ruleTerm,exprTree){
         ruleTerm.names.forEach(function(name) {
             var o = resolveName(name,exprTree);
             nameTerm(o.name,o.value,ruleTerm);
@@ -10643,8 +10643,8 @@ var findSequenceMatch = jme.rules.findSequenceMatch = function(pattern,input,opt
             capture.push(-1);
             increment_start();
             return;
-        } 
-        
+        }
+
         ic -= 1;
         while(ic>=start && (ic>=capture.length || capture[ic]>=pattern.length)) {
             ic -= 1;
@@ -10872,7 +10872,7 @@ function matchType(wantedType,exprTree) {
     }
 }
 
-/** Match all of the given patterns against the given expression. 
+/** Match all of the given patterns against the given expression.
  * Return `false` if any of the patterns don't match.
  * @param {Array.<Numbas.jme.tree>} patterns
  * @param {Numbas.jme.tree} exprTree
@@ -10993,7 +10993,7 @@ var transform = jme.rules.transform = function(ruleTree,resultTree,exprTree,opti
 var transformAll = jme.rules.transformAll = function(ruleTree,resultTree,exprTree,options) {
     var changed = false;
     if(exprTree.args) {
-        var args = exprTree.args.map(function(arg){ 
+        var args = exprTree.args.map(function(arg){
             var o = transformAll(ruleTree,resultTree,arg,options);
             changed = changed || o.changed;
             return  o.expression;
@@ -11024,7 +11024,7 @@ patternParser.addPostfixOperator('`?','`?',{precedence: 0.5});  // optional
 patternParser.addPostfixOperator('`*','`*',{precedence: 0.5}); // any number of times
 patternParser.addPostfixOperator('`+','`+',{precedence: 0.5}); // at least one time
 
-patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not 
+patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not
 patternParser.addPrefixOperator('`+-','`+-',{precedence: 0.5});  // unary plus or minus
 patternParser.addPrefixOperator('`*/','`*/',{precedence: 0.5});  // unary multiply or divide
 
@@ -11104,7 +11104,7 @@ Ruleset.prototype = /** @lends Numbas.jme.rules.Ruleset.prototype */ {
             return false;
     },
 
-    /** Apply this set's rules to the given expression until they don't change any more 
+    /** Apply this set's rules to the given expression until they don't change any more
      * @param {Numbas.jme.tree} exprTree
      * @param {Numbas.jme.Scope} scope
      * @see Numbas.jme.rules.transform
@@ -11676,7 +11676,7 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
         settings = util.extend_object({},default_settings,settings);
         var checkingFunction = checkingFunctions[settings.checkingType.toLowerCase()];    //work out which checking type is being used
         try {
-            if(tree1 == null || tree2 == null) {    
+            if(tree1 == null || tree2 == null) {
                 //one or both expressions are invalid, can't compare
                 return false;
             }
@@ -11691,7 +11691,7 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
                 if( !varnamesAgree(vars1,vars2) ) {    //whoops, differing variables
                     return false;
                 }
-            } else { 
+            } else {
                 vars2.forEach(function(n) {
                     if(vars1.indexOf(n)==-1) {
                         vars1.push(n);
@@ -11708,8 +11708,8 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
                 var nscope = new jme.Scope([scope,{variables:rs[i]}]);
                 var r1 = nscope.evaluate(tree1);
                 var r2 = nscope.evaluate(tree2);
-                if( !resultsEqual(r1,r2,checkingFunction,settings.checkingAccuracy) ) { 
-                    errors++; 
+                if( !resultsEqual(r1,r2,checkingFunction,settings.checkingAccuracy) ) {
+                    errors++;
                 }
             }
             return errors < failureRate;
@@ -12214,7 +12214,7 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
 /** A parser for {@link JME} expressions
  * @memberof Numbas.jme
  * @constructor
- * 
+ *
  * @param {Numbas.jme.parser_options} options
  */
 var Parser = jme.Parser = function(options) {
@@ -12326,7 +12326,7 @@ jme.Parser.prototype = /** @lends Numbas.jme.Parser.prototype */ {
      */
     ops: ['not','and','or','xor','implies','isa','except','in','divides','as','..','#','<=','>=','<>','&&','||','|','*','+','-','/','^','<','>','=','!','&','÷','×','∈','∧','∨','⟹','≠','≥','≤'],
 
-    /** Regular expressions to match tokens 
+    /** Regular expressions to match tokens
      * @type {Object.<RegExp>}
      */
     re: {
@@ -12662,7 +12662,7 @@ jme.Parser.prototype = /** @lends Numbas.jme.Parser.prototype */ {
             if(!tok.prefix) {
                 var o1 = this.getPrecedence(tok.name);
                 //while ops on stack have lower precedence, pop them onto output because they need to be calculated before this one. left-associative operators also pop off operations with equal precedence
-                
+
                 /** Should the next token on the stack be popped off?
                  * @returns {Boolean}
                  */
@@ -13170,13 +13170,13 @@ Scope.prototype = /** @lends Numbas.jme.Scope.prototype */ {
             if(fn.typecheck(args)) {
                 var match = fn.intype(args);
                 var k = 0;
-                var exact_match = match.every(function(m,i) { 
+                var exact_match = match.every(function(m,i) {
                     if(m.missing) {
                         return;
                     }
                     var ok = args[k].type==m.type;
                     k += 1;
-                    return ok; 
+                    return ok;
                 });
                 if(exact_match) {
                     return {fn: fn, signature: match};
@@ -13396,7 +13396,7 @@ Scope.prototype = /** @lends Numbas.jme.Scope.prototype */ {
                         }
                         var arg = eargs[j];
                         if(signature[i]) {
-                            castargs.push(jme.castToType(arg,signature[i])); 
+                            castargs.push(jme.castToType(arg,signature[i]));
                         } else {
                             castargs.push(arg);
                         }
@@ -13474,7 +13474,7 @@ var TNum = types.TNum = function(num) {
 }
 jme.registerType(
     TNum,
-    'number', 
+    'number',
     {
         'decimal': function(n) {
             var dp = 14;
@@ -14068,7 +14068,7 @@ var funcObj = jme.funcObj = function(name,intype,outcons,fn,options)
     this.id = funcObjAcc++;
     options = options || {};
 
-    /** Parse a signature definition. 
+    /** Parse a signature definition.
      * @param {String|Function} sig - either a string consisting of a variable name optionally followed by '*' and/or '?', a {@link Numbas.jme.token} constructor, or a {@link Numbas.jme.signature} function.
      * @returns {Numbas.jme.signature}
      */
@@ -14270,7 +14270,7 @@ var checkingFunctions = jme.checkingFunctions =
         tolerance = Math.floor(Math.abs(tolerance));
         return math.eq( math.precround(r1,tolerance), math.precround(r2,tolerance) );
     },
-    /** Round both values to `tolerance` significant figures, and fail if unequal. 
+    /** Round both values to `tolerance` significant figures, and fail if unequal.
      * @param {Number} r1
      * @param {Number} r2
      * @param {Number} tolerance
@@ -14453,7 +14453,7 @@ var resultsEqual = jme.resultsEqual = function(r1,r2,checkingFunction,checkingAc
 /** List names of variables used in `tree`, obtained by depth-first search.
  *
  * Differs from {@link Numbas.jme.findvars} by including duplicates, and ignoring {@link Numbas.jme.findvarsOps}.
- * 
+ *
  * @memberof Numbas.jme
  * @method
  * @param {Numbas.jme.tree} tree
@@ -18357,7 +18357,7 @@ var jmeRealNumber = jme.display.jmeRealNumber = function(n,settings)
         im += im.match(/\d$/) ? 'i' : '*i';
         if(Math.abs(n.im)<1e-15) {
             return re;
-        } 
+        }
         else if(n.re==0)
         {
             if(n.im==1)
@@ -18441,7 +18441,7 @@ var jmeDecimal = jme.display.jmeDecimal = function(n,settings)
         var re = jmeDecimal(n.re);
         if(n.isReal()) {
             return re;
-        } 
+        }
         var im = jmeDecimal(n.im)+'*i';
         if(n.re.isZero()) {
             if(n.im.eq(1))
@@ -18779,7 +18779,7 @@ var align_text_blocks = jme.display.align_text_blocks = function(header,items) {
         }
         return line;
     }
-    
+
     var item_lines = items.map(function(item){return item.split('\n')});
     var item_widths = item_lines.map(function(lines) {return lines.reduce(function(m,l){return Math.max(l.length,m)},0)});
     var num_lines = item_lines.reduce(function(t,ls){return Math.max(ls.length,t)},0);

--- a/tests/jme-runtime.js
+++ b/tests/jme-runtime.js
@@ -11070,7 +11070,8 @@ var displayFlags = jme.rules.displayFlags = {
     fractionnumbers: undefined,
     rowvector: undefined,
     alwaystimes: undefined,
-    mixedfractions: undefined
+    mixedfractions: undefined,
+    flatfractions: undefined
 };
 /** Flags used in JME simplification rulesets
  * @type Object.<Boolean>
@@ -11078,6 +11079,7 @@ var displayFlags = jme.rules.displayFlags = {
  * @property {Boolean} fractionnumbers - Show all numbers as fractions?
  * @property {Boolean} rowvector - Display vectors as a horizontal list of components?
  * @property {Boolean} alwaystimes - Always show the multiplication symbol between multiplicands?
+ * @property {Boolean} flatfractions - Display fractions horizontally?
  * @see Numbas.jme.rules.Ruleset
  */
 /** Set of simplification rules
@@ -17443,7 +17445,18 @@ var texOps = jme.display.texOps = {
         }
         return s;
     }),
-    '/': (function(thing,texArgs) { return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }'); }),
+    '/': (function(thing,texArgs,settings) {
+        if (settings.flatfractions) {
+            for (var i=0; i<2; i++) {
+                // identifying if the numerator and denominator need brackets around them by
+                // checking whether they contain whitespaces
+                if (texArgs[i].includes(' ')) texArgs[i] = '(' + texArgs[i] + ')'
+            }
+            return ('\\left. '+texArgs[0]+' \\middle/ '+texArgs[1]+' \\right.');
+        } else {
+            return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }');
+        }
+    }),
     '+': (function(thing,texArgs,settings) {
         var a = thing.args[0];
         var b = thing.args[1];

--- a/tests/jme.html
+++ b/tests/jme.html
@@ -1575,6 +1575,8 @@
                     assert.equal(exprToLaTeX('pi','fractionNumbers'),'\\pi','pi with fractionNumbers');
                     assert.equal(exprToLaTeX('e^(3x)','fractionNumbers'),'e^{ 3 x }','e^(3x) with fractionNumbers');
                     assert.equal(exprToLaTeX('e*i',''),'e i','e*i');
+                    assert.equal(exprToLaTeX('2/4','flatFractions'),'\\left. 2 \\middle/ 4 \\right.','');
+                    assert.equal(exprToLaTeX('(2 + 3)/(a + b)','flatFractions'),'\\left. (2 + 3) \\middle/ (a + b) \\right.','');
 				});
 
                 doc_tests.forEach(function(section) {

--- a/tests/jme.html
+++ b/tests/jme.html
@@ -250,8 +250,8 @@
                     raisesNumbasError(assert, function(){ compile('[2,"a":1]') },'jme.shunt.list mixed argument types','mixed list/dict arguments: [2,"a":1]');
                     assert.equal(compile("true AND true").tok.name,'and','operator names are case insensitive');
 				})
-			
-				
+
+
 				QUnit.module('Evaluating');
 
 				QUnit.test('Numbas.math',function(assert) {
@@ -990,7 +990,7 @@
                     assert.equal(evaluate('table([["x","y"],["3",1]])').value.html(),"<tbody><tr><td>x</td><td>y</td></tr><tr><td>3</td><td>1</td></tr></tbody>",'table');
                     assert.equal(evaluate('table([["x","y"],["3",1]],["a","b"])').value.html(),"<thead><th>a</th><th>b</th></thead><tbody><tr><td>x</td><td>y</td></tr><tr><td>3</td><td>1</td></tr></tbody>",'table with headers');
                 });
-				
+
 				QUnit.module('Scopes');
 
 				QUnit.test('Variables',function(assert) {
@@ -1228,7 +1228,7 @@
                         var rule = new Numbas.jme.rules.Rule(pattern,repl,options);
                         return rule.replaceAll(Numbas.jme.compile(expr), Numbas.jme.builtinScope);
                     }
-                    
+
                     var res = replace('?;x+?;y','x*y','acg','1+2');
                     assert.ok(res.changed);
                     var treeToJME = Numbas.jme.display.treeToJME;

--- a/tests/numbas-runtime.js
+++ b/tests/numbas-runtime.js
@@ -115,7 +115,7 @@ RequireScript.prototype = {
     fdeps: [],
     callback: null,
 
-    
+
     /** Try to run this script. It will run if all of its dependencies have run.
      * Once it has run, every script which depends on it will try to run.
      */
@@ -748,7 +748,7 @@ var util = Numbas.util = /** @lends Numbas.util */ {
         b = b.toString().toLowerCase();
         return( b=='true' || b=='yes' );
     },
-    /** Regular expression recognising a fraction 
+    /** Regular expression recognising a fraction
      * @type RegExp
      */
     re_fraction: /^\s*(-?)\s*(\d+)\s*\/\s*(\d+)\s*/,
@@ -1727,8 +1727,8 @@ Copyright 2011-14 Newcastle University
  * Provides {@link Numbas.math}, {@link Numbas.vectormath} and {@link Numbas.matrixmath}
  */
 Numbas.queueScript('math',['base','decimal'],function() {
-    
-    Decimal.set({ 
+
+    Decimal.set({
         precision: 40,
         modulo: Decimal.EUCLID,
         toExpPos: 1000,
@@ -1751,7 +1751,7 @@ Numbas.queueScript('math',['base','decimal'],function() {
  * @see Numbas.math.defineRange
  */
 var math = Numbas.math = /** @lends Numbas.math */ {
-    /** Regex to match numbers in scientific notation 
+    /** Regex to match numbers in scientific notation
      * @type {RegExp}
      * @memberof Numbas.math
      */
@@ -4053,7 +4053,7 @@ var vectormath = Numbas.vectormath = {
  * @namespace Numbas.matrixmath
  */
 var matrixmath = Numbas.matrixmath = {
-    /** Negate a matrix - negate each of its elements 
+    /** Negate a matrix - negate each of its elements
      * @param {matrix} m
      * @returns {matrix}
      */
@@ -4617,7 +4617,7 @@ var Term = Numbas.jme.rules.Term = function(tree) {
 }
 
 /** Replacements to make when identifying terms in a sequence of applications of a given op.
- * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`. 
+ * When looking for terms joined by `op`, `nonStrictReplacements[op]` is a list of objects with keys `op` and `replacement`.
  * A tree `A op B` should be replaced with `replacement(tree)`.
  * For example, `x-y` should be rewritten to `x+(-y)`.
  */
@@ -4627,7 +4627,7 @@ var nonStrictReplacements = {
             return {tok: new jme.types.TOp('+',false,false,2,true,true), args: [tree.args[0],insertUnaryMinus(tree.args[1])]};
         }
     },
-    '*': { 
+    '*': {
         '/': function(tree) {
             tree = {tok: new jme.types.TOp('*',false,false,2,true,true), args: [tree.args[0],{tok:new jme.types.TOp('/u',false,true,1,false,false),args:[tree.args[1]]}]};
             return tree;
@@ -4696,12 +4696,12 @@ var getTerms = Numbas.jme.rules.getTerms = function(tree,op,options,calculate_mi
     function add_existing_names(items,existing_names,existing_equal_names) {
         return existing_names.length==0 && existing_equal_names.length==0 ? items : items.map(function(item) {
             return {
-                term: item.term, 
+                term: item.term,
                 names: existing_names.concat(item.names),
                 inside_equalnames: item.inside_equalnames,
                 outside_equalnames: existing_equal_names.concat(item.outside_equalnames),
-                quantifier: item.quantifier, 
-                min: item.min, 
+                quantifier: item.quantifier,
+                min: item.min,
                 max: item.max,
                 defaultValue: item.defaultValue,
             };
@@ -5078,7 +5078,7 @@ function matchFunction(ruleTree,exprTree,options) {
     }
     if(ruleTok.nameWithoutAnnotation in specialMatchFunctions) {
         return specialMatchFunctions[ruleTok.nameWithoutAnnotation](ruleTree,exprTree,options);
-    } else { 
+    } else {
         return matchOrdinaryFunction(ruleTree,exprTree,options);
     }
 }
@@ -5492,7 +5492,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * The indices of the input and rule terms are given so the result of the match can be cached
      * @param {Numbas.jme.rules.term} exprTerm - the input term
      * @param {Numbas.jme.rules.term} ruleTerm - the term in the pattern which must be matched
-     * @param {Number} ic - the index of the input term 
+     * @param {Number} ic - the index of the input term
      * @param {Number} pc - the index of the rule term
      * @returns {Boolean}
      */
@@ -5521,7 +5521,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
                 outside_equalnames: outside_equalnames
             }
         }
-        return matches[ic][pc].match!==false; 
+        return matches[ic][pc].match!==false;
     }
 
     /** Does the given assignment satisfy the constraints of the matching algorithm?
@@ -5592,7 +5592,7 @@ function matchTermSequence(ruleTerms, exprTerms, commuting, allowOtherTerms, opt
      * @param {Numbas.jme.rules.term} ruleTerm
      * @param {Numbas.jme.tree} exprTree
      */
-    function matchTerm(ruleTerm,exprTree){ 
+    function matchTerm(ruleTerm,exprTree){
         ruleTerm.names.forEach(function(name) {
             var o = resolveName(name,exprTree);
             nameTerm(o.name,o.value,ruleTerm);
@@ -5694,8 +5694,8 @@ var findSequenceMatch = jme.rules.findSequenceMatch = function(pattern,input,opt
             capture.push(-1);
             increment_start();
             return;
-        } 
-        
+        }
+
         ic -= 1;
         while(ic>=start && (ic>=capture.length || capture[ic]>=pattern.length)) {
             ic -= 1;
@@ -5923,7 +5923,7 @@ function matchType(wantedType,exprTree) {
     }
 }
 
-/** Match all of the given patterns against the given expression. 
+/** Match all of the given patterns against the given expression.
  * Return `false` if any of the patterns don't match.
  * @param {Array.<Numbas.jme.tree>} patterns
  * @param {Numbas.jme.tree} exprTree
@@ -6044,7 +6044,7 @@ var transform = jme.rules.transform = function(ruleTree,resultTree,exprTree,opti
 var transformAll = jme.rules.transformAll = function(ruleTree,resultTree,exprTree,options) {
     var changed = false;
     if(exprTree.args) {
-        var args = exprTree.args.map(function(arg){ 
+        var args = exprTree.args.map(function(arg){
             var o = transformAll(ruleTree,resultTree,arg,options);
             changed = changed || o.changed;
             return  o.expression;
@@ -6075,7 +6075,7 @@ patternParser.addPostfixOperator('`?','`?',{precedence: 0.5});  // optional
 patternParser.addPostfixOperator('`*','`*',{precedence: 0.5}); // any number of times
 patternParser.addPostfixOperator('`+','`+',{precedence: 0.5}); // at least one time
 
-patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not 
+patternParser.addPrefixOperator('`!','`!',{precedence: 0.5});  // not
 patternParser.addPrefixOperator('`+-','`+-',{precedence: 0.5});  // unary plus or minus
 patternParser.addPrefixOperator('`*/','`*/',{precedence: 0.5});  // unary multiply or divide
 
@@ -6155,7 +6155,7 @@ Ruleset.prototype = /** @lends Numbas.jme.rules.Ruleset.prototype */ {
             return false;
     },
 
-    /** Apply this set's rules to the given expression until they don't change any more 
+    /** Apply this set's rules to the given expression until they don't change any more
      * @param {Numbas.jme.tree} exprTree
      * @param {Numbas.jme.Scope} scope
      * @see Numbas.jme.rules.transform
@@ -6727,7 +6727,7 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
         settings = util.extend_object({},default_settings,settings);
         var checkingFunction = checkingFunctions[settings.checkingType.toLowerCase()];    //work out which checking type is being used
         try {
-            if(tree1 == null || tree2 == null) {    
+            if(tree1 == null || tree2 == null) {
                 //one or both expressions are invalid, can't compare
                 return false;
             }
@@ -6742,7 +6742,7 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
                 if( !varnamesAgree(vars1,vars2) ) {    //whoops, differing variables
                     return false;
                 }
-            } else { 
+            } else {
                 vars2.forEach(function(n) {
                     if(vars1.indexOf(n)==-1) {
                         vars1.push(n);
@@ -6759,8 +6759,8 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
                 var nscope = new jme.Scope([scope,{variables:rs[i]}]);
                 var r1 = nscope.evaluate(tree1);
                 var r2 = nscope.evaluate(tree2);
-                if( !resultsEqual(r1,r2,checkingFunction,settings.checkingAccuracy) ) { 
-                    errors++; 
+                if( !resultsEqual(r1,r2,checkingFunction,settings.checkingAccuracy) ) {
+                    errors++;
                 }
             }
             return errors < failureRate;
@@ -7265,7 +7265,7 @@ var jme = Numbas.jme = /** @lends Numbas.jme */ {
 /** A parser for {@link JME} expressions
  * @memberof Numbas.jme
  * @constructor
- * 
+ *
  * @param {Numbas.jme.parser_options} options
  */
 var Parser = jme.Parser = function(options) {
@@ -7377,7 +7377,7 @@ jme.Parser.prototype = /** @lends Numbas.jme.Parser.prototype */ {
      */
     ops: ['not','and','or','xor','implies','isa','except','in','divides','as','..','#','<=','>=','<>','&&','||','|','*','+','-','/','^','<','>','=','!','&','÷','×','∈','∧','∨','⟹','≠','≥','≤'],
 
-    /** Regular expressions to match tokens 
+    /** Regular expressions to match tokens
      * @type {Object.<RegExp>}
      */
     re: {
@@ -7713,7 +7713,7 @@ jme.Parser.prototype = /** @lends Numbas.jme.Parser.prototype */ {
             if(!tok.prefix) {
                 var o1 = this.getPrecedence(tok.name);
                 //while ops on stack have lower precedence, pop them onto output because they need to be calculated before this one. left-associative operators also pop off operations with equal precedence
-                
+
                 /** Should the next token on the stack be popped off?
                  * @returns {Boolean}
                  */
@@ -8221,13 +8221,13 @@ Scope.prototype = /** @lends Numbas.jme.Scope.prototype */ {
             if(fn.typecheck(args)) {
                 var match = fn.intype(args);
                 var k = 0;
-                var exact_match = match.every(function(m,i) { 
+                var exact_match = match.every(function(m,i) {
                     if(m.missing) {
                         return;
                     }
                     var ok = args[k].type==m.type;
                     k += 1;
-                    return ok; 
+                    return ok;
                 });
                 if(exact_match) {
                     return {fn: fn, signature: match};
@@ -8447,7 +8447,7 @@ Scope.prototype = /** @lends Numbas.jme.Scope.prototype */ {
                         }
                         var arg = eargs[j];
                         if(signature[i]) {
-                            castargs.push(jme.castToType(arg,signature[i])); 
+                            castargs.push(jme.castToType(arg,signature[i]));
                         } else {
                             castargs.push(arg);
                         }
@@ -8525,7 +8525,7 @@ var TNum = types.TNum = function(num) {
 }
 jme.registerType(
     TNum,
-    'number', 
+    'number',
     {
         'decimal': function(n) {
             var dp = 14;
@@ -9119,7 +9119,7 @@ var funcObj = jme.funcObj = function(name,intype,outcons,fn,options)
     this.id = funcObjAcc++;
     options = options || {};
 
-    /** Parse a signature definition. 
+    /** Parse a signature definition.
      * @param {String|Function} sig - either a string consisting of a variable name optionally followed by '*' and/or '?', a {@link Numbas.jme.token} constructor, or a {@link Numbas.jme.signature} function.
      * @returns {Numbas.jme.signature}
      */
@@ -9321,7 +9321,7 @@ var checkingFunctions = jme.checkingFunctions =
         tolerance = Math.floor(Math.abs(tolerance));
         return math.eq( math.precround(r1,tolerance), math.precround(r2,tolerance) );
     },
-    /** Round both values to `tolerance` significant figures, and fail if unequal. 
+    /** Round both values to `tolerance` significant figures, and fail if unequal.
      * @param {Number} r1
      * @param {Number} r2
      * @param {Number} tolerance
@@ -9504,7 +9504,7 @@ var resultsEqual = jme.resultsEqual = function(r1,r2,checkingFunction,checkingAc
 /** List names of variables used in `tree`, obtained by depth-first search.
  *
  * Differs from {@link Numbas.jme.findvars} by including duplicates, and ignoring {@link Numbas.jme.findvarsOps}.
- * 
+ *
  * @memberof Numbas.jme
  * @method
  * @param {Numbas.jme.tree} tree
@@ -13408,7 +13408,7 @@ var jmeRealNumber = jme.display.jmeRealNumber = function(n,settings)
         im += im.match(/\d$/) ? 'i' : '*i';
         if(Math.abs(n.im)<1e-15) {
             return re;
-        } 
+        }
         else if(n.re==0)
         {
             if(n.im==1)
@@ -13492,7 +13492,7 @@ var jmeDecimal = jme.display.jmeDecimal = function(n,settings)
         var re = jmeDecimal(n.re);
         if(n.isReal()) {
             return re;
-        } 
+        }
         var im = jmeDecimal(n.im)+'*i';
         if(n.re.isZero()) {
             if(n.im.eq(1))
@@ -13830,7 +13830,7 @@ var align_text_blocks = jme.display.align_text_blocks = function(header,items) {
         }
         return line;
     }
-    
+
     var item_lines = items.map(function(item){return item.split('\n')});
     var item_widths = item_lines.map(function(lines) {return lines.reduce(function(m,l){return Math.max(l.length,m)},0)});
     var num_lines = item_lines.reduce(function(t,ls){return Math.max(ls.length,t)},0);
@@ -15807,7 +15807,7 @@ var Question = Numbas.Question = function( number, exam, group, gscope, store)
 Question.prototype = /** @lends Numbas.Question.prototype */
 {
     /** Signals produced while loading this question.
-     * @type {Numbas.schedule.SignalBox} 
+     * @type {Numbas.schedule.SignalBox}
      * */
     signals: undefined,
 
@@ -16221,7 +16221,7 @@ Question.prototype = /** @lends Numbas.Question.prototype */
     leave: function() {
     this.display && this.display.leave();
     },
-    /** Execute the question's JavaScript preamble - should happen as soon as the configuration has been loaded from XML, before variables are generated. 
+    /** Execute the question's JavaScript preamble - should happen as soon as the configuration has been loaded from XML, before variables are generated.
      * @fires Numbas.Question#preambleRun
      */
     runPreamble: function() {
@@ -16522,7 +16522,7 @@ Numbas.Exam = Exam;
 
 Exam.prototype = /** @lends Numbas.Exam.prototype */ {
     /** Signals produced while loading this exam.
-     * @type {Numbas.schedule.SignalBox} 
+     * @type {Numbas.schedule.SignalBox}
      * */
     signals: undefined,
 
@@ -16531,7 +16531,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
      */
     store: undefined,
 
-    /** How was the exam started? 
+    /** How was the exam started?
      * One of: `ab-initio`, `resume`, or `review`
      * @type {String}
      */
@@ -16712,7 +16712,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
             exam.signals.trigger('ready');
         });
     },
-    /** Restore previously started exam from storage 
+    /** Restore previously started exam from storage
      * @fires Numbas.Exam#event:ready
      * @listens Numbas.Exam#event:question list initialised
      */
@@ -17809,10 +17809,10 @@ Numbas.queueScript('marking',['util', 'jme','localisation','jme-variables','math
 
 
     /** A JME scope with marking state attached.
-     *  The "current" state is a list of feedback items. 
+     *  The "current" state is a list of feedback items.
      *  The scope can also refer to previously computed states by name.
      *  The state can be modified by functions as they are called.
-     *  This should be the base 
+     *  This should be the base
      *
      *  @memberof Numbas.marking
      *  @augments Numbas.jme.Scope
@@ -17833,7 +17833,7 @@ Numbas.queueScript('marking',['util', 'jme','localisation','jme-variables','math
             scope.addFunction(fn);
         });
     }
-    StatefulScope.prototype = /** @lends Numbas.marking.StatefulScope.prototype */ { 
+    StatefulScope.prototype = /** @lends Numbas.marking.StatefulScope.prototype */ {
         evaluate: function(expr, variables) {
             var is_top = this.state===undefined || this.nesting_depth==0;
             this.nesting_depth += 1;
@@ -17873,7 +17873,7 @@ Numbas.queueScript('marking',['util', 'jme','localisation','jme-variables','math
      *  @property {Numbas.marking.note_definition} expr - The JME expression to evaluate to compute this note.
      *  @property {Numbas.jme.tree} tree - The compiled form of the expression
      *  @property {String[]} vars - The names of the variables this note depends on
-     *  
+     *
      *  @param {JME} source
      */
     var MarkingNote = marking.MarkingNote = function(source) {
@@ -17916,13 +17916,13 @@ Numbas.queueScript('marking',['util', 'jme','localisation','jme-variables','math
      *  A list of notes, which can refer to each other. The dependencies must form a directed acyclic graph, like for JME variables.
      *
      *  Two notes are required:
-     *  
+     *
      *  * The `mark` note is the final note, used to provide feedback on the part.
      *  * The value of the `interpreted_answer` note is used to represent the student's answer, as the script interpreted it.
-     *  
+     *
      *  @memberof Numbas.marking
      *  @constructor
-     *  
+     *
      *  @param {String} source - The definitions of the script's notes.
      *  @param {Numbas.marking.MarkingScript} [base] - a base script to extend.
      *
@@ -19479,7 +19479,7 @@ if (!Object.entries) {
         resArray = new Array(i); // preallocate the Array
     while (i--)
       resArray[i] = [ownProps[i], obj[ownProps[i]]];
-    
+
     return resArray;
   };
 }
@@ -24665,7 +24665,7 @@ JMEPart.prototype = /** @lends Numbas.JMEPart.prototype */
         var parametersPath = 'answer';
         tryGetAttribute(settings,xml,parametersPath+'/checking',['type','accuracy','failurerate'],['checkingType','checkingAccuracy','failureRate']);
         tryGetAttribute(settings,xml,parametersPath+'/checking/range',['start','end','points'],['vsetRangeStart','vsetRangeEnd','vsetRangePoints']);
-        
+
         var valueGeneratorsNode = xml.selectSingleNode('answer/checking/valuegenerators');
         if(valueGeneratorsNode) {
             var valueGenerators = valueGeneratorsNode.selectNodes('generator');
@@ -25566,7 +25566,7 @@ MultipleResponsePart.prototype = /** @lends Numbas.parts.MultipleResponsePart.pr
         settings.matrix = matrix;
         return settings.maxMatrix;
     },
-    /** Store the student's choices 
+    /** Store the student's choices
      * @param {Object} answer - object with properties `answer` and `choice`, giving the index of the chosen item
      * */
     storeTick: function(answer)

--- a/tests/numbas-runtime.js
+++ b/tests/numbas-runtime.js
@@ -6121,7 +6121,8 @@ var displayFlags = jme.rules.displayFlags = {
     fractionnumbers: undefined,
     rowvector: undefined,
     alwaystimes: undefined,
-    mixedfractions: undefined
+    mixedfractions: undefined,
+    flatfractions: undefined
 };
 /** Flags used in JME simplification rulesets
  * @type Object.<Boolean>
@@ -6129,6 +6130,7 @@ var displayFlags = jme.rules.displayFlags = {
  * @property {Boolean} fractionnumbers - Show all numbers as fractions?
  * @property {Boolean} rowvector - Display vectors as a horizontal list of components?
  * @property {Boolean} alwaystimes - Always show the multiplication symbol between multiplicands?
+ * @property {Boolean} flatfractions - Display fractions horizontally?
  * @see Numbas.jme.rules.Ruleset
  */
 /** Set of simplification rules
@@ -12494,7 +12496,18 @@ var texOps = jme.display.texOps = {
         }
         return s;
     }),
-    '/': (function(thing,texArgs) { return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }'); }),
+    '/': (function(thing,texArgs,settings) {
+        if (settings.flatfractions) {
+            for (var i=0; i<2; i++) {
+                // identifying if the numerator and denominator need brackets around them by
+                // checking whether they contain whitespaces
+                if (texArgs[i].includes(' ')) texArgs[i] = '(' + texArgs[i] + ')'
+            }
+            return ('\\left. '+texArgs[0]+' \\middle/ '+texArgs[1]+' \\right.');
+        } else {
+            return ('\\frac{ '+texArgs[0]+' }{ '+texArgs[1]+' }');
+        }
+    }),
     '+': (function(thing,texArgs,settings) {
         var a = thing.args[0];
         var b = thing.args[1];


### PR DESCRIPTION
This addresses issue #626 

The flatFractions display flag is used to display fractions horizontally, it renders them as Latex: `\left. numerator \middle/ denominator \right.`.

Sometimes, the numerator or denominator contain other operations, and it's nice to display brackets around them to make it clear that for example in `(a + b)/4` the complete numerator is `a + b`. To identify these cases, I looked for a whitespace in the numerator and denominator. This solution might not be very elegant and although I've tested it with several situations, I might be forgetting some edge cases. Tell me what you think of it.

Also, my editor linted and removed trailing whitespaces in the modified files. I've put this in two separate commits, so that it is easy to revert if you'd rather not include this in the PR. I also advise you to read the PR commit by commit as this linting thing is hiding the main changes I've made.