### PR TITLE
HTML elements with `data-interactive="false"` can be safely copied

### DIFF
--- a/runtime/scripts/jme-builtins.js
+++ b/runtime/scripts/jme-builtins.js
@@ -330,7 +330,9 @@ newBuiltin('html',[TString],THTML,null, {
         container.innerHTML = args[0].value;
         var subber = new jme.variables.DOMcontentsubber(scope);
         subber.subvars(container);
-        return new THTML(Array.from(container.childNodes));
+        var nodes = Array.from(container.childNodes);
+        nodes.forEach(node => node.setAttribute('data-interactive', 'false'));
+        return new THTML(nodes);
     }
 });
 newBuiltin('isnonemptyhtml',[TString],TBool,function(html) {
@@ -351,6 +353,7 @@ newBuiltin('image',[TString, '[number]', '[number]'],THTML,null, {
         }
         var subber = new jme.variables.DOMcontentsubber(scope);
         var element = subber.subvars(img);
+        element.setAttribute('data-interactive', 'false');
         return new THTML(element);
     }
 });
@@ -826,6 +829,7 @@ newBuiltin('scientificnumberhtml', [TDecimal], THTML, function(n) {
     var bits = math.parseScientific(n.re.toExponential());
     var s = document.createElement('span');
     s.innerHTML = math.niceRealNumber(bits.significand)+' × 10<sup>'+bits.exponent+'</sup>';
+    s.setAttribute('data-interactive', 'false');
     return s;
 });
 newBuiltin('scientificnumberhtml', [TNum], THTML, function(n) {
@@ -835,6 +839,7 @@ newBuiltin('scientificnumberhtml', [TNum], THTML, function(n) {
     var bits = math.parseScientific(math.niceRealNumber(n,{style:'scientific', scientificStyle:'plain'}));
     var s = document.createElement('span');
     s.innerHTML = math.niceRealNumber(bits.significand)+' × 10<sup>'+bits.exponent+'</sup>';
+    s.setAttribute('data-interactive', 'false');
     return s;
 });
 
@@ -2394,6 +2399,7 @@ newBuiltin('table',[TList,TList],THTML, null, {
                 row.appendChild(td);
             }
         }
+        table.setAttribute('data-interactive','false');
         return new THTML(table);
     }
 });
@@ -2412,6 +2418,7 @@ newBuiltin('table',[TList],THTML, null, {
                 row.appendChild(td);
             }
         }
+        table.setAttribute('data-interactive','false');
         return new THTML(table);
     }
 });

--- a/runtime/scripts/jme-variables.js
+++ b/runtime/scripts/jme-variables.js
@@ -538,6 +538,9 @@ jme.variables = /** @lends Numbas.jme.variables */ {
         function doToken(token) {
             if(jme.isType(token,'html')) {
                 token = jme.castToType(token,'html');
+                if(token.value.every(e => e.getAttribute('data-interactive') === 'false')) {
+                    return token.value.map(e => e.cloneNode(true));
+                }
                 if(token.value.numbas_embedded) {
                     throw(new Numbas.Error('jme.subvars.html inserted twice'))
                 }

--- a/runtime/scripts/jme.js
+++ b/runtime/scripts/jme.js
@@ -3230,6 +3230,9 @@ jme.registerType(TBool,'boolean');
 
 /** HTML DOM element.
  *
+ * If the element has the attribute `data-interactive="false"` then it can be safely copied and embedded multiple times.
+ * If the attribute is not present or has any other value, then it's assumed that it can't be safely copied.
+ *
  * @memberof Numbas.jme.types
  * @augments Numbas.jme.token
  * @property {Element} value


### PR DESCRIPTION
fixes #1120

HTML elements with the attribute `data-interactive="false"` are considered to be noninteractive and can be safely copied before embedding in content areas.

The `table`, `html`, `image` and `scientificnumberhtml` functions add this attribute to the elements that they create.

Need to document this.