### PR TITLE
Issue 506: Some options for what's shown on the results page

### DIFF
--- a/bin/exam.py
+++ b/bin/exam.py
@@ -320,7 +320,7 @@ class Exam(object):
         results_options = feedback.find('results_options')
         results_options.attrib = {
                 'resultsshowquestions': strcons_fix(self.resultsshowquestions),
-                'resultsshowadvice': strcons_fix(self.resultsshowquestions),
+                'resultsshowadvice': strcons_fix(self.resultsshowadvice),
         }
         feedbackmessages = feedback.find('feedbackmessages')
         for fm in self.feedbackMessages:

--- a/bin/exam.py
+++ b/bin/exam.py
@@ -142,6 +142,8 @@ class Exam(object):
     reviewshowfeedback = True       # show part feedback messages in review mode?
     reviewshowexpectedanswer = True # show expected answers in review mode?
     reviewshowadvice = True         # show question advice in review mode?
+    resultsshowquestions = True     # show questions on printed results page
+    resultsshowadvice = True        # show advice on printed results page
     feedbackMessages = []           # text shown on the results page when the student achieves a certain score
     showQuestionGroupNames = False  # show the names of question groups?
     showstudentname = True          # show the student's name?
@@ -208,6 +210,9 @@ class Exam(object):
             if haskey(data['feedback'],'advice'):
                 advice = data['feedback']['advice']
             tryLoad(data['feedback'],['intro','end_message'],exam,['intro','end_message'])
+            if haskey(data['feedback'],'results_options'):
+                results_options = data['feedback']['results_options']
+                tryLoad(results_options,['resultsshowquestions','resultsshowadvice'],exam)
             if haskey(data['feedback'],'feedbackmessages'):
                 exam.feedbackMessages = [builder.feedback_message(f) for f in data['feedback']['feedbackmessages']]
 
@@ -252,6 +257,7 @@ class Exam(object):
                                 ['feedback',
                                     ['intro'],
                                     ['end_message'],
+                                    ['results_options'],
                                     ['feedbackmessages'],
                                 ],
                                 ['rulesets'],
@@ -311,6 +317,11 @@ class Exam(object):
         }
         feedback.find('intro').append(makeContentNode(self.intro))
         feedback.find('end_message').append(makeContentNode(self.end_message))
+        results_options = feedback.find('results_options')
+        results_options.attrib = {
+                'resultsshowquestions': strcons_fix(self.resultsshowquestions),
+                'resultsshowadvice': strcons_fix(self.resultsshowquestions),
+        }
         feedbackmessages = feedback.find('feedbackmessages')
         for fm in self.feedbackMessages:
             feedbackmessages.append(fm.toxml())

--- a/runtime/scripts/exam.js
+++ b/runtime/scripts/exam.js
@@ -144,6 +144,7 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
                 'reviewShowAdvice'
             ]
         );
+        tryGetAttribute(settings,xml,'settings/feedback/results_options',['resultsshowquestions','resultsshowadvice']);
         var serializer = new XMLSerializer();
         var isEmpty = Numbas.xml.isEmpty;
         var introNode = this.xml.selectSingleNode(feedbackPath+'/intro/content/span');
@@ -249,6 +250,10 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
         if(feedback) {
             tryLoad(feedback,['showActualMark','showTotalMark','showAnswerState','allowRevealAnswer','adviceThreshold'], exam);
             tryLoad(feedback,['intro'],exam,['introMessage']);
+            var results_options = tryGet(feedback,'results_options')
+            if(results_options) {
+                tryLoad(results_options,['resultsshowquestions','resultsshowadvice'],settings);
+            }
             var feedbackmessages = tryGet(feedback,'feedbackmessages');
             if(feedbackmessages) {
                 feedbackmessages.forEach(function(d) {
@@ -379,6 +384,8 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
      * @property {boolean} reviewShowScore - Show student's score in review mode?
      * @property {boolean} reviewShowFeedback - Show part feedback messages in review mode?
      * @property {boolean} reviewShowAdvice - Show question advice in review mode?
+     * @property {boolean} resultsshowquestions - Show questions in printed results?
+     * @property {boolean} resultsshowadvice - Show advice in printed results?
      * @memberof Numbas.Exam
      * @instance
      */
@@ -415,6 +422,8 @@ Exam.prototype = /** @lends Numbas.Exam.prototype */ {
         reviewShowFeedback: true,
         reviewShowExpectedAnswer: true,
         reviewShowAdvice: true,
+        resultsshowquestions: true,
+        resultsshowadvice: true,
         diagnosticScript: 'diagnosys',
         customDiagnosticScript: ''
     },

--- a/themes/default/files/resources/exam.css
+++ b/themes/default/files/resources/exam.css
@@ -1283,6 +1283,10 @@ input[type=text], input[type=number] {
         display: none;
     }
 
+    body.no-printing-questions #questionContainer {
+        display: none;
+    }
+
     #standalone-warning {
         display: none;
     }

--- a/themes/default/files/resources/exam.css
+++ b/themes/default/files/resources/exam.css
@@ -1287,6 +1287,10 @@ input[type=text], input[type=number] {
         display: none;
     }
 
+    .no-printing-advice .adviceContainer {
+        display: none;
+    }
+
     #standalone-warning {
         display: none;
     }

--- a/themes/default/files/scripts/display-base.js
+++ b/themes/default/files/scripts/display-base.js
@@ -91,6 +91,7 @@ var display = Numbas.display = /** @lends Numbas.display */ {
                 'no-printing': !exam.allowPrinting(),
                 'info-page': exam.viewType() == 'infopage',
                 'no-printing-questions': !exam.exam.settings.resultsshowquestions,
+                'no-printing-advice': !exam.exam.settings.resultsshowadvice,
             }
             classes['navigate-'+navigateMode] = true;
             return classes;

--- a/themes/default/files/scripts/display-base.js
+++ b/themes/default/files/scripts/display-base.js
@@ -89,7 +89,8 @@ var display = Numbas.display = /** @lends Numbas.display */ {
                 'show-nav': exam.viewType()=='question', 
                 'show-sidebar': navigateMode=='sequence' || navigateMode=='diagnostic',
                 'no-printing': !exam.allowPrinting(),
-                'info-page': exam.viewType() == 'infopage'
+                'info-page': exam.viewType() == 'infopage',
+                'no-printing-questions': !exam.exam.settings.resultsshowquestions,
             }
             classes['navigate-'+navigateMode] = true;
             return classes;


### PR DESCRIPTION
**Background**
Compiler changes to support option not to show the questions and advice on the printed version of the results page.

Accompanies [Numbas/editor#799](https://github.com/numbas/editor/pull/799)

**Changes**
- Add handling for new `resultsshowquestions` and  `resultsshowadvice` options in Exam.py, exam.js
- Add new selectors for new classes in exam.css for printing
- Add handling to apply additional css classes to display-base.js

**Discussion**
The new classes have perhaps not gone in to the most appropriate viewmodel.