### PR TITLE
DOC - swap out README malicious URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you make a change, please try to add unit tests to confirm that Numbas behave
 The Makefile in this repository collects together scripts to run the unit tests, and builds the API documentation. Linux and Mac OS have built-in support Makefiles, but Windows doesn't. On Windows, [cygwin](https://www.cygwin.com/) provides `make`.
 
 API documentation for developers is at [numbas.github.io/Numbas](https://numbas.github.io/Numbas).
-This is generated using [JSDoc](http://usejsdoc.org), with [a custom template](http://github.com/numbas/numbas-jsdoc-template).
+This is generated using [JSDoc](https://jsdoc.app/), with [a custom template](http://github.com/numbas/numbas-jsdoc-template).
 Run `make docs` to rebuild the API documentation into `../numbas-docs`.
 
 ### Copyright


### PR DESCRIPTION
Hi Numbas team,

The previous README URL of: 'http:// usejsdoc DOT org' seemed compromised, swap it out for the official url of jsdoc: https://jsdoc.app/ 

Malicious URL redirects to: 'https:// theelwins DOT com/'


Screenshot of malicious URL page:

![image](https://github.com/user-attachments/assets/aa0d9e1f-2627-4f63-8fb2-fa3ddcbe8ebb)


Galen,
UNSW Sydney Software student :smile: 
