### PR TITLE
Add confirmation dialog before applying next part penalty

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -282,6 +282,8 @@
     "part.choose next part.will be locked": "(This part will be locked)",
     "part.reached dead end": "There's nothing more to do from here.",
     "part.next part.penalty amount": "(lose {{count}} $t(mark))",
+    "part.next part.confirm penalty": {
+    "message": "This will apply a penalty of {count, plural, =1{# mark} other{# marks}}. Do you want to continue?"},
     "part.script.error": "Error in part {{path}} custom script {{script}}: {{-message}}",
     "part.marking.steps no matter": "Because you received full marks for the part, your answers to the steps aren't counted.",
     "part.marking.steps change": "You were awarded <strong>{{count,niceNumber}}</strong> $t(mark) for your answers to the steps.",

--- a/themes/default/files/scripts/part-display.js
+++ b/themes/default/files/scripts/part-display.js
@@ -851,12 +851,21 @@ Numbas.queueScript('part-display', ['display-util', 'display-base', 'util', 'jme
                     penaltyAmount: penaltyAmount,
                     lockAfterLeaving: np.lockAfterLeaving,
                     select: function() {
-                        if(np.instance) {
-                            p.question.setCurrentPart(np.instance)
-                        } else {
-                            p.makeNextPart(np);
-                        }
-                    }
+                           if(np.instance) {
+                              p.question.setCurrentPart(np.instance)
+                            } else {
+                            // Check if there's a penalty before making the next part
+                            var penaltyAmount = np.penalty ? np.penaltyAmount : 0;
+                           if(penaltyAmount > 0) {
+                            // Show confirmation dialog
+                              var message = R('part.next part.confirm penalty', {count: penaltyAmount});
+                           if(!confirm(message)) {
+                              return; // User cancelled, don't proceed
+            }
+        }
+        p.makeNextPart(np);
+    }
+}
                 };
             }));
         },


### PR DESCRIPTION
Fixes #1158

When a student clicks on a next part option that applies a penalty in explore mode, they now see a confirmation dialog asking if they want to proceed. This prevents accidental loss of marks.

The confirmation only appears for next parts with penaltyAmount > 0. Already-created next parts do not show the confirmation when navigating back to them.