### PR TITLE
add "interpreted as" before the JME answer preview

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -6,6 +6,7 @@
     "answer.matrix.some cell not a number": "One or more of the cells in your answer is not a valid number.",
     "page.loading": "Loading...",
     "page.saving": "<p>Saving.</p>\n<p>This might take a few seconds.</p>",
+    "page.skip to content": "Skip to content",
     "mathjax.math processing error": "\"{{-message}}\" when texifying <code>{{expression}}</code>",
     "mathjax.error": "MathJax processing error: {{-message}}",
     "mathjax.error with context": "MathJax processing error in {{-context}}: {{-message}}",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -146,6 +146,7 @@
     "jme.display.simplifyTree.empty expression": "Expression is empty",
     "jme.display.simplifyTree.stuck in a loop": "Simplifier is stuck in a loop: <code>{{expr}}</code>",
     "jme.calculus.unknown derivative": "Don't know how to differentiate <code>{{tree}}</code>",
+    "jme.interpreted as": "interpreted as",
     "math.precround.complex": "Can't round to a complex number of decimal places",
     "math.siground.complex": "Can't round to a complex number of sig figs",
     "math.combinations.complex": "Can't compute combinations of complex numbers",

--- a/themes/default/files/resources/exam.css
+++ b/themes/default/files/resources/exam.css
@@ -1003,6 +1003,19 @@ body.navigate-sequence .question-header {
     display: none;
 }
 
+.sr-only#skip-link:focus {
+  top: 0;
+  left: 0;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 0.5em;
+  background: var(--main-colour);
+  z-index: 2000;
+  color: black;
+  clip: initial;
+}
+
 @media print {
     body.no-printing #questionContainer {
         display: none;

--- a/themes/default/templates/index.html
+++ b/themes/default/templates/index.html
@@ -25,6 +25,7 @@ Copyright 2011-16 Newcastle University
         {% include 'loading.html' %}
 
 		<div id="everything" style="display:none">
+            <a class="sr-only" id="skip-link" data-bind="attr: {href: infoPage() ? '#infoDisplay' : '#questionDisplay'}" data-localise="page.skip to content"></a>
             {% include 'nav.html' %}
 
             <!-- main content area - info pages or questions go in here -->

--- a/themes/default/templates/index.html
+++ b/themes/default/templates/index.html
@@ -24,16 +24,16 @@ Copyright 2011-16 Newcastle University
         {% include 'die.html' %}
         {% include 'loading.html' %}
 
-		<main id="everything" style="display:none" role="main">
+		<div id="everything" style="display:none">
             {% include 'nav.html' %}
 
             <!-- main content area - info pages or questions go in here -->
-            <div class="mainDisplay">
+            <main class="mainDisplay" role="main">
                 {% include 'infopage.html' %}
 
                 {% include 'question.html' %}
-            </div>
-		</main>
+            </main>
+		</div>
 
         {% include 'footer.html' %}
 

--- a/themes/default/templates/nav.html
+++ b/themes/default/templates/nav.html
@@ -4,9 +4,9 @@
         <nav id="navMenu" class="navmenu navmenu-default navmenu-fixed-left offcanvas-sm" role="navigation">
 
             <div class="navmenu-header clearfix">
-                <a class="navmenu-brand">
+                <div class="navmenu-brand">
                     {% include "logo.html" %}
-                </a>
+                </div>
                 <p class="exam-name navmenu-brand" data-bind="text: exam.settings.name, typeset: exam.settings.name"></p>
             </div>
 

--- a/themes/default/templates/xslt/parts/jme.xslt
+++ b/themes/default/templates/xslt/parts/jme.xslt
@@ -2,7 +2,10 @@
 <xsl:template match="part[@type='jme']" mode="typespecific">
     <xsl:if test="count(steps/part)>0"><localise>part.with steps answer prompt</localise></xsl:if>
     <input type="text" autocapitalize="off" inputmode="text" spellcheck="false" class="jme" data-bind="event: inputEvents, textInput: studentAnswer, autosize: true, disable: disabled, attr: {{title: input_title}}"/>
-    <span class="jme-preview" data-bind="visible: showPreview &amp;&amp; studentAnswerLaTeX(), maths: showPreview ? '\\displaystyle{{'+studentAnswerLaTeX()+'}}' : '', click: focusInput"></span>
+    <span class="jme-preview" data-bind="visible: showPreview &amp;&amp; studentAnswerLaTeX()">
+        <span class="sr-only"><localise>jme.interpreted as</localise></span>
+        <span aria-live="polite" data-bind="maths: showPreview ? '\\displaystyle{{'+studentAnswerLaTeX()+'}}' : '', click: focusInput"></span>
+    </span>
 {% endraw %}
     {% include 'xslt/feedback_icon.xslt' %}
 {% raw %}
@@ -12,7 +15,10 @@
         <label>
             <localise>part.correct answer</localise>
             <input type="text" autocapitalize="off" inputmode="text" spellcheck="false" disabled="true" class="jme" data-bind="value: correctAnswer, autosize: true"/>
-            <span class="jme-preview" aria-live="polite" data-bind="maths: '\\displaystyle{{'+correctAnswerLaTeX()+'}}'"></span>
+            <span class="jme-preview" aria-live="polite">
+                <span class="sr-only"><localise>jme.interpreted as</localise></span>
+                <span aria-live="polite" data-bind="maths: '\\displaystyle{{'+correctAnswerLaTeX()+'}}'"></span>
+            </span>
         </label>
     </span>
 </xsl:template>


### PR DESCRIPTION
this adds the screenreader-only text "interpreted as" to the start of
the JME preview box. Both the box and the MathJax part are marked as
aria-live="polite" - need to test with a screenreader to establish if
this is right. I don't think it's helpful to keep reading out
"interpreted as" each time the maths changes, but it's needed when
reading through the page, to separate it from the input box.

see #831