### PR TITLE
Remove MathJax webfont

### DIFF
--- a/themes/default/templates/scripts.html
+++ b/themes/default/templates/scripts.html
@@ -10,9 +10,7 @@
             processEscapes: true
         },
         "HTML-CSS": {
-            mtextFontInherit: true,
-            preferredFont: 'Latin-Modern',
-            webFont: 'Latin-Modern'
+            mtextFontInherit: true
         },
         skipStartupTypeset: true,
         displayAlign: "center",


### PR DESCRIPTION
Webfont is no longer required, and caused trouble with older browsers.