### PR TITLE
Issue 515 confirm end

### DIFF
--- a/runtime/scripts/exam.js
+++ b/runtime/scripts/exam.js
@@ -946,7 +946,8 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
         else if(!submittedAll) {
             message = R('control.not all questions submitted') + '<br/>' + message;
         }
-        Numbas.display.showConfirm(
+        message = message + '<br/>' + 'Type "end" into the textbox to confirm you want to end the exam'; 
+        Numbas.display.confirmEndExam(
             message,
             function() {
                 job(exam.end,exam,true);
@@ -960,6 +961,10 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
      */
     end: function(save)
     {
+        textbox_value = document.getElementById('confirm_end').value
+        if (textbox_value === "end"){
+
+        
         this.mode = 'review';
         //work out summary info
         this.passed = (this.percentScore >= this.settings.percentPass*100);
@@ -1005,6 +1010,10 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
             this.revealAnswers();
         }
         this.display && this.display.showInfoPage( 'result' );
+    }
+    else{
+        Numbas.display.confirmEndExam()
+    }
     },
     /** Reveal the answers to every question in the exam.
      */

--- a/runtime/scripts/exam.js
+++ b/runtime/scripts/exam.js
@@ -1011,9 +1011,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
         }
         this.display && this.display.showInfoPage( 'result' );
     }
-    else{
-        Numbas.display.confirmEndExam()
-    }
+
     },
     /** Reveal the answers to every question in the exam.
      */

--- a/tests/python/confirm_end_tests.py
+++ b/tests/python/confirm_end_tests.py
@@ -1,0 +1,120 @@
+import requests
+import selenium
+from selenium import webdriver
+import unittest
+import rstr
+
+
+
+def enter_value(textbox_value):
+        # Once you login, you have to click through a few buttons
+        # First click the start button to launch the exam
+        driver = webdriver.Chrome()
+        driver.get("r.url")
+        start_button = driver.driver.find_element_by_id("startBtn")
+        start_button.click()
+
+        # Next you have to click the end button to end the exam and access my feature
+        end_button = driver.driver.find_element_by_id("endBtn")
+        end_button.click()
+
+        inputElement = driver.find_element_by_id("confirm_end")
+        inputElement.send_keys(textbox_value)
+        
+        finished_exam_succesfully = True
+        try:
+            finished_exam_text = driver.driver.find_element_by_class("btn btn-link review")
+            finished_exam_succesfully = True
+        Exception:
+            finished_exam_succesfully = False
+
+
+# Test to confirm that the additional functions which I added do not break the ability to reach the server
+def test_confirm_connection():
+    url = 'http://localhost:8000/exam/login'
+    with requests.Session() as s:
+        s.get(url)
+        if 'csrftoken' in s.cookies:
+        # Django 1.6 and up
+            csrftoken = s.cookies['csrftoken']
+        else:
+        # older versions
+            csrftoken = s.cookies['csrf']
+
+        login_data = dict(username="vnathan", password="napoleon123", csrfmiddlewaretoken=csrftoken, next='/')
+        r = s.post(url, data=login_data, headers=dict(Referer=url))
+        assert(r.url, 'http://localhost:8000/exam/1/test-exam/preview/')
+
+
+def test_confirm_type_end():
+
+    # This test checks to see if my new functionality works.
+    #It enters end into the textbox, and then checks to see if you have moved on to the next page
+
+    url = 'http://localhost:8000/exam/login'
+    with requests.Session() as s:
+        s.get(url)
+        if 'csrftoken' in s.cookies:
+        # Django 1.6 and up
+            csrftoken = s.cookies['csrftoken']
+        else:
+        # older versions
+            csrftoken = s.cookies['csrf']
+
+        login_data = dict(username="vnathan", password="napoleon123", csrfmiddlewaretoken=csrftoken, next='/')
+        r = s.post(url, data=login_data, headers=dict(Referer=url))
+
+
+        # Once you login, you have to click through a few buttons
+        # First click the start button to launch the exam
+        driver = webdriver.Chrome()
+        driver.get("r.url")
+        start_button = driver.driver.find_element_by_id("startBtn")
+        start_button.click()
+
+        # Next you have to click the end button to end the exam and access my feature
+        end_button = driver.driver.find_element_by_id("endBtn")
+        end_button.click()
+
+        inputElement = driver.find_element_by_id("confirm_end")
+        inputElement.send_keys('end')
+        
+        finished_exam_succesfully = True
+        try:
+            finished_exam_text = driver.driver.find_element_by_class("btn btn-link review")
+            finished_exam_succesfully = True
+        Exception:
+            finished_exam_succesfully = False
+        assert (finished_exam_succesfully, True)
+
+def test_confirm_fuzzer_values():
+
+    status_list = []
+    random_string_list = []
+    for i in range (0,10000):
+        random_string_list.append(rstr.rstr(string.printable))
+
+    for fuzzed_input in random_string.printable():
+        url = 'http://localhost:8000/exam/login'
+        with requests.Session() as s:
+            s.get(url)
+            if 'csrftoken' in s.cookies:
+            # Django 1.6 and up
+                csrftoken = s.cookies['csrftoken']
+            else:
+            # older versions
+                csrftoken = s.cookies['csrf']
+
+            login_data = dict(username="vnathan", password="napoleon123", csrfmiddlewaretoken=csrftoken, next='/')
+            r = s.post(url, data=login_data, headers=dict(Referer=url))
+            enter_value(fuzzed_input)
+            r = requests.get('http://localhost:8000/exam/1/test-exam/preview/')
+            status_list.append(r.status)
+    is_ok = True
+    for stat in status_list:
+        if stat != 200:
+            is_ok = False
+    assert(is_ok, True)
+            
+    
+

