### PR TITLE
added weighted_random function with signature (list of [item, probability]) to handle issue #839

### DIFF
--- a/runtime/scripts/jme-builtins.js
+++ b/runtime/scripts/jme-builtins.js
@@ -816,6 +816,7 @@ newBuiltin('sum',[sig.listof(sig.type('number'))],TNum,math.sum,{unwrapValues: t
 newBuiltin('sum',[TVector],TNum,math.sum);
 newBuiltin('prod',[sig.listof(sig.type('number'))],TNum,math.prod,{unwrapValues: true});
 newBuiltin('prod',[TVector],TNum,math.prod);
+newBuiltin('weighted_random',[[TNum,TNum]],TNum,math.weighted_random);
 newBuiltin('deal',[TNum],TList,
     function(n) {
         return math.deal(n).map(function(i) {

--- a/runtime/scripts/math.js
+++ b/runtime/scripts/math.js
@@ -1972,6 +1972,28 @@ var math = Numbas.math = /** @lends Numbas.math */ {
             product = math.mul(product, list[i]);
         }
         return product;
+    },
+    /** Weighted random given a list of [item, probability] 
+     * 
+     * @param {Array} list
+     * @returns {number}
+    */
+     weighted_random: function(list) {
+        var item;
+        var prob;
+        weights = new Map();
+        var probSum = 0;
+        for (var i = 0; i < list.length; i++) {
+            [item, prob] = list[i];
+            probSum += prob;
+            weights.set(probSum, item);
+        }
+        var target = Math.floor(Math.random() * probSum);
+        for (var key of weights.keys()) {
+            if (target < key) {
+                return weights.get(key);
+            }
+        }
     }
 };
 math.gcf = math.gcd;


### PR DESCRIPTION
Addresses issue #839 
Added weighted_random function to runtime/scripts/math.js with the function signature (list of [item, probability]) and defined a JME function in runtime/scripts/jme-builtins.js with input list of [TNum, TNum] and output of TNum. 
The weighted_random function can handle item of type int, float, string. Please let me know how we can add those to the JME function definition. 
I tested the weighted_random function logic externally but did not know how to write unit tests. Would love to learn how to do so. Hope this helps!