### PR TITLE
Fix issue #892: Throw an error if a marking parameter has the same name as a variable already defined in the scope

### DIFF
--- a/runtime/scripts/part.js
+++ b/runtime/scripts/part.js
@@ -1815,6 +1815,12 @@ if(res) { \
             if(pre_submit_result.waiting) {
                 return {waiting_for_pre_submit: pre_submit_result.waiting};
             }
+            var mark_parameters=this.marking_parameters(studentAnswer, pre_submit_result.parameters, exec_path);
+            Object.keys(mark_parameters).forEach(function(key){
+                if(scope[key]!==undefined){
+                    throw(new Numbas.Error("marking parameter already in scope"));
+                }
+            });
             var result = this.markingScript.evaluate(
                 scope,
                 this.marking_parameters(studentAnswer, pre_submit_result.parameters, exec_path)


### PR DESCRIPTION
I followed the recommended solution. 
Added a check in `mark_answers` function in part [runtime/scripts/part.js](https://github.com/numbas/Numbas/blob/master/runtime/scripts/part.js#L1810) : if an entry in the marking parameters object is defined in the scope, throw an error. 