--- a/themes/default/files/scripts/display-base.js
+++ b/themes/default/files/scripts/display-base.js
@@ -222,6 +222,20 @@ var display = Numbas.display = /** @lends Numbas.display */ {
         $('#confirm-modal .modal-body').html(msg);
         $('#confirm-modal').modal('show');
     },
+
+    /** Show a confirmation dialog box.
+     *
+     * @param {string} msg - message to show the user
+     * @param {Function} fnOK - callback if OK is clicked
+     * @param {Function} fnCancel - callback if cancelled
+     */
+     confirmEndExam: function(msg,fnOK,fnCancel) {
+        this.modal.ok = fnOK || function(){};
+        this.modal.cancel = fnCancel || function(){};
+        $('#end-exam-modal .modal-body').html(msg);
+        $('#end-exam-modal').modal('show');
+    },
+
     /** Make MathJax typeset any maths in the selector.
      *
      * @param {jQuery|Element} [selector] - Elements to typeset. If not given, the whole page is typeset.

--- a/themes/default/templates/modals.html
+++ b/themes/default/templates/modals.html
@@ -30,6 +30,25 @@
     </div>
 </div>
 
+<div class="modal fade" id="end-exam-modal" tabindex="-1" aria-role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+            </div>
+            <div class="modal-footer">
+                <input type="text" id="confirm_end" placeholder="end">
+                <br>
+                <br>
+                <button type="button" class="cancel btn btn-default" data-dismiss="modal" data-localise="modal.cancel"></button>
+                <button type="button" class="ok btn btn-primary" data-dismiss="modal" data-localise="modal.ok"></button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="modal fade" id="style-modal" tabindex="-1" aria-role="dialog" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">


### PR DESCRIPTION
#515 

This pull request was created in response to issue 515 "Force students to type something to enter exam"

The goal of this pull request was to make sure that students did not carelessly end the exam.

In order to fix this issue, I made it mandatory to type "end" into a text box before you could click the "ok" button when you end the exam

I made 3 majors changes as suggested by the origin poster

1. In themes/default/files/scripts/display-base.js, I added a new modal, which includes a text box where a student can type "end" before ending the exam
2. I added a new function to themes/default/files/scripts/display-base.js called confirmEndExam. This function is called in runtime/scripts/exam.js rather than the function showConfirm.
3. I edited runtime/scripts/exam.js in two places. First, I changed the showConfirm function to confirmEndExam, and next I created a guard so that the end function could only trigger if the word "end" was written in the text box.