### PR TITLE
Defined Max and Min functions for Ranges

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -127,5 +127,6 @@
 * [Jesse Hoobergs](https://github.com/jhoobergs)
 * [Anurag Raut](https://github.com/Anurag-Raut) -([issue #1008](https://github.com/numbas/Numbas/issues/1008))
 * [Ioulia Lallou](https://github.com/itlallou) - ([issue #1031](https://github.com/numbas/Numbas/issues/1031))
+* [Kalanithi J P](https://github.com/Kalanithi96) - ([issue #1028](https://github.com/numbas/Numbas/issues/1028))
 
 * *Add your name here - [contribute to the Numbas project](http://www.numbas.org.uk/contributing-to-numbas/)!*

--- a/runtime/scripts/jme-builtins.js
+++ b/runtime/scripts/jme-builtins.js
@@ -683,6 +683,8 @@ newBuiltin('mod', [TNum,TNum], TNum, math.mod );
 newBuiltin('max', [TNum,TNum], TNum, math.max );
 newBuiltin('min', [TNum,TNum], TNum, math.min );
 newBuiltin('clamp',[TNum,TNum,TNum], TNum, function(x,min,max) { return math.max(math.min(x,max),min); });
+newBuiltin('max', [TRange], TNum, function(range) { return range[1]; });
+newBuiltin('min', [TRange], TNum, function(range) { return range[0]; });
 newBuiltin('max', [sig.listof(sig.type('number'))], TNum, math.listmax, {unwrapValues: true});
 newBuiltin('min', [sig.listof(sig.type('number'))], TNum, math.listmin, {unwrapValues: true});
 /**


### PR DESCRIPTION
This solves issue #1028 

The current implementation of Min and Max function for a Range:
1. Range is converted to List
1. Then it is sorted
1. Finally Min and Max are calculated as first and last elements respectively

This branch utilizes the following structure of a Range to return min and max:
```
var TRange = types.TRange = function(range) {
    this.value = range;
    if(this.value!==undefined)
    {
        this.start = this.value[0];
        this.end = this.value[1];
        this.step = this.value[2];
        this.size = Math.floor((this.end-this.start)/this.step);
    }
}
```
The Minimum of a `TRange range` is `range[0]` and
The Maximum of a `TRange range` is `range[1]`