### PR TITLE
Save to store when ending a diagnostic test

### DIFF
--- a/runtime/scripts/exam.js
+++ b/runtime/scripts/exam.js
@@ -1200,7 +1200,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
         var question_number = data.number;
         var exam = this;
         if(topic_name===null) {
-            this.end();
+            this.end(true);
         } else {
             var group = this.question_groups.find(function(g) { return g.settings.name==topic_name; });
             var question = group.createQuestion(question_number);


### PR DESCRIPTION
Diagnostic tests that are ended when there are no more topics, don't seem to get the completed status in our lti provider.

I haven't tested this change, but I guess this could be the solution?

Might be related to https://github.com/numbas/numbas-lti-provider/issues/143