### PR TITLE
Add support for standalone_scripts folder in extensions.

### DIFF
--- a/bin/numbas.py
+++ b/bin/numbas.py
@@ -404,6 +404,11 @@ class NumbasCompiler(object):
         for dst,src in self.files.items():
             if os.path.splitext(dst)[1]!='.js':
                 continue
+
+            # Files in the 'standalone_scripts' folder of extensions should not be added to scripts.js but preserved
+            if os.path.normpath(dst).split(os.sep)[0:3:2] == ["extensions", "standalone_scripts"]:
+                continue
+
             if not dst.startswith('./standalone_scripts'):
                 javascripts.append((dst,src))
 


### PR DESCRIPTION
Sometimes it is useful to have js files in extensions that are not added to the script.js file. One example is when you use WebWorkers and they need to run a specific js file as used in my new extension https://github.com/jhoobergs/numbas-extension-sqlite/