### PR TITLE
Make the HTMLAttached trigger behave as documented

### DIFF
--- a/runtime/scripts/exam.js
+++ b/runtime/scripts/exam.js
@@ -585,7 +585,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
      * @param {boolean} loading
      * @fires Numbas.Exam#event:question list initialised
      * @listens Numbas.Question#event:ready
-     * @listens Numbas.Question#event:HTMLAttached
+     * @listens Numbas.Question#event:partsHTMLAttached
      */
     makeQuestionList: function(loading)
     {
@@ -632,7 +632,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
             }).catch(function(e) {
                 Numbas.schedule.halt(e);
             });
-            Promise.all(exam.questionList.map(function(q){ return q.signals.on(['ready','HTMLAttached']) })).then(function() {
+            Promise.all(exam.questionList.map(function(q){ return q.signals.on(['ready','partsHTMLAttached']) })).then(function() {
                 //register questions with exam display
                 exam.display.initQuestionList();
                 exam.signals.trigger('display question list initialised');
@@ -887,7 +887,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
      * Regenerate the current question.
      *
      * @listens Numbas.Question#event:ready
-     * @listens Numbas.Question#event:HTMLAttached
+     * @listens Numbas.Question#event:partsHTMLAttached
      */
     regenQuestion: function()
     {
@@ -904,7 +904,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
             e.changeQuestion(n);
             e.updateScore();
         });
-        q.signals.on(['ready','HTMLAttached'], function() {
+        q.signals.on(['ready','partsHTMLAttached'], function() {
             e.currentQuestion.display.init();
             e.display.showQuestion();
             e.display.endRegen();

--- a/runtime/scripts/part.js
+++ b/runtime/scripts/part.js
@@ -394,7 +394,7 @@ Part.prototype = /** @lends Numbas.parts.Part.prototype */ {
             }
         });
         this.display && this.display.updateNextParts();
-        this.display && this.question && this.question.signals.on(['ready','HTMLAttached'], function() {
+        this.display && this.question && this.question.signals.on(['ready','partsHTMLAttached'], function() {
             part.display.restoreAnswer(part.resume_stagedAnswer!==undefined ? part.resume_stagedAnswer : part.studentAnswer);
         })
         this.resuming = false;

--- a/runtime/scripts/question.js
+++ b/runtime/scripts/question.js
@@ -171,6 +171,14 @@ var Question = Numbas.Question = function( number, exam, group, gscope, store)
  */
 /** The question's HTML has been generated and attached to the page.
  *
+ * @event Numbas.Question#mainHTMLAttached
+ */
+/** Each part's HTML has been generated and attached to each part.
+ *
+ * @event Numbas.Question#partsHTMLAttached
+ */
+/** The entire question, including each part's HTML, has been generated and attached to the page.
+ *
  * @event Numbas.Question#HTMLAttached
  */
 
@@ -692,7 +700,7 @@ Question.prototype = /** @lends Numbas.Question.prototype */
         q.signals.on('ready',function() {
             q.updateScore();
         });
-        q.signals.on(['ready','HTMLAttached'], function() {
+        q.signals.on(['ready','partsHTMLAttached'], function() {
             q.display && q.display.showScore();
         });
     },

--- a/themes/default/files/scripts/question-display.js
+++ b/themes/default/files/scripts/question-display.js
@@ -310,6 +310,19 @@ Numbas.queueScript('question-display',['display-base','jme-variables','xml','sch
             return css;
         },this);
 
+        /** Called when the DOM has finished binding all the
+         * question parts.
+         * @memberof Numbas.display.QuestionDisplay
+         */
+        this.partsBound = function(nodes) {
+            q.signals.trigger('partsBound');
+        };
+        q.signals.on('partsBound', function() {
+            // Backwards compatibility: an event triggered on the body element when a question's HTML is attached.
+            // Deprecated because there's no way of saying
+            $('body').trigger('question-html-attached',[q,qd]);
+        });
+
         /** A promise resolving to the question's HTML element.
          *
          * @see Numbas.display.makeHTMLFromXML
@@ -326,11 +339,6 @@ Numbas.queueScript('question-display',['display-base','jme-variables','xml','sch
             Promise.all([qd.html_promise].concat(qd.parts().map(function(pd) { return pd.html_promise; }))).then(function() {
                 q.signals.trigger('HTMLAttached');
             })
-        });
-        q.signals.on('HTMLAttached', function() {
-            // Backwards compatibility: an event triggered on the body element when a question's HTML is attached.
-            // Deprecated because there's no way of saying
-            $('body').trigger('question-html-attached',[q,qd]);
         });
     }
     display.QuestionDisplay.prototype = /** @lends Numbas.display.QuestionDisplay.prototype */

--- a/themes/default/files/scripts/question-display.js
+++ b/themes/default/files/scripts/question-display.js
@@ -315,9 +315,9 @@ Numbas.queueScript('question-display',['display-base','jme-variables','xml','sch
          * @memberof Numbas.display.QuestionDisplay
          */
         this.partsBound = function(nodes) {
-            q.signals.trigger('partsBound');
-        };
-        q.signals.on('partsBound', function() {
+            q.signals.trigger('HTMLAttached');
+        }
+        q.signals.on('HTMLAttached',function() {
             // Backwards compatibility: an event triggered on the body element when a question's HTML is attached.
             // Deprecated because there's no way of saying
             $('body').trigger('question-html-attached',[q,qd]);
@@ -337,7 +337,7 @@ Numbas.queueScript('question-display',['display-base','jme-variables','xml','sch
         });
         q.signals.on('partsGenerated',function() {
             Promise.all([qd.html_promise].concat(qd.parts().map(function(pd) { return pd.html_promise; }))).then(function() {
-                q.signals.trigger('HTMLAttached');
+                q.signals.trigger('partsHTMLAttached');
             })
         });
     }

--- a/themes/default/templates/question.xslt
+++ b/themes/default/templates/question.xslt
@@ -47,8 +47,10 @@ Copyright 2011-16 Newcastle University
         </xsl:copy>
     </xsl:template>
     <xsl:template match="parts">
-        <div class="parts" data-bind="foreach: parts">
-            <div data-bind="promise: html_promise"></div>
+        <div data-bind="descendantsComplete: partsBound">
+            <div class="parts" data-bind="foreach: parts">
+                <div data-bind="promise: html_promise"></div>
+            </div>
         </div>
     </xsl:template>
     <xsl:template match="part">


### PR DESCRIPTION
`HTMLAttached` does not currently behave as documented. When `HTMLAttached` triggers, the `question.display.html` property does not contain the individual question parts' HTML, even though each part's HTML is available in the `part.display.html` property.

This pull request rewrites `HTMLAttached` so that it triggers after we receive a `descendantsComplete` event from Knockout<sup>1</sup>, indicating that the DOM has finished binding. With this change `question.display.html` also contains each part's HTML when the `HTMLAttached` signal is triggered.

1: https://knockoutjs.com/documentation/binding-lifecycle-events.html