### PR TITLE
Doctests: Force stdin to be decoded as utf8

### DIFF
--- a/tests/jme/make_tests_from_docs.py
+++ b/tests/jme/make_tests_from_docs.py
@@ -207,7 +207,7 @@ class MyVisitor(SimpleNodeVisitor):
     
 import sys
 
-source = sys.stdin.read()
+source = sys.stdin.buffer.read().decode("utf8")
 
 parser = rst.Parser()
 opts = docutils.frontend.OptionParser(


### PR DESCRIPTION
On windows, stdin by default uses a different encoding and cannot detect the arrows used to denote examples. Enforcing utf8 decoding of the buffer enables the tests to correctly interpret the examples.