### PR TITLE
Diagnosys: Also update state on exam end, when there is no more action

### DIFF
--- a/diagnostic_scripts/diagnosys.jme
+++ b/diagnostic_scripts/diagnosys.jme
@@ -93,6 +93,7 @@ next_actions (Actions to offer to the student when they ask to move on):
 
 after_exam_ended (Update the state after the exam ends):
     let(
+        state, after_answering,
         ntopics, map(t+["status": if(t["status"]="unknown","failed",t["status"])],t,state["topics"]),
         state+["finished": true]
     )


### PR DESCRIPTION
We found a bug in the diagnosys script where the progress and score is not updated after answering the last question.

The easiest way to test this is to take any diagnosys test and skip all question except the last one, answer that one correctly and you will see that you have no progress and points.

Adding this one line seems to fix the problem.